### PR TITLE
Remove ie_mobile

### DIFF
--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": "11"
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },
@@ -77,9 +74,6 @@
             },
             "ie": {
               "version_added": "11"
-            },
-            "ie_mobile": {
-              "version_added": null
             },
             "opera": {
               "version_added": null
@@ -129,9 +123,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },
@@ -179,9 +170,6 @@
             },
             "ie": {
               "version_added": "11"
-            },
-            "ie_mobile": {
-              "version_added": null
             },
             "opera": {
               "version_added": null

--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": false
           },
@@ -77,9 +74,6 @@
               "version_added": "57"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -130,9 +124,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -179,9 +170,6 @@
               "version_added": "57"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": false
           },
@@ -76,9 +73,6 @@
               "version_added": "57"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -127,9 +121,6 @@
               "version_added": "57"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/AnalyserNode.json
+++ b/api/AnalyserNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -77,9 +74,6 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -130,9 +124,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -179,9 +170,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -232,9 +220,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -281,9 +266,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -334,9 +316,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -383,9 +362,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -436,9 +412,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -487,9 +460,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -536,9 +506,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/AudioBuffer.json
+++ b/api/AudioBuffer.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -80,9 +77,6 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -135,9 +129,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -184,9 +175,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -237,9 +225,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -286,9 +271,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -339,9 +321,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -390,9 +369,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -439,9 +415,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -80,9 +77,6 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -135,9 +129,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -184,9 +175,6 @@
               "version_added": "40"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -237,9 +225,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -286,9 +271,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -339,9 +321,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -390,9 +369,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -439,9 +415,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -42,9 +42,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": [
             {
               "version_added": "22"
@@ -108,9 +105,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": false
             },
@@ -160,9 +154,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -217,9 +208,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -272,9 +260,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "47"
             },
@@ -321,9 +306,6 @@
               "version_added": false
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -374,9 +356,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": true
             },
@@ -423,9 +402,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -476,9 +452,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -525,9 +498,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -578,9 +548,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": null
             },
@@ -629,9 +596,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "44"
             },
@@ -678,9 +642,6 @@
               "version_added": "40"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/AudioDestinationNode.json
+++ b/api/AudioDestinationNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -76,9 +73,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/AudioListener.json
+++ b/api/AudioListener.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -76,9 +73,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -132,9 +126,6 @@
               "notes": "Supports a deprecated way of setting orientation — the <code>setOrientation()</code> method."
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -192,9 +183,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false,
               "notes": "Supports a deprecated way of setting orientation — the <code>setOrientation()</code> method."
@@ -248,9 +236,6 @@
               "notes": "Supports a deprecated way of setting orientation — the <code>setOrientation()</code> method."
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -308,9 +293,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false,
               "notes": "Supports a deprecated way of setting orientation — the <code>setOrientation()</code> method."
@@ -364,9 +346,6 @@
               "notes": "Supports a deprecated way of setting orientation — the <code>setOrientation()</code> method."
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -424,9 +403,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false,
               "notes": "Supports a deprecated way of setting orientation — the <code>setOrientation()</code> method."
@@ -475,9 +451,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -531,9 +504,6 @@
               "notes": "Supports a deprecated way of setting orientation — the <code>setOrientation()</code> method."
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -591,9 +561,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false,
               "notes": "Supports a deprecated way of setting orientation — the <code>setOrientation()</code> method."
@@ -649,9 +616,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false,
               "notes": "Supports a deprecated way of setting orientation — the <code>setOrientation()</code> method."
@@ -702,9 +666,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -751,9 +712,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/AudioNode.json
+++ b/api/AudioNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -76,9 +73,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -129,9 +123,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -178,9 +169,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -231,9 +219,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -280,9 +265,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -333,9 +315,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -382,9 +361,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -435,9 +411,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -483,9 +456,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -534,9 +504,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -76,9 +73,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -129,9 +123,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "39"
             },
@@ -180,9 +171,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "39"
             },
@@ -229,9 +217,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -303,9 +288,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"
@@ -368,9 +350,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -417,9 +396,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -470,9 +446,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -519,9 +492,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -572,9 +542,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -621,9 +588,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/AudioParamMap.json
+++ b/api/AudioParamMap.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },
@@ -77,9 +74,6 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
-          },
-          "ie_mobile": {
             "version_added": null
           },
           "opera": {
@@ -130,9 +124,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },
@@ -179,9 +170,6 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
-          },
-          "ie_mobile": {
             "version_added": null
           },
           "opera": {
@@ -232,9 +220,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },
@@ -283,9 +268,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },
@@ -332,9 +314,6 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
-          },
-          "ie_mobile": {
             "version_added": null
           },
           "opera": {

--- a/api/AudioProcessingEvent.json
+++ b/api/AudioProcessingEvent.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -76,9 +73,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -129,9 +123,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -178,9 +169,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -63,9 +63,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": [
             {
               "version_added": "44"
@@ -127,9 +124,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -178,9 +172,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -227,9 +218,6 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/BiquadFilterNode.json
+++ b/api/BiquadFilterNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -80,9 +77,6 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -135,9 +129,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -184,9 +175,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -237,9 +225,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -286,9 +271,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -339,9 +321,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -388,9 +367,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/ChannelMergerNode.json
+++ b/api/ChannelMergerNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -77,9 +74,6 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/ChannelSplitterNode.json
+++ b/api/ChannelSplitterNode.json
@@ -31,9 +31,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15",
             "notes": "Starting in Opera 43, <code>channelCountMode</code> is set to <code>explicit</code> and <code>channelCount</code> is fixed to the number of outputs, as per the latest spec."
@@ -82,9 +79,6 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/ConstantSourceNode.json
+++ b/api/ConstantSourceNode.json
@@ -30,9 +30,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": false
           },
@@ -79,9 +76,6 @@
               "version_added": "52"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -136,9 +130,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -189,9 +180,6 @@
               "notes": "This property is still available, but via the inheritance of <code>AudioScheduledSourceNode</code>."
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -246,9 +234,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -299,9 +284,6 @@
               "notes": "This property is still available, but via the inheritance of <code>AudioScheduledSourceNode</code>."
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/ConvolverNode.json
+++ b/api/ConvolverNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -77,9 +74,6 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -130,9 +124,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -179,9 +170,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -35,9 +35,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "41",
             "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"

--- a/api/DelayNode.json
+++ b/api/DelayNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -82,9 +79,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "42"
             },
@@ -131,9 +125,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/DynamicsCompressorNode.json
+++ b/api/DynamicsCompressorNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -82,9 +79,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "42"
             },
@@ -131,9 +125,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -184,9 +175,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -233,9 +221,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -289,9 +274,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -340,9 +322,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -389,9 +368,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/EXT_blend_minmax.json
+++ b/api/EXT_blend_minmax.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/EXT_color_buffer_float.json
+++ b/api/EXT_color_buffer_float.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/EXT_color_buffer_half_float.json
+++ b/api/EXT_color_buffer_half_float.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/EXT_disjoint_timer_query.json
+++ b/api/EXT_disjoint_timer_query.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },
@@ -76,9 +73,6 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
-            },
-            "ie_mobile": {
               "version_added": null
             },
             "opera": {
@@ -129,9 +123,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },
@@ -178,9 +169,6 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
-            },
-            "ie_mobile": {
               "version_added": null
             },
             "opera": {
@@ -231,9 +219,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },
@@ -280,9 +265,6 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
-            },
-            "ie_mobile": {
               "version_added": null
             },
             "opera": {
@@ -333,9 +315,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },
@@ -384,9 +363,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },
@@ -433,9 +409,6 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
-            },
-            "ie_mobile": {
               "version_added": null
             },
             "opera": {

--- a/api/EXT_frag_depth.json
+++ b/api/EXT_frag_depth.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/EXT_sRGB.json
+++ b/api/EXT_sRGB.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/EXT_shader_texture_lod.json
+++ b/api/EXT_shader_texture_lod.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/EXT_texture_filter_anisotropic.json
+++ b/api/EXT_texture_filter_anisotropic.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/GainNode.json
+++ b/api/GainNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -82,9 +79,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "42"
             },
@@ -131,9 +125,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -56,9 +56,6 @@
           "edge_mobile": {
             "version_added": true
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera_android": {
             "version_added": false
           },
@@ -130,9 +127,6 @@
             },
             "edge_mobile": {
               "version_added": true
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "opera_android": {
               "version_added": false
@@ -207,9 +201,6 @@
             "edge_mobile": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera_android": {
               "version_added": false
             },
@@ -283,9 +274,6 @@
             "edge_mobile": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera_android": {
               "version_added": false
             },
@@ -330,9 +318,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -381,9 +366,6 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera_android": {
@@ -438,9 +420,6 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera_android": {
@@ -516,9 +495,6 @@
             "edge_mobile": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera_android": {
               "version_added": false
             },
@@ -591,9 +567,6 @@
             },
             "edge_mobile": {
               "version_added": true
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "opera_android": {
               "version_added": false
@@ -668,9 +641,6 @@
             "edge_mobile": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera_android": {
               "version_added": false
             },
@@ -723,9 +693,6 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera_android": {
@@ -800,9 +767,6 @@
             },
             "edge_mobile": {
               "version_added": true
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "opera_android": {
               "version_added": false

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -56,9 +56,6 @@
           "edge_mobile": {
             "version_added": true
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera_android": {
             "version_added": false
           },
@@ -130,9 +127,6 @@
             },
             "edge_mobile": {
               "version_added": true
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "opera_android": {
               "version_added": false
@@ -206,9 +200,6 @@
             },
             "edge_mobile": {
               "version_added": true
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "opera_android": {
               "version_added": false

--- a/api/GamepadEvent.json
+++ b/api/GamepadEvent.json
@@ -56,9 +56,6 @@
           "edge_mobile": {
             "version_added": true
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera_android": {
             "version_added": false
           },
@@ -130,9 +127,6 @@
             },
             "edge_mobile": {
               "version_added": true
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "opera_android": {
               "version_added": false

--- a/api/GamepadHapticActuator.json
+++ b/api/GamepadHapticActuator.json
@@ -37,9 +37,6 @@
           "edge_mobile": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera_android": {
             "version_added": false
           },
@@ -91,9 +88,6 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera_android": {
@@ -148,9 +142,6 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera_android": {

--- a/api/GamepadPose.json
+++ b/api/GamepadPose.json
@@ -37,9 +37,6 @@
           "edge_mobile": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera_android": {
             "version_added": false
           },
@@ -91,9 +88,6 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera_android": {
@@ -150,9 +144,6 @@
             "edge_mobile": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera_android": {
               "version_added": false
             },
@@ -205,9 +196,6 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera_android": {
@@ -264,9 +252,6 @@
             "edge_mobile": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera_android": {
               "version_added": false
             },
@@ -319,9 +304,6 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera_android": {
@@ -378,9 +360,6 @@
             "edge_mobile": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera_android": {
               "version_added": false
             },
@@ -435,9 +414,6 @@
             "edge_mobile": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera_android": {
               "version_added": false
             },
@@ -490,9 +466,6 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera_android": {

--- a/api/IIRFilterNode.json
+++ b/api/IIRFilterNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "36"
           },
@@ -82,9 +79,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "42"
             },
@@ -131,9 +125,6 @@
               "version_added": "50"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -33,9 +33,6 @@
           "edge_mobile": {
             "version_added": true
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "chrome_android": {
             "version_added": "51"
           }
@@ -79,9 +76,6 @@
             },
             "edge_mobile": {
               "version_added": true
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": "51"
@@ -127,9 +121,6 @@
             "edge_mobile": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": "51"
             }
@@ -174,9 +165,6 @@
             "edge_mobile": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": "51"
             }
@@ -220,9 +208,6 @@
             },
             "edge_mobile": {
               "version_added": true
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": "51"
@@ -269,9 +254,6 @@
             "edge_mobile": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": "51"
             }
@@ -315,9 +297,6 @@
             },
             "edge_mobile": {
               "version_added": true
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": "51"
@@ -364,9 +343,6 @@
             "edge_mobile": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": "51"
             }
@@ -411,9 +387,6 @@
             },
             "edge_mobile": {
               "version_added": true
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": "51"

--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -33,9 +33,6 @@
           "edge_mobile": {
             "version_added": true
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "chrome_android": {
             "version_added": "51"
           }
@@ -78,9 +75,6 @@
             },
             "edge_mobile": {
               "version_added": true
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": "51"
@@ -126,9 +120,6 @@
             "edge_mobile": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": "51"
             }
@@ -173,9 +164,6 @@
             "edge_mobile": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": "51"
             }
@@ -218,9 +206,6 @@
               "version_added": "51"
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "chrome_android": {
@@ -267,9 +252,6 @@
             "edge_mobile": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": "51"
             }
@@ -314,9 +296,6 @@
             "edge_mobile": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": "51"
             }
@@ -360,9 +339,6 @@
             },
             "edge_mobile": {
               "version_added": true
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": "51"

--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -80,9 +77,6 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/MediaRecorderErrorEvent.json
+++ b/api/MediaRecorderErrorEvent.json
@@ -30,9 +30,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": false,
             "notes": "Uses a generic event with an <code>error</code> property."
@@ -85,9 +82,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false,
               "notes": "Uses a generic event with an <code>error</code> property."
@@ -138,9 +132,6 @@
               "version_added": "57"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/MediaStreamAudioDestinationNode.json
+++ b/api/MediaStreamAudioDestinationNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -82,9 +79,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "42"
             },
@@ -131,9 +125,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/MediaStreamAudioSourceNode.json
+++ b/api/MediaStreamAudioSourceNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -80,9 +77,6 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/OES_element_index_uint.json
+++ b/api/OES_element_index_uint.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/OES_standard_derivatives.json
+++ b/api/OES_standard_derivatives.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/OES_texture_float.json
+++ b/api/OES_texture_float.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/OES_texture_float_linear.json
+++ b/api/OES_texture_float_linear.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/OES_texture_half_float.json
+++ b/api/OES_texture_half_float.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/OES_texture_half_float_linear.json
+++ b/api/OES_texture_half_float_linear.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/OES_vertex_array_object.json
+++ b/api/OES_vertex_array_object.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },
@@ -76,9 +73,6 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
-            },
-            "ie_mobile": {
               "version_added": null
             },
             "opera": {
@@ -129,9 +123,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },
@@ -180,9 +171,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },
@@ -229,9 +217,6 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
-            },
-            "ie_mobile": {
               "version_added": null
             },
             "opera": {

--- a/api/OfflineAudioCompletionEvent.json
+++ b/api/OfflineAudioCompletionEvent.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -82,9 +79,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "42"
             },
@@ -131,9 +125,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -82,9 +79,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "42"
             },
@@ -130,9 +124,6 @@
                 "version_added": "57"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -184,9 +175,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "38"
             },
@@ -233,9 +221,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -286,9 +271,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "36"
             },
@@ -335,9 +317,6 @@
               "version_added": false
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -388,9 +367,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -436,9 +412,6 @@
                 "version_added": "37"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/api/OscillatorNode.json
+++ b/api/OscillatorNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -82,9 +79,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "42"
             },
@@ -131,9 +125,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -184,9 +175,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -233,9 +221,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -286,9 +271,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -335,9 +317,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -390,9 +369,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -441,9 +417,6 @@
               "notes": "Before Firefox 30, the <code>when</code> parameter was not optional."
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -82,9 +79,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "42"
             },
@@ -131,9 +125,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -184,9 +175,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -233,9 +221,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -286,9 +271,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -335,9 +317,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -388,9 +367,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": true
             },
@@ -437,9 +413,6 @@
               "version_added": "50"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -490,9 +463,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": true
             },
@@ -539,9 +509,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -592,9 +559,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": true
             },
@@ -641,9 +605,6 @@
               "version_added": "50"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -694,9 +655,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": true
             },
@@ -743,9 +701,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -796,9 +751,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -847,9 +799,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -896,9 +845,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -950,9 +896,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/PeriodicWave.json
+++ b/api/PeriodicWave.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -80,9 +77,6 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -56,17 +56,6 @@
               "notes": "See <a href='https://msdn.microsoft.com/library/dn304886'>MSDN Pointer events updates</a>."
             }
           ],
-          "ie_mobile": [
-            {
-              "version_added": "11"
-            },
-            {
-              "version_added": "10",
-              "prefix": "MS",
-              "partial_implementation": true,
-              "notes": "See <a href='https://msdn.microsoft.com/library/dn304886'>MSDN Pointer events updates</a>."
-            }
-          ],
           "opera": {
             "version_added": "42"
           },
@@ -133,17 +122,6 @@
               }
             ],
             "ie": [
-              {
-                "version_added": "11"
-              },
-              {
-                "version_added": "10",
-                "prefix": "MS",
-                "partial_implementation": true,
-                "notes": "See <a href='https://msdn.microsoft.com/library/dn304886'>MSDN Pointer events updates</a>."
-              }
-            ],
-            "ie_mobile": [
               {
                 "version_added": "11"
               },
@@ -222,9 +200,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "opera": {
               "version_added": "42"
             },
@@ -291,16 +266,6 @@
               }
             ],
             "ie": [
-              {
-                "version_added": "11"
-              },
-              {
-                "version_added": "10",
-                "partial_implementation": true,
-                "notes": "Returns values in screen pixels instead of CSS document pixels."
-              }
-            ],
-            "ie_mobile": [
               {
                 "version_added": "11"
               },
@@ -385,16 +350,6 @@
                 "notes": "Returns values in screen pixels instead of CSS document pixels."
               }
             ],
-            "ie_mobile": [
-              {
-                "version_added": "11"
-              },
-              {
-                "version_added": "10",
-                "partial_implementation": true,
-                "notes": "Returns values in screen pixels instead of CSS document pixels."
-              }
-            ],
             "opera": {
               "version_added": "42"
             },
@@ -461,16 +416,6 @@
               }
             ],
             "ie": [
-              {
-                "version_added": "11"
-              },
-              {
-                "version_added": "10",
-                "partial_implementation": true,
-                "notes": "Returns 0 instead of 0.5 on hardware that doesn't support pressure."
-              }
-            ],
-            "ie_mobile": [
               {
                 "version_added": "11"
               },
@@ -548,9 +493,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "45"
             },
@@ -617,9 +559,6 @@
               }
             ],
             "ie": {
-              "version_added": "10"
-            },
-            "ie_mobile": {
               "version_added": "10"
             },
             "opera": {
@@ -690,9 +629,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "opera": {
               "version_added": "42"
             },
@@ -759,9 +695,6 @@
               }
             ],
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -839,16 +772,6 @@
                 "notes": "Returns an integer enumeration instead of a string."
               }
             ],
-            "ie_mobile": [
-              {
-                "version_added": "11"
-              },
-              {
-                "version_added": "10",
-                "partial_implementation": true,
-                "notes": "Returns an integer enumeration instead of a string."
-              }
-            ],
             "opera": {
               "version_added": "42"
             },
@@ -917,9 +840,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "opera": {
               "version_added": "42"
             },
@@ -966,9 +886,6 @@
               "version_added": false
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/StereoPannerNode.json
+++ b/api/StereoPannerNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "28"
           },
@@ -82,9 +79,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "42"
             },
@@ -131,9 +125,6 @@
               "version_added": "37"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -34,9 +34,6 @@
           "edge_mobile": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "chrome_android": {
             "version_added": true,
             "notes": "Currently supported only by Google Daydream."
@@ -81,9 +78,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -131,9 +125,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -179,9 +170,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -229,9 +217,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -277,9 +262,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -327,9 +309,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -375,9 +354,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -425,9 +401,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -473,9 +446,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -523,9 +493,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -565,9 +532,6 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "chrome_android": {
@@ -615,9 +579,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -650,9 +611,6 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "chrome_android": {
@@ -700,9 +658,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -748,9 +703,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -798,9 +750,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -846,9 +795,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -896,9 +842,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -945,9 +888,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -993,9 +933,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -34,9 +34,6 @@
           "edge_mobile": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "chrome_android": {
             "version_added": true,
             "notes": "Currently supported only by Google Daydream."
@@ -81,9 +78,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -131,9 +125,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -179,9 +170,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -229,9 +217,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -277,9 +262,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -34,9 +34,6 @@
           "edge_mobile": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "chrome_android": {
             "version_added": true,
             "notes": "Currently supported only by Google Daydream."
@@ -82,9 +79,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -132,9 +126,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -180,9 +171,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -34,9 +34,6 @@
           "edge_mobile": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "chrome_android": {
             "version_added": true,
             "notes": "Currently supported only by Google Daydream."
@@ -82,9 +79,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -126,9 +120,6 @@
             "edge_mobile": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": false
             }
@@ -167,9 +158,6 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "chrome_android": {
@@ -217,9 +205,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -252,9 +237,6 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "chrome_android": {
@@ -302,9 +284,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -337,9 +316,6 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "chrome_android": {
@@ -386,9 +362,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -34,9 +34,6 @@
           "edge_mobile": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "chrome_android": {
             "version_added": true,
             "notes": "Currently supported only by Google Daydream."
@@ -69,9 +66,6 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "chrome_android": {
@@ -119,9 +113,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -167,9 +158,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -217,9 +205,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -265,9 +250,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -34,9 +34,6 @@
           "edge_mobile": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "chrome_android": {
             "version_added": true,
             "notes": "Currently supported only by Google Daydream."
@@ -82,9 +79,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -132,9 +126,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -180,9 +171,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -230,9 +218,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -278,9 +263,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -328,9 +310,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -376,9 +355,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,

--- a/api/VRLayerInit.json
+++ b/api/VRLayerInit.json
@@ -34,9 +34,6 @@
           "edge_mobile": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "chrome_android": {
             "version_added": true,
             "notes": "Currently supported only by Google Daydream."
@@ -81,9 +78,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -131,9 +125,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -179,9 +170,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -34,9 +34,6 @@
           "edge_mobile": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "chrome_android": {
             "version_added": true,
             "notes": "Currently supported only by Google Daydream."
@@ -81,9 +78,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -131,9 +125,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -168,9 +159,6 @@
             "edge_mobile": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": false
             }
@@ -202,9 +190,6 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "chrome_android": {
@@ -252,9 +237,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -300,9 +282,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -350,9 +329,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -399,9 +375,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -434,9 +407,6 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "chrome_android": {

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -34,9 +34,6 @@
           "edge_mobile": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "chrome_android": {
             "version_added": true,
             "notes": "Currently supported only by Google Daydream."
@@ -81,9 +78,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,
@@ -131,9 +125,6 @@
             "edge_mobile": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "chrome_android": {
               "version_added": true,
               "notes": "Currently supported only by Google Daydream."
@@ -179,9 +170,6 @@
             },
             "edge_mobile": {
               "version_added": null
-            },
-            "ie_mobile": {
-              "version_added": false
             },
             "chrome_android": {
               "version_added": true,

--- a/api/WEBGL_color_buffer_float.json
+++ b/api/WEBGL_color_buffer_float.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },
@@ -76,9 +73,6 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
-            },
-            "ie_mobile": {
               "version_added": null
             },
             "opera": {

--- a/api/WEBGL_compressed_texture_astc.json
+++ b/api/WEBGL_compressed_texture_astc.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },
@@ -76,9 +73,6 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
-            },
-            "ie_mobile": {
               "version_added": null
             },
             "opera": {

--- a/api/WEBGL_compressed_texture_atc.json
+++ b/api/WEBGL_compressed_texture_atc.json
@@ -35,9 +35,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/WEBGL_compressed_texture_etc.json
+++ b/api/WEBGL_compressed_texture_etc.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/WEBGL_compressed_texture_etc1.json
+++ b/api/WEBGL_compressed_texture_etc1.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -35,9 +35,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -35,9 +35,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -39,9 +39,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/WEBGL_debug_shaders.json
+++ b/api/WEBGL_debug_shaders.json
@@ -36,9 +36,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },
@@ -92,9 +89,6 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
-            },
-            "ie_mobile": {
               "version_added": null
             },
             "opera": {

--- a/api/WEBGL_depth_texture.json
+++ b/api/WEBGL_depth_texture.json
@@ -35,9 +35,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/WEBGL_draw_buffers.json
+++ b/api/WEBGL_draw_buffers.json
@@ -40,9 +40,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },
@@ -100,9 +97,6 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
-            },
-            "ie_mobile": {
               "version_added": null
             },
             "opera": {

--- a/api/WEBGL_lose_context.json
+++ b/api/WEBGL_lose_context.json
@@ -35,9 +35,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },
@@ -90,9 +87,6 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
-            },
-            "ie_mobile": {
               "version_added": null
             },
             "opera": {
@@ -148,9 +142,6 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
-            },
-            "ie_mobile": {
               "version_added": null
             },
             "opera": {

--- a/api/WaveShaperNode.json
+++ b/api/WaveShaperNode.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "15"
           },
@@ -82,9 +79,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "42"
             },
@@ -133,9 +127,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -182,9 +173,6 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "43"
           },
@@ -76,9 +73,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -129,9 +123,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -178,9 +169,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -231,9 +219,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -280,9 +265,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -333,9 +315,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -382,9 +361,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -435,9 +411,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -486,9 +459,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": true
             },
@@ -534,9 +504,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -588,9 +555,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -639,9 +603,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -687,9 +648,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -741,9 +699,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -789,9 +744,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -843,9 +795,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -891,9 +840,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -945,9 +891,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -996,9 +939,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -1044,9 +984,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -1098,9 +1035,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -1147,9 +1081,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -1200,9 +1131,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -1249,9 +1177,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -1302,9 +1227,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -1351,9 +1273,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -1404,9 +1323,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -1453,9 +1369,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -1506,9 +1419,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -1555,9 +1465,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -1608,9 +1515,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -1657,9 +1561,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -1710,9 +1611,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -1759,9 +1657,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -1812,9 +1707,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -1861,9 +1753,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -1914,9 +1803,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -1963,9 +1849,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -2016,9 +1899,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -2065,9 +1945,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -2118,9 +1995,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -2167,9 +2041,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -2220,9 +2091,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -2271,9 +2139,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": true
             },
@@ -2319,9 +2184,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -2373,9 +2235,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -2422,9 +2281,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -2475,9 +2331,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -2524,9 +2377,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -2577,9 +2427,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -2626,9 +2473,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -2679,9 +2523,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -2728,9 +2569,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -2781,9 +2619,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -2830,9 +2665,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -2883,9 +2715,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -2932,9 +2761,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -2985,9 +2811,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -3034,9 +2857,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -3087,9 +2907,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -3136,9 +2953,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -3189,9 +3003,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -3238,9 +3049,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -3291,9 +3099,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -3340,9 +3145,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -3393,9 +3195,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -3442,9 +3241,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -3495,9 +3291,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -3546,9 +3339,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -3594,9 +3384,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -3648,9 +3435,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -3697,9 +3481,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -3750,9 +3531,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -3798,9 +3576,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -3852,9 +3627,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -3901,9 +3673,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -3954,9 +3723,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -4003,9 +3769,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -4056,9 +3819,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -4105,9 +3865,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -4158,9 +3915,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -4207,9 +3961,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -4260,9 +4011,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -4309,9 +4057,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -4362,9 +4107,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -4411,9 +4153,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -4464,9 +4203,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -4513,9 +4249,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -4566,9 +4299,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -4615,9 +4345,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -4668,9 +4395,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -4717,9 +4441,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -4770,9 +4491,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -4818,9 +4536,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -4872,9 +4587,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -4920,9 +4632,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -4974,9 +4683,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -5022,9 +4728,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -5076,9 +4779,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -5124,9 +4824,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -5178,9 +4875,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -5226,9 +4920,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -5280,9 +4971,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -5328,9 +5016,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -5382,9 +5067,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -5430,9 +5112,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -5484,9 +5163,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -5532,9 +5208,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -5586,9 +5259,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -5634,9 +5304,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -5688,9 +5355,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -5737,9 +5401,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -5790,9 +5451,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -5838,9 +5496,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -5892,9 +5547,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -5943,9 +5595,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -5991,9 +5640,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -6045,9 +5691,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "43"
             },
@@ -6094,9 +5737,6 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/WebGLActiveInfo.json
+++ b/api/WebGLActiveInfo.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": "11"
           },
-          "ie_mobile": {
-            "version_added": "11"
-          },
           "opera": {
             "version_added": "12"
           },
@@ -83,9 +80,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -132,9 +126,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -185,9 +176,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -234,9 +222,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {

--- a/api/WebGLBuffer.json
+++ b/api/WebGLBuffer.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": "11"
           },
-          "ie_mobile": {
-            "version_added": "11"
-          },
           "opera": {
             "version_added": "12"
           },
@@ -81,9 +78,6 @@
               "version_added": false
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/WebGLContextEvent.json
+++ b/api/WebGLContextEvent.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": "11"
           },
-          "ie_mobile": {
-            "version_added": "11"
-          },
           "opera": {
             "version_added": "12"
           },
@@ -83,9 +80,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -132,9 +126,6 @@
               "version_added": "49"
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {

--- a/api/WebGLFramebuffer.json
+++ b/api/WebGLFramebuffer.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": "11"
           },
-          "ie_mobile": {
-            "version_added": "11"
-          },
           "opera": {
             "version_added": "12"
           },
@@ -81,9 +78,6 @@
               "version_added": false
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/WebGLProgram.json
+++ b/api/WebGLProgram.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": "11"
           },
-          "ie_mobile": {
-            "version_added": "11"
-          },
           "opera": {
             "version_added": "12"
           },
@@ -81,9 +78,6 @@
               "version_added": false
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/WebGLQuery.json
+++ b/api/WebGLQuery.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "43"
           },

--- a/api/WebGLRenderbuffer.json
+++ b/api/WebGLRenderbuffer.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": "11"
           },
-          "ie_mobile": {
-            "version_added": "11"
-          },
           "opera": {
             "version_added": "12"
           },
@@ -81,9 +78,6 @@
               "version_added": false
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -37,12 +37,6 @@
               "To access the WebGL context, use <code>experimental-webgl</code> rather than the standard <code>webgl</code> identifier."
             ]
           },
-          "ie_mobile": {
-            "version_added": "11",
-            "notes": [
-              "To access the WebGL context, use <code>experimental-webgl</code> rather than the standard <code>webgl</code> identifier."
-            ]
-          },
           "opera": {
             "version_added": "12"
           },
@@ -95,9 +89,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -144,9 +135,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -197,9 +185,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -246,9 +231,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -299,9 +281,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -346,9 +325,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -400,9 +376,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -447,9 +420,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -501,9 +471,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -552,9 +519,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -599,9 +563,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -653,9 +614,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -704,9 +662,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -751,9 +706,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -805,9 +757,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -852,9 +801,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -906,9 +852,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -957,9 +900,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -1005,9 +945,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -1059,9 +996,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -1106,9 +1040,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -1160,9 +1091,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -1207,9 +1135,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -1259,9 +1184,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -1315,9 +1237,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -1367,9 +1286,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -1414,9 +1330,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -1468,9 +1381,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -1517,9 +1427,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -1570,9 +1477,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -1621,9 +1525,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -1670,9 +1571,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -1728,9 +1626,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -1777,9 +1672,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -1830,9 +1722,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -1877,9 +1766,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -1928,9 +1814,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -1982,9 +1865,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -2029,9 +1909,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -2079,9 +1956,6 @@
                   "version_added": null
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "opera": {
@@ -2134,9 +2008,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -2183,9 +2054,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -2236,9 +2104,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -2285,9 +2150,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -2338,9 +2200,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -2387,9 +2246,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -2440,9 +2296,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -2489,9 +2342,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -2542,9 +2392,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -2591,9 +2438,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -2644,9 +2488,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -2693,9 +2534,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -2746,9 +2584,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -2795,9 +2630,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -2848,9 +2680,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -2897,9 +2726,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -2950,9 +2776,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -2999,9 +2822,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -3052,9 +2872,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -3101,9 +2918,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -3154,9 +2968,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -3203,9 +3014,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -3256,9 +3064,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -3305,9 +3110,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -3358,9 +3160,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -3407,9 +3206,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -3460,9 +3256,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -3509,9 +3302,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -3562,9 +3352,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -3613,9 +3400,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -3660,9 +3444,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -3714,9 +3495,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -3761,9 +3539,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -3815,9 +3590,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -3866,9 +3638,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -3913,9 +3682,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -3967,9 +3733,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -4016,9 +3779,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -4069,9 +3829,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -4118,9 +3875,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -4171,9 +3925,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -4218,9 +3969,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -4272,9 +4020,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -4321,9 +4066,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -4374,9 +4116,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -4425,9 +4164,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -4472,9 +4208,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -4526,9 +4259,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -4575,9 +4305,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -4628,9 +4355,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -4675,9 +4399,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -4729,9 +4450,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -4776,9 +4494,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -4830,9 +4545,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -4879,9 +4591,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -4932,9 +4641,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -4981,9 +4687,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -5034,9 +4737,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -5085,9 +4785,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -5132,9 +4829,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -5186,9 +4880,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -5233,9 +4924,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -5287,9 +4975,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -5338,9 +5023,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -5385,9 +5067,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -5439,9 +5118,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -5488,9 +5164,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -5541,9 +5214,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -5590,9 +5260,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -5643,9 +5310,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -5690,9 +5354,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -5744,9 +5405,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -5793,9 +5451,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -5846,9 +5501,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -5895,9 +5547,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -5948,9 +5597,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -5997,9 +5643,6 @@
               "version_added": false
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -6050,9 +5693,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -6101,9 +5741,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -6148,9 +5785,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -6202,9 +5836,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -6253,9 +5884,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -6300,9 +5928,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -6350,9 +5975,6 @@
                   "version_added": null
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "opera": {
@@ -6405,9 +6027,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -6452,9 +6071,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -6506,9 +6122,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -6555,9 +6168,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -6608,9 +6218,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -6657,9 +6264,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -6710,9 +6314,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -6759,9 +6360,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -6812,9 +6410,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -6861,9 +6456,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -6914,9 +6506,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -6965,9 +6554,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -7012,9 +6598,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -7062,9 +6645,6 @@
                   "version_added": null
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "opera": {
@@ -7117,9 +6697,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -7164,9 +6741,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -7218,9 +6792,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -7265,9 +6836,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -7319,9 +6887,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -7366,9 +6931,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -7416,9 +6978,6 @@
                   "version_added": null
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "opera": {
@@ -7471,9 +7030,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -7520,9 +7076,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -7573,9 +7126,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -7622,9 +7172,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -7675,9 +7222,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -7724,9 +7268,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -7777,9 +7318,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -7826,9 +7364,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -7879,9 +7414,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -7928,9 +7460,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -7981,9 +7510,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -8030,9 +7556,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -8083,9 +7606,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -8132,9 +7652,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -8185,9 +7702,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -8234,9 +7748,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -8287,9 +7798,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -8334,9 +7842,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -8384,9 +7889,6 @@
                   "version_added": null
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "opera": {
@@ -8439,9 +7941,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -8486,9 +7985,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -8536,9 +8032,6 @@
                   "version_added": null
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "opera": {
@@ -8591,9 +8084,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -8638,9 +8128,6 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -8688,9 +8175,6 @@
                   "version_added": null
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "opera": {
@@ -8743,9 +8227,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -8792,9 +8273,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {
@@ -8845,9 +8323,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -8896,9 +8371,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -8944,9 +8416,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -8998,9 +8467,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -9049,9 +8515,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -9097,9 +8560,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -9151,9 +8611,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -9202,9 +8659,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -9250,9 +8704,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -9304,9 +8755,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -9355,9 +8803,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -9403,9 +8848,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -9457,9 +8899,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12"
             },
@@ -9506,9 +8945,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
-            },
-            "ie_mobile": {
               "version_added": "11"
             },
             "opera": {

--- a/api/WebGLSampler.json
+++ b/api/WebGLSampler.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "43"
           },

--- a/api/WebGLShader.json
+++ b/api/WebGLShader.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": "11"
           },
-          "ie_mobile": {
-            "version_added": "11"
-          },
           "opera": {
             "version_added": "12"
           },
@@ -81,9 +78,6 @@
               "version_added": false
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/WebGLShaderPrecisionFormat.json
+++ b/api/WebGLShaderPrecisionFormat.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": "11"
           },
-          "ie_mobile": {
-            "version_added": "11"
-          },
           "opera": {
             "version_added": "12"
           },
@@ -83,9 +80,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -133,9 +127,6 @@
             "version_added": true
           },
           "ie": {
-            "version_added": "11"
-          },
-          "ie_mobile": {
             "version_added": "11"
           },
           "opera": {
@@ -186,9 +177,6 @@
           "ie": {
             "version_added": "11"
           },
-          "ie_mobile": {
-            "version_added": "11"
-          },
           "opera": {
             "version_added": "12"
           },
@@ -235,9 +223,6 @@
             "version_added": true
           },
           "ie": {
-            "version_added": "11"
-          },
-          "ie_mobile": {
             "version_added": "11"
           },
           "opera": {

--- a/api/WebGLSync.json
+++ b/api/WebGLSync.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "43"
           },

--- a/api/WebGLTexture.json
+++ b/api/WebGLTexture.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": "11"
           },
-          "ie_mobile": {
-            "version_added": "11"
-          },
           "opera": {
             "version_added": "12"
           },
@@ -81,9 +78,6 @@
               "version_added": false
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/WebGLTransformFeedback.json
+++ b/api/WebGLTransformFeedback.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "43"
           },

--- a/api/WebGLUniformLocation.json
+++ b/api/WebGLUniformLocation.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": "11"
           },
-          "ie_mobile": {
-            "version_added": "11"
-          },
           "opera": {
             "version_added": "12"
           },
@@ -81,9 +78,6 @@
               "version_added": false
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {

--- a/api/WebGLVertexArrayObject.json
+++ b/api/WebGLVertexArrayObject.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "opera": {
             "version_added": "43"
           },

--- a/api/WebGLVertexArrayObjectOES.json
+++ b/api/WebGLVertexArrayObjectOES.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": null
           },
-          "ie_mobile": {
-            "version_added": null
-          },
           "opera": {
             "version_added": null
           },

--- a/api/Window.json
+++ b/api/Window.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": true
           },
-          "ie_mobile": {
-            "version_added": true
-          },
           "opera": {
             "version_added": true
           },

--- a/browsers/browsers.schema.json
+++ b/browsers/browsers.schema.json
@@ -39,7 +39,6 @@
       "edge_mobile": { "$ref": "#/definitions/browser_statement" },
       "firefox": { "$ref": "#/definitions/browser_statement" },
       "firefox_android": { "$ref": "#/definitions/browser_statement" },
-      "ie_mobile": { "$ref": "#/definitions/browser_statement" },
       "ie": { "$ref": "#/definitions/browser_statement" },
       "nodejs": { "$ref": "#/definitions/browser_statement" },
       "opera": { "$ref": "#/definitions/browser_statement" },

--- a/compat-data-schema.md
+++ b/compat-data-schema.md
@@ -102,7 +102,6 @@ The currently accepted browser identifiers should be declared in the following o
 * `edge_mobile`, MS Edge, the mobile version,
 * `firefox`, Mozilla Firefox (on desktops),
 * `firefox_android`, Firefox for Android, sometimes nicknamed Fennec,
-* `ie_mobile`, Microsoft Internet Explorer, the mobile version,
 * `ie`, Microsoft Internet Explorer (discontinued),
 * `nodejs` Node.js JavaScript runtime built on Chrome's V8 JavaScript engine,
 * `opera`, the Opera browser (desktop), based on Blink since Opera 15,

--- a/compat-data.schema.json
+++ b/compat-data.schema.json
@@ -74,7 +74,6 @@
         "edge_mobile": { "$ref": "#/definitions/support_statement" },
         "firefox": { "$ref": "#/definitions/support_statement" },
         "firefox_android": { "$ref": "#/definitions/support_statement" },
-        "ie_mobile": { "$ref": "#/definitions/support_statement" },
         "ie": { "$ref": "#/definitions/support_statement" },
         "nodejs": { "$ref": "#/definitions/support_statement" },
         "opera": { "$ref": "#/definitions/support_statement" },

--- a/css/at-rules/charset.json
+++ b/css/at-rules/charset.json
@@ -32,9 +32,6 @@
               "version_added": "5.5",
               "notes": "From Internet Explorer 5.5 to IE 7 (inclusive), Internet Explorer supported an invalid syntax where the character encoding is not between single or double quotes."
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "9"
             },

--- a/css/at-rules/counter-style.json
+++ b/css/at-rules/counter-style.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -79,9 +76,6 @@
                 "version_added": "33"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -133,9 +127,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -183,9 +174,6 @@
                 "version_added": "33"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -237,9 +225,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -287,9 +272,6 @@
                 "version_added": "33"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -341,9 +323,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -391,9 +370,6 @@
                 "version_added": "33"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -445,9 +421,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -497,9 +470,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -547,9 +517,6 @@
                 "version_added": "33"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "10"
             },
@@ -79,9 +76,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": "10"
               },
               "opera": {
                 "version_added": "11.1"
@@ -151,9 +145,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "23"
               },
@@ -201,9 +192,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -254,9 +242,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "47"
               },
@@ -304,9 +289,6 @@
               },
               "ie": {
                 "version_added": "6"
-              },
-              "ie_mobile": {
-                "version_added": "10"
               },
               "opera": {
                 "version_added": "9"
@@ -375,9 +357,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -426,9 +405,6 @@
               "ie": {
                 "version_added": "4"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10"
               },
@@ -475,9 +451,6 @@
               },
               "ie": {
                 "version_added": "4"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": "10"
@@ -527,9 +500,6 @@
               "ie": {
                 "version_added": "6"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "opera": {
                 "version_added": "9"
               },
@@ -577,9 +547,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": true

--- a/css/at-rules/font-feature-values.json
+++ b/css/at-rules/font-feature-values.json
@@ -50,9 +50,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -119,9 +116,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -193,9 +187,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -262,9 +253,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -336,9 +324,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -406,9 +391,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -480,9 +462,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -550,9 +529,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "5.5"
             },
-            "ie_mobile": {
-              "version_added": "5.5"
-            },
             "opera": {
               "version_added": true
             },

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -87,9 +87,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": [
               {
                 "version_added": "12.1",
@@ -170,9 +167,6 @@
                 "version_added": "19"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "6"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "9.2"
             },
@@ -78,9 +75,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -130,9 +124,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": "9.2"
@@ -189,9 +180,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": true
               },
@@ -240,9 +228,6 @@
                 "notes": "Firefox 47 and later support <code>display-mode</code> values <code>fullscreen</code> and <code>browser</code>. Firefox 57 added support for <code>minimal-ui</code> and <code>standalone</code> values."
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/at-rules/namespace.json
+++ b/css/at-rules/namespace.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "8"
             },

--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "6"
             },

--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -52,9 +52,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "12.1"
             },

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -77,9 +77,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12.1"
             },
@@ -139,9 +136,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -192,9 +186,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": true,
@@ -261,9 +252,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true,
                 "notes": "This value is recognized, but has no effect."
@@ -314,9 +302,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "44"
               },
@@ -365,9 +350,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -414,9 +396,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -93,9 +93,6 @@
               "version_added": "11",
               "notes": "In Internet Explorer 10 and 11, if column flex items have <code>align-items: center;</code> set on them and their content is too large, then they will overflow the bounds of their container. See <a href='https://github.com/philipwalton/flexbugs#2-column-flex-items-set-to-align-itemscenter-overflow-their-container'>Flexbug #2</a>."
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "12.1"
             },
@@ -143,9 +140,6 @@
                 "version_added": "45"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -196,9 +190,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -245,9 +236,6 @@
                 "version_added": "45"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -66,9 +66,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "12.1"
             },
@@ -114,9 +111,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -167,9 +161,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -216,9 +207,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -269,9 +257,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -318,9 +303,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/properties/all.json
+++ b/css/properties/all.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "24"
             },
@@ -77,9 +74,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/animation-delay.json
+++ b/css/properties/animation-delay.json
@@ -86,9 +86,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": [
               {
                 "version_added": "12.1",

--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -97,9 +97,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": [
               {
                 "version_added": "12.1",
@@ -224,9 +221,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": true

--- a/css/properties/animation-duration.json
+++ b/css/properties/animation-duration.json
@@ -97,9 +97,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": [
               {
                 "version_added": "12.1",

--- a/css/properties/animation-fill-mode.json
+++ b/css/properties/animation-fill-mode.json
@@ -97,9 +97,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": [
               {
                 "version_added": "12.1",

--- a/css/properties/animation-iteration-count.json
+++ b/css/properties/animation-iteration-count.json
@@ -97,9 +97,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": [
               {
                 "version_added": "12.1",

--- a/css/properties/animation-name.json
+++ b/css/properties/animation-name.json
@@ -97,9 +97,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": [
               {
                 "version_added": "12.1",

--- a/css/properties/animation-play-state.json
+++ b/css/properties/animation-play-state.json
@@ -97,9 +97,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": [
               {
                 "version_added": "12.1",

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -97,9 +97,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": [
               {
                 "version_added": "12.1",

--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -35,9 +35,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/css/properties/backface-visibility.json
+++ b/css/properties/backface-visibility.json
@@ -82,15 +82,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": [
-              {
-                "version_added": "8.1"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "11"
-              }
-            ],
             "opera": {
               "prefix": "-webkit-",
               "version_added": "15"

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -78,9 +75,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": "10.5"
@@ -129,9 +123,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": "10.5"

--- a/css/properties/background-blend-mode.json
+++ b/css/properties/background-blend-mode.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "22"
             },

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -32,9 +32,6 @@
               "version_added": "9",
               "notes": "In IE 7 and IE 8 of Internet Explorer, this property always behaved like <code>background-clip: padding</code> when <code>overflow</code> was <code>hidden</code>, <code>auto</code>, or <code>scroll</code>."
             },
-            "ie_mobile": {
-              "version_added": "7.1"
-            },
             "opera": {
               "version_added": "10.5"
             },
@@ -84,9 +81,6 @@
               "ie": {
                 "version_added": "9",
                 "notes": "In IE 7 and IE 9 of Internet Explorer, it always behaved like <code>background-clip: padding</code> if <code>overflow: hidden | auto | scroll</code>"
-              },
-              "ie_mobile": {
-                "version_added": "7.1"
               },
               "opera": {
                 "version_added": "10.5"
@@ -145,9 +139,6 @@
                 "notes": "In Firefox 48, it was not activated by default and its support could be activated by setting <code>layout.css.background-clip-text.enabled</code> pref to <code>true</code>."
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/background-color.json
+++ b/css/properties/background-color.json
@@ -30,9 +30,6 @@
               "version_added": "4",
               "notes": "In Internet Explorer 8 and 9, there is a bug where a computed <code>background-color</code> of <code>transparent</code> causes <code>click</code> events to not get fired on overlaid elements."
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -78,9 +75,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -32,9 +32,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -81,9 +78,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": true
@@ -137,9 +131,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": "11",
                 "notes": "Some versions support only experimental gradients prefixed with <code>-o</code>."
@@ -192,9 +183,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": "9.5"
               },
@@ -245,9 +233,6 @@
                 "notes": "<code>element()</code> is supported only in its <code>-moz-element()</code> prefixed version"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -302,9 +287,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -351,9 +333,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -35,9 +35,6 @@
               "version_added": "9",
               "notes": "In IE 7 and before, Internet explorer was behaving as if <code>background-origin: border-box</code> was set. In Internet Explorer 8, as if <code>background-origin: padding-box</code>, the regular default value, was set."
             },
-            "ie_mobile": {
-              "version_added": "7.1"
-            },
             "opera": {
               "version_added": "10.5"
             },
@@ -87,9 +84,6 @@
               "ie": {
                 "version_added": "9",
                 "notes": "In IE 7 and IE 9 of Internet Explorer, it always behaved like <code>background-clip: padding</code> if <code>overflow: hidden | auto | scroll</code>."
-              },
-              "ie_mobile": {
-                "version_added": "7.1"
               },
               "opera": {
                 "version_added": "10.5"

--- a/css/properties/background-position-x.json
+++ b/css/properties/background-position-x.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "6"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": true
             },
@@ -78,9 +75,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false

--- a/css/properties/background-position-y.json
+++ b/css/properties/background-position-y.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "6"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": true
             },
@@ -78,9 +75,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false

--- a/css/properties/background-position.json
+++ b/css/properties/background-position.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -78,9 +75,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": "10.5"
@@ -129,9 +123,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": "10.5"

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -78,9 +75,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "10.5"
@@ -130,9 +124,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": true
               },
@@ -180,9 +171,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "10.5"

--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -57,9 +57,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": [
               {
                 "prefix": "-o-",
@@ -121,9 +118,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "opera": {
                 "version_added": "10"
               },
@@ -171,9 +165,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "31"

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -78,9 +75,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": "10"
               },
               "opera": {
                 "version_added": "10.5"
@@ -130,9 +124,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "opera": {
                 "version_added": "21"
               },
@@ -180,9 +171,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": "10"
               },
               "opera": {
                 "version_added": "21"
@@ -232,9 +220,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "opera": {
                 "version_added": "21"
               },
@@ -282,9 +267,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": "10"
               },
               "opera": {
                 "version_added": "21"

--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/border-block-end-color.json
+++ b/css/properties/border-block-end-color.json
@@ -42,9 +42,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/border-block-end-style.json
+++ b/css/properties/border-block-end-style.json
@@ -42,9 +42,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/border-block-end-width.json
+++ b/css/properties/border-block-end-width.json
@@ -42,9 +42,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/border-block-end.json
+++ b/css/properties/border-block-end.json
@@ -42,9 +42,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/border-block-start-color.json
+++ b/css/properties/border-block-start-color.json
@@ -42,9 +42,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/border-block-start-style.json
+++ b/css/properties/border-block-start-style.json
@@ -42,9 +42,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/border-block-start-width.json
+++ b/css/properties/border-block-start-width.json
@@ -42,9 +42,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/border-block-start.json
+++ b/css/properties/border-block-start.json
@@ -42,9 +42,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/border-bottom-color.json
+++ b/css/properties/border-bottom-color.json
@@ -28,9 +28,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6.5"
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/border-bottom-style.json
+++ b/css/properties/border-bottom-style.json
@@ -28,9 +28,6 @@
             "ie": {
               "version_added": "5.5"
             },
-            "ie_mobile": {
-              "version_added": "7"
-            },
             "opera": {
               "version_added": "9.2"
             },

--- a/css/properties/border-bottom-width.json
+++ b/css/properties/border-bottom-width.json
@@ -26,9 +26,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/border-bottom.json
+++ b/css/properties/border-bottom.json
@@ -26,9 +26,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/border-collapse.json
+++ b/css/properties/border-collapse.json
@@ -26,9 +26,6 @@
             "ie": {
               "version_added": "5"
             },
-            "ie_mobile": {
-              "version_added": "7"
-            },
             "opera": {
               "version_added": "4"
             },

--- a/css/properties/border-color.json
+++ b/css/properties/border-color.json
@@ -28,9 +28,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "7"
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/border-image-outset.json
+++ b/css/properties/border-image-outset.json
@@ -23,9 +23,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },

--- a/css/properties/border-image-repeat.json
+++ b/css/properties/border-image-repeat.json
@@ -23,9 +23,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },

--- a/css/properties/border-image-slice.json
+++ b/css/properties/border-image-slice.json
@@ -42,9 +42,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },

--- a/css/properties/border-image-source.json
+++ b/css/properties/border-image-source.json
@@ -23,9 +23,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },

--- a/css/properties/border-image-width.json
+++ b/css/properties/border-image-width.json
@@ -23,9 +23,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -92,9 +92,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": [
               {
                 "version_added": "10.5"

--- a/css/properties/border-inline-end-color.json
+++ b/css/properties/border-inline-end-color.json
@@ -50,9 +50,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/border-inline-end-style.json
+++ b/css/properties/border-inline-end-style.json
@@ -50,9 +50,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/border-inline-end-width.json
+++ b/css/properties/border-inline-end-width.json
@@ -50,9 +50,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/border-inline-end.json
+++ b/css/properties/border-inline-end.json
@@ -40,9 +40,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/border-inline-start-color.json
+++ b/css/properties/border-inline-start-color.json
@@ -50,9 +50,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/border-inline-start-style.json
+++ b/css/properties/border-inline-start-style.json
@@ -50,9 +50,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/border-inline-start-width.json
+++ b/css/properties/border-inline-start-width.json
@@ -42,9 +42,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/border-inline-start.json
+++ b/css/properties/border-inline-start.json
@@ -40,9 +40,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/border-left-color.json
+++ b/css/properties/border-left-color.json
@@ -28,9 +28,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6.5"
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/border-left-style.json
+++ b/css/properties/border-left-style.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": "5.5"
             },
-            "ie_mobile": {
-              "version_added": "7"
-            },
             "opera": {
               "version_added": "9.2"
             },

--- a/css/properties/border-left-width.json
+++ b/css/properties/border-left-width.json
@@ -26,9 +26,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/border-left.json
+++ b/css/properties/border-left.json
@@ -26,9 +26,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -58,9 +58,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": ""
-            },
             "opera": {
               "version_added": "10.5",
               "notes": "In Opera prior to version 11.60, replaced elements with <code>border-radius</code> will not have rounded corners."

--- a/css/properties/border-right-color.json
+++ b/css/properties/border-right-color.json
@@ -28,9 +28,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6.5"
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/border-right-style.json
+++ b/css/properties/border-right-style.json
@@ -28,9 +28,6 @@
             "ie": {
               "version_added": "5.5"
             },
-            "ie_mobile": {
-              "version_added": "7"
-            },
             "opera": {
               "version_added": "9.2"
             },

--- a/css/properties/border-right-width.json
+++ b/css/properties/border-right-width.json
@@ -26,9 +26,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/border-right.json
+++ b/css/properties/border-right.json
@@ -26,9 +26,6 @@
             "ie": {
               "version_added": "5.5"
             },
-            "ie_mobile": {
-              "version_added": "7"
-            },
             "opera": {
               "version_added": "9.2"
             },

--- a/css/properties/border-style.json
+++ b/css/properties/border-style.json
@@ -28,9 +28,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "7"
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/border-top-color.json
+++ b/css/properties/border-top-color.json
@@ -28,9 +28,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6.5"
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/border-top-width.json
+++ b/css/properties/border-top-width.json
@@ -26,9 +26,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/border-top.json
+++ b/css/properties/border-top.json
@@ -26,9 +26,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/border-width.json
+++ b/css/properties/border-width.json
@@ -26,9 +26,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/bottom.json
+++ b/css/properties/bottom.json
@@ -30,9 +30,6 @@
               "version_added": "5",
               "notes": "In Internet Explorer versions before 7, when both <code>top</code> and <code>bottom</code> are specified, the element position is overconstrained and the <code>top</code> property has precedence; the computed value of <code>bottom</code> is set to <code>-top</code>, while its specified value is ignored."
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "6"
             },

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -48,9 +48,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "prefix": "-webkit-",

--- a/css/properties/box-shadow.json
+++ b/css/properties/box-shadow.json
@@ -63,9 +63,6 @@
                 "Since version 5.5, Internet Explorer supports Microsoft's <a href='http://msdn.microsoft.com/en-us/library/ms532985%28VS.85,loband%29.aspx'>DropShadow</a> and <a href='http://msdn.microsoft.com/en-us/library/ms533086%28VS.85,loband%29.aspx'>Shadow Filter</a>. You can use this proprietary extension to cast a drop shadow (though the syntax and the effect are different from CSS3)"
               ]
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "10.5",
               "notes": "Shadows affect layout in this browser. For example, if you cast an outer shadow to a box with a <code>width</code> of <code>100%</code>, then you'll see a scrollbar."
@@ -144,9 +141,6 @@
                 "version_added": "9",
                 "notes": "To use <code>box-shadow</code> in Internet Explorer 9 or later, you must set <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> to <code>separate</code>."
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10.5"
               },
@@ -222,9 +216,6 @@
                 "version_added": "9",
                 "notes": "To use <code>box-shadow</code> in Internet Explorer 9 or later, you must set <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> to <code>separate</code>."
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10.5"
               },
@@ -299,9 +290,6 @@
               "ie": {
                 "version_added": "9",
                 "notes": "To use <code>box-shadow</code> in Internet Explorer 9 or later, you must set <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> to <code>separate</code>."
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "10.5"

--- a/css/properties/box-sizing.json
+++ b/css/properties/box-sizing.json
@@ -96,9 +96,6 @@
               "version_added": "8",
               "notes": "<code>box-sizing</code> is not respected when the height is calculated from <a href='https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle'><code>window.getComputedStyle()</code></a>."
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "7"
             },
@@ -153,9 +150,6 @@
                 "version_removed": "50"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "11.1",
               "version_removed": "12.1"
@@ -79,9 +76,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "11.1",
@@ -132,9 +126,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -181,9 +172,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "11.1",
               "version_removed": "12.1"
@@ -79,9 +76,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "11.1",
@@ -132,9 +126,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -181,9 +172,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/break-inside.json
+++ b/css/properties/break-inside.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "11.1",
               "version_removed": "12.1"
@@ -79,9 +76,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "11.1",
@@ -132,9 +126,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -181,9 +172,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/caption-side.json
+++ b/css/properties/caption-side.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "4"
             },
@@ -79,9 +76,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -128,9 +122,6 @@
                 "version_added": "42"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/caret-color.json
+++ b/css/properties/caret-color.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "44"
             },

--- a/css/properties/clear.json
+++ b/css/properties/clear.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -77,9 +74,6 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -42,9 +42,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "42"
             },
@@ -94,9 +91,6 @@
               "ie": {
                 "version_added": true,
                 "notes": "Internet Explorer only supports clip paths defined by <code>url()</code>."
-              },
-              "ie_mobile": {
-                "version_added": false
               },
               "opera": {
                 "version_added": "42"
@@ -168,9 +162,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "42"
               },
@@ -239,9 +230,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "42"
               },
@@ -288,9 +276,6 @@
                 "version_added": "49"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -341,9 +326,6 @@
                 "notes": "This value was supported before Firefox 51, but as an alias to <code>border-box</code>."
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/clip.json
+++ b/css/properties/clip.json
@@ -30,9 +30,6 @@
               "version_added": "4",
               "notes": "Before Internet Explorer 7, Internet Explorer incorrectly interprets <code>clip: auto</code> as <code>clip: rect(auto, auto, auto, auto)</code>."
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "7"
             },

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
               "ie": {
                 "version_added": "3",
                 "notes": "Internet Explorer 8 and later support gray color keywords spelled with an <em>e</em> (<code>grey</code>, <code>darkgrey</code>, <code>darkslategrey</code>, <code>dimgrey</code>, <code>lightgrey</code>, and <code>lightslategrey</code>). Internet Explorer 3 to Internet Explorer 7 only support the keywords spelled with <em>a</em> (<code>gray</code>, <code>darkgray</code>, <code>darkslategray</code>, <code>dimgray</code>, <code>lightgray</code>, and <code>lightslategray</code>)."
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": "3.5"
@@ -133,9 +127,6 @@
               "ie": {
                 "version_added": "3"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": "3.5"
               },
@@ -184,9 +175,6 @@
               },
               "ie": {
                 "version_added": "4"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": "3.5"
@@ -237,9 +225,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": "9.5"
               },
@@ -288,9 +273,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": "10"
@@ -341,9 +323,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "9.5"
               },
@@ -393,9 +372,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10"
               },
@@ -443,9 +419,6 @@
               },
               "ie": {
                 "version_added": "11"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "25"
@@ -504,9 +477,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "39",
                 "flag": {
@@ -557,9 +527,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -59,9 +59,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": [
               {
                 "version_added": "11.1"
@@ -123,9 +120,6 @@
                 "version_added": "37"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -65,9 +65,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "11.1"
             },
@@ -105,9 +102,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -156,9 +150,6 @@
                 "version_added": "37"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/css/properties/columns.json
+++ b/css/properties/columns.json
@@ -65,9 +65,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "opera": [
               {
                 "version_added": "11.1"
@@ -124,9 +121,6 @@
                 "version_added": "37"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": "8"
-            },
             "opera": {
               "version_added": "4"
             },
@@ -79,9 +76,6 @@
               },
               "ie": {
                 "version_added": "8"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "7"

--- a/css/properties/counter-increment.json
+++ b/css/properties/counter-increment.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "9.2"
             },

--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "opera": {
               "version_added": "9.2"
             },

--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -30,9 +30,6 @@
               "version_added": "4",
               "notes": "In Internet Explorer 11, when <code>cursor</code> is applied to an element and this element is underneath an open <a href='https://developer.mozilla.org/docs/Web/HTML/Element/select'><code>&lt;select&gt;</code></a> menu and the user hovers over a <a href='https://developer.mozilla.org/docs/Web/HTML/Element/select'><code>&lt;select&gt;</code></a> menu item that's on top of said element, the cursor for said element will be displayed rather than the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/select'><code>&lt;select&gt;</code></a>'s normal cursor. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/817822/'>bug 817822</a>."
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "7"
             },
@@ -79,9 +76,6 @@
               },
               "ie": {
                 "version_added": "4"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "7"
@@ -131,9 +125,6 @@
               "ie": {
                 "version_added": "4"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "7"
               },
@@ -182,9 +173,6 @@
               "ie": {
                 "version_added": "8"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "9"
               },
@@ -232,9 +220,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "15"
@@ -286,9 +271,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10.6"
               },
@@ -336,9 +318,6 @@
               },
               "ie": {
                 "version_added": "4"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "7"
@@ -388,9 +367,6 @@
               "ie": {
                 "version_added": "6"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "7"
               },
@@ -438,9 +414,6 @@
               },
               "ie": {
                 "version_added": "6"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "7"
@@ -490,9 +463,6 @@
               "ie": {
                 "version_added": "4"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "7"
               },
@@ -540,9 +510,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "10.6"
@@ -592,9 +559,6 @@
               "ie": {
                 "version_added": "4"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "7"
               },
@@ -642,9 +606,6 @@
               },
               "ie": {
                 "version_added": "4"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "7"
@@ -694,9 +655,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10.6"
               },
@@ -744,9 +702,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "10.6"
@@ -796,9 +751,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10.6"
               },
@@ -846,9 +798,6 @@
               },
               "ie": {
                 "version_added": "4"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "7"
@@ -898,9 +847,6 @@
               "ie": {
                 "version_added": "6"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10.6"
               },
@@ -948,9 +894,6 @@
               },
               "ie": {
                 "version_added": "6"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "10.6"
@@ -1000,9 +943,6 @@
               "ie": {
                 "version_added": "6"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10.6"
               },
@@ -1050,9 +990,6 @@
               },
               "ie": {
                 "version_added": "6"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "10.6"
@@ -1102,9 +1039,6 @@
               "ie": {
                 "version_added": "6"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10.6"
               },
@@ -1153,9 +1087,6 @@
               "ie": {
                 "version_added": "4"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "7"
               },
@@ -1203,9 +1134,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "10.6"
@@ -1266,9 +1194,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": [
                 {
@@ -1339,9 +1264,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": true
               },
@@ -1392,9 +1314,6 @@
               "ie": {
                 "version_added": "6"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -1442,9 +1361,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "36"
             },
@@ -112,9 +109,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/direction.json
+++ b/css/properties/direction.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "5.5"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "9.2"
             },

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "7"
             },
@@ -78,9 +75,6 @@
               },
               "ie": {
                 "version_added": "6"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "7"
@@ -131,9 +125,6 @@
                 "version_added": "6",
                 "notes": "Until Internet Explorer 8, <code>inline-block</code> is only for natural inline elements."
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "7"
               },
@@ -182,9 +173,6 @@
               "ie": {
                 "version_added": "8"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "7"
               },
@@ -232,9 +220,6 @@
               },
               "ie": {
                 "version_added": "8"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "7"
@@ -308,9 +293,6 @@
                   "version_added": "8"
                 }
               ],
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": true
               },
@@ -384,9 +366,6 @@
                   "version_added": "8"
                 }
               ],
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": true
               },
@@ -438,9 +417,6 @@
                 "prefix": "-ms-",
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "44"
               },
@@ -491,9 +467,6 @@
                 "prefix": "-ms-",
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "44"
               },
@@ -541,9 +514,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -598,9 +568,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -651,9 +618,6 @@
               "ie": {
                 "version_added": "8"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "7",
                 "version_removed": "15"
@@ -703,9 +667,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -770,9 +731,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false

--- a/css/properties/empty-cells.json
+++ b/css/properties/empty-cells.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": "8"
-            },
             "opera": {
               "version_added": "4"
             },

--- a/css/properties/filter.json
+++ b/css/properties/filter.json
@@ -103,9 +103,6 @@
               "version_added": false,
               "notes": "Internet Explorer 4 to 9 implemented a non-standard <code>filter</code> property. The syntax was completely different from this one and is not documented here."
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "40"
@@ -165,9 +162,6 @@
                 "version_added": "35"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -87,9 +87,6 @@
               "version_added": "11",
               "notes": "When a non-<code>auto</code> <code>flex-basis</code> is specified, Internet Explorer 10 and 11 always uses a <code>content-box</code> box model to calculate the size of a flex item, even if <a href='http://developer.mozilla.org/docs/Web/CSS/box-sizing'><code>box-sizing: border-box</code></a> is applied to the element. See <a href='https://github.com/philipwalton/flexbugs#7-flex-basis-doesnt-account-for-box-sizingborder-box'>Flexbug #7</a> for more info."
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "12.1"
@@ -190,9 +187,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -64,9 +64,6 @@
                 "version_added": "10"
               }
             ],
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "12.1"

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -59,9 +59,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": [
               {
                 "version_added": "12.1"

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -61,9 +61,6 @@
               "alternative_name": "-ms-flex-positive",
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "12.1"

--- a/css/properties/flex-shrink.json
+++ b/css/properties/flex-shrink.json
@@ -93,9 +93,6 @@
               "version_added": "10",
               "notes": "Internet Explorer 10 uses <code>0</code> instead of <code>1</code> as the initial value for the <code>flex-shrink</code> property. A workaround is to always set an explicit value for <code>flex-shrink</code>. See <a href='https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed'>Flexbug #6</a> for more info."
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "12.1"

--- a/css/properties/flex-wrap.json
+++ b/css/properties/flex-wrap.json
@@ -28,9 +28,6 @@
               "partial_implementation": true,
               "notes": "Partial support due to large number of bugs present. See <a href='https://github.com/philipwalton/flexbugs'>Flexbugs</a>."
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "17"
             },

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -92,9 +92,6 @@
                 ]
               }
             ],
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "12.1"
             },

--- a/css/properties/float.json
+++ b/css/properties/float.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "7"
             },
@@ -77,9 +74,6 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "3"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -84,9 +81,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/font-feature-settings.json
+++ b/css/properties/font-feature-settings.json
@@ -55,9 +55,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": [
               {
                 "version_added": "35"

--- a/css/properties/font-kerning.json
+++ b/css/properties/font-kerning.json
@@ -52,9 +52,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": null
             },

--- a/css/properties/font-language-override.json
+++ b/css/properties/font-language-override.json
@@ -59,9 +59,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -40,9 +40,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "30",
               "flag": {

--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "5.5"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "7"
             },
@@ -90,9 +87,6 @@
                   "version_removed": "10"
                 }
               ],
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "opera": {
                 "version_added": "28"
               },

--- a/css/properties/font-stretch.json
+++ b/css/properties/font-stretch.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "35"
             },

--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "7"
             },

--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -40,9 +40,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -122,9 +119,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -198,9 +192,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -270,9 +261,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -346,9 +334,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -420,9 +405,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -492,9 +474,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/font-variant-caps.json
+++ b/css/properties/font-variant-caps.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "39"
             },

--- a/css/properties/font-variant-east-asian.json
+++ b/css/properties/font-variant-east-asian.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "50"
             },

--- a/css/properties/font-variant-ligatures.json
+++ b/css/properties/font-variant-ligatures.json
@@ -63,9 +63,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": [
               {
                 "version_added": "21"

--- a/css/properties/font-variant-numeric.json
+++ b/css/properties/font-variant-numeric.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "39"
             },

--- a/css/properties/font-variant-position.json
+++ b/css/properties/font-variant-position.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -77,9 +74,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -130,9 +124,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -179,9 +170,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -252,9 +240,6 @@
                 }
               ],
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/properties/font-variation-settings.json
+++ b/css/properties/font-variation-settings.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "49"
             },

--- a/css/properties/font-weight.json
+++ b/css/properties/font-weight.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "3"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/font.json
+++ b/css/properties/font.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "3"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -79,9 +76,6 @@
               "ie": {
                 "version_added": "4"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "6"
               },
@@ -128,9 +122,6 @@
                 "version_added": "43"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/properties/grid-area.json
+++ b/css/properties/grid-area.json
@@ -67,9 +67,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"

--- a/css/properties/grid-auto-columns.json
+++ b/css/properties/grid-auto-columns.json
@@ -80,9 +80,6 @@
               "version_added": "10",
               "alternative_name": "-ms-grid-columns"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"

--- a/css/properties/grid-auto-flow.json
+++ b/css/properties/grid-auto-flow.json
@@ -67,9 +67,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"

--- a/css/properties/grid-auto-rows.json
+++ b/css/properties/grid-auto-rows.json
@@ -80,9 +80,6 @@
               "version_added": "10",
               "alternative_name": "-ms-grid-rows"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"

--- a/css/properties/grid-column-end.json
+++ b/css/properties/grid-column-end.json
@@ -76,9 +76,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"

--- a/css/properties/grid-column-gap.json
+++ b/css/properties/grid-column-gap.json
@@ -76,9 +76,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"

--- a/css/properties/grid-column-start.json
+++ b/css/properties/grid-column-start.json
@@ -76,9 +76,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"

--- a/css/properties/grid-column.json
+++ b/css/properties/grid-column.json
@@ -76,9 +76,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"

--- a/css/properties/grid-gap.json
+++ b/css/properties/grid-gap.json
@@ -67,9 +67,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"
@@ -124,9 +121,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/grid-row-end.json
+++ b/css/properties/grid-row-end.json
@@ -67,9 +67,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"

--- a/css/properties/grid-row-gap.json
+++ b/css/properties/grid-row-gap.json
@@ -67,9 +67,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"

--- a/css/properties/grid-row-start.json
+++ b/css/properties/grid-row-start.json
@@ -67,9 +67,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"

--- a/css/properties/grid-row.json
+++ b/css/properties/grid-row.json
@@ -67,9 +67,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"

--- a/css/properties/grid-template-areas.json
+++ b/css/properties/grid-template-areas.json
@@ -67,9 +67,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -67,9 +67,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"
@@ -154,9 +151,6 @@
                 }
               ],
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": [
@@ -246,9 +240,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": [

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -67,9 +67,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"
@@ -154,9 +151,6 @@
                 }
               ],
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": [
@@ -246,9 +240,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": [

--- a/css/properties/grid-template.json
+++ b/css/properties/grid-template.json
@@ -67,9 +67,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"

--- a/css/properties/grid.json
+++ b/css/properties/grid.json
@@ -67,9 +67,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "44"

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "7"
             },
@@ -77,9 +74,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -130,9 +124,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -181,9 +172,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -230,9 +218,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -58,9 +58,6 @@
               "version_added": "10",
               "notes": "Automatic hyphenation only works for languages with hyphenation dictionaries that are integrated into Internet Explorer."
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "44"
             },
@@ -110,9 +107,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -160,9 +154,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -212,9 +203,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -262,9 +250,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -314,9 +299,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -364,9 +346,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -416,9 +395,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -466,9 +442,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -518,9 +491,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -568,9 +538,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -620,9 +587,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -670,9 +634,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -722,9 +683,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -773,9 +731,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -822,9 +777,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -875,9 +827,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -925,9 +874,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -977,9 +923,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -1027,9 +970,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -1079,9 +1019,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -1129,9 +1066,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -1181,9 +1115,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "44"
               },
@@ -1231,9 +1162,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -1283,9 +1211,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -1333,9 +1258,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -1385,9 +1307,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -1436,9 +1355,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -1486,9 +1402,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -1539,9 +1452,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -1589,9 +1499,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -1641,9 +1548,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -1691,9 +1595,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -1743,9 +1644,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -1793,9 +1691,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -1845,9 +1740,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -1895,9 +1787,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -1947,9 +1836,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -1998,9 +1884,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "44"

--- a/css/properties/image-orientation.json
+++ b/css/properties/image-orientation.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -77,9 +74,6 @@
                 "version_added": "26"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -128,9 +122,6 @@
                 "version_added": "26"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": true
             },
@@ -79,9 +76,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "prefix": "-o-",
@@ -133,9 +127,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "26"
               },
@@ -184,9 +175,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": true
               },
@@ -234,9 +222,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": true

--- a/css/properties/ime-mode.json
+++ b/css/properties/ime-mode.json
@@ -35,9 +35,6 @@
                 "version_added": "8"
               }
             ],
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/initial-letter.json
+++ b/css/properties/initial-letter.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/inline-size.json
+++ b/css/properties/inline-size.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/isolation.json
+++ b/css/properties/isolation.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "30"
             },

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -74,9 +74,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "12.1"
             },
@@ -122,9 +119,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -175,9 +169,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": true,
@@ -242,9 +233,6 @@
                 "version_added": true,
                 "notes": "This value is recognized, but has no effect."
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": true,
                 "notes": "This value is recognized, but has no effect."
@@ -292,9 +280,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -345,9 +330,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -395,9 +377,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "44"

--- a/css/properties/justify-items.json
+++ b/css/properties/justify-items.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/css/properties/left.json
+++ b/css/properties/left.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "5.5"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "5"
             },

--- a/css/properties/letter-spacing.json
+++ b/css/properties/letter-spacing.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -77,9 +74,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/properties/line-break.json
+++ b/css/properties/line-break.json
@@ -53,9 +53,6 @@
                 "version_added": "8"
               }
             ],
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": [
               {
                 "version_added": "45"

--- a/css/properties/line-height.json
+++ b/css/properties/line-height.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "7"
             },

--- a/css/properties/list-style-image.json
+++ b/css/properties/list-style-image.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "7"
             },

--- a/css/properties/list-style-position.json
+++ b/css/properties/list-style-position.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -85,9 +82,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -135,9 +129,6 @@
               },
               "ie": {
                 "version_added": "8"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "6"
@@ -193,9 +184,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -243,9 +231,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false
@@ -301,9 +286,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -358,9 +340,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -408,9 +387,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": [
                 {
@@ -467,9 +443,6 @@
               "ie": {
                 "version_added": "8"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "8"
               },
@@ -524,9 +497,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -575,9 +545,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -625,9 +592,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false
@@ -684,9 +648,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -734,9 +695,6 @@
               },
               "ie": {
                 "version_added": "8"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "6"
@@ -792,9 +750,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -849,9 +804,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -899,9 +851,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": [
                 {
@@ -958,9 +907,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": [
                 {
                   "version_added": "15"
@@ -1015,9 +961,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": [
                 {
@@ -1080,9 +1023,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -1136,9 +1076,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false
@@ -1194,9 +1131,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -1244,9 +1178,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": [
                 {
@@ -1302,9 +1233,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": [
                 {
@@ -1367,9 +1295,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -1417,9 +1342,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false
@@ -1469,9 +1391,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -1519,9 +1438,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false
@@ -1577,9 +1493,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -1628,9 +1541,6 @@
               "ie": {
                 "version_added": "8"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "6"
               },
@@ -1678,9 +1588,6 @@
               },
               "ie": {
                 "version_added": "8"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "6"
@@ -1736,9 +1643,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -1786,9 +1690,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false
@@ -1844,9 +1745,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -1900,9 +1798,6 @@
               ],
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false
@@ -1958,9 +1853,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -2014,9 +1906,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false
@@ -2072,9 +1961,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -2128,9 +2014,6 @@
               ],
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false
@@ -2186,9 +2069,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -2242,9 +2122,6 @@
               ],
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false
@@ -2300,9 +2177,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -2357,9 +2231,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -2407,9 +2278,6 @@
               },
               "ie": {
                 "version_added": "8"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "6"
@@ -2459,9 +2327,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -2508,9 +2373,6 @@
                 "version_added": "35"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/list-style.json
+++ b/css/properties/list-style.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "7"
             },
@@ -77,9 +74,6 @@
                 "version_added": "35"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/margin-block-end.json
+++ b/css/properties/margin-block-end.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/margin-block-start.json
+++ b/css/properties/margin-block-start.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/margin-bottom.json
+++ b/css/properties/margin-bottom.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "3"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -79,9 +76,6 @@
               "ie": {
                 "version_added": "6",
                 "notes": "The <code>auto</code> value is not supported in quirks mode."
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "3.5"

--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -60,9 +60,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": null
             },

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -60,9 +60,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": null
             },

--- a/css/properties/margin-left.json
+++ b/css/properties/margin-left.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "3"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -79,9 +76,6 @@
               "ie": {
                 "version_added": "6",
                 "notes": "The <code>auto</code> value is not supported in quirks mode."
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "3.5"

--- a/css/properties/margin-right.json
+++ b/css/properties/margin-right.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "3"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -79,9 +76,6 @@
               "ie": {
                 "version_added": "6",
                 "notes": "The <code>auto</code> value is not supported in quirks mode."
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "3.5"

--- a/css/properties/margin-top.json
+++ b/css/properties/margin-top.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "3"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -79,9 +76,6 @@
               "ie": {
                 "version_added": "6",
                 "notes": "The <code>auto</code> value is not supported in quirks mode."
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "3.5"

--- a/css/properties/margin.json
+++ b/css/properties/margin.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "3"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -79,9 +76,6 @@
               "ie": {
                 "version_added": "6",
                 "notes": "The <code>auto</code> value is not supported in quirks mode."
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "3.5"

--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "prefix": "-webkit-",
               "version_added": true
@@ -80,9 +77,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -133,9 +127,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -184,9 +175,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -233,9 +221,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/mask-composite.json
+++ b/css/properties/mask-composite.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false,
               "notes": "See also <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-composite'><code>-webkit-mask-composite</code></a> for a similar non-standard property that uses different keywords."

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -33,9 +33,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "prefix": "-webkit-",
               "version_added": true
@@ -88,9 +85,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": true
               },
@@ -138,9 +132,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": true

--- a/css/properties/mask-mode.json
+++ b/css/properties/mask-mode.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "prefix": "-webkit-",
               "version_added": true,
@@ -85,9 +82,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -186,9 +177,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -239,9 +227,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false

--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -1,4 +1,4 @@
-  {
+{
   "css": {
     "properties": {
       "mask-position": {
@@ -28,9 +28,6 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
-            },
-            "ie_mobile": {
               "version_added": null
             },
             "opera": {

--- a/css/properties/mask-repeat.json
+++ b/css/properties/mask-repeat.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/css/properties/mask-type.json
+++ b/css/properties/mask-type.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },
@@ -100,9 +97,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false

--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -45,9 +45,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": [
               {
                 "version_added": true,
@@ -115,9 +112,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "prefix": "-webkit-",
                 "version_added": true
@@ -167,9 +161,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "prefix": "-webkit-",

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "7"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "7",
               "notes": "CSS 2.1 leaves the behavior of <code>max-height</code> with <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>table</code></a> undefined. Opera supports applying <code>max-height</code> to <code>table</code> elements."
@@ -85,9 +82,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -137,9 +131,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -54,9 +54,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "prefix": "-webkit-",
               "version_added": true

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "7"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "4",
               "notes": "CSS 2.1 leaves the behavior of <code>max-width</code> with <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>table</code></a> undefined. Opera supports applying <code>max-width</code> to <code>table</code> elements."
@@ -84,9 +81,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -135,9 +129,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false

--- a/css/properties/min-block-size.json
+++ b/css/properties/min-block-size.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -31,9 +31,6 @@
               "version_added": "7",
               "notes": "In Internet Explorer 10 and 11, a <code>min-height</code> declaration on a column-direction flex container doesn't apply to the container's flex items. See <a href='https://github.com/philipwalton/flexbugs#3-min-height-on-a-column-flex-container-wont-apply-to-its-flex-items'>Flexbug #3</a> for more info."
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "4",
               "notes": "CSS 2.1 leaves the behavior of <code>min-height</code> with <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>table</code></a> undefined. Opera supports applying <code>min-height</code> to <code>table</code> elements."
@@ -82,9 +79,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -132,9 +126,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false
@@ -185,9 +176,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "12.1"

--- a/css/properties/min-inline-size.json
+++ b/css/properties/min-inline-size.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "7"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "4",
               "notes": "CSS 2.1 leaves the behavior of <code>min-width</code> with <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>table</code></a> undefined. Opera supports applying <code>min-width</code> to <code>table</code> elements."
@@ -84,9 +81,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -135,9 +129,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false
@@ -195,9 +186,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "12.1",

--- a/css/properties/mix-blend-mode.json
+++ b/css/properties/mix-blend-mode.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": true
             },
@@ -77,9 +74,6 @@
                 "version_added": "32"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/properties/object-fit.json
+++ b/css/properties/object-fit.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "19"

--- a/css/properties/object-position.json
+++ b/css/properties/object-position.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "19"

--- a/css/properties/offset-block-end.json
+++ b/css/properties/offset-block-end.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/offset-block-start.json
+++ b/css/properties/offset-block-start.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/offset-distance.json
+++ b/css/properties/offset-distance.json
@@ -47,9 +47,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/css/properties/offset-inline-end.json
+++ b/css/properties/offset-inline-end.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/offset-inline-start.json
+++ b/css/properties/offset-inline-start.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -47,9 +47,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/css/properties/offset-rotate.json
+++ b/css/properties/offset-rotate.json
@@ -59,9 +59,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/css/properties/offset.json
+++ b/css/properties/offset.json
@@ -47,9 +47,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/css/properties/opacity.json
+++ b/css/properties/opacity.json
@@ -36,9 +36,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "9"
             },

--- a/css/properties/order.json
+++ b/css/properties/order.json
@@ -103,9 +103,6 @@
                 "version_added": "10"
               }
             ],
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "12.1"
             },
@@ -163,9 +160,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "opera": {

--- a/css/properties/orphans.json
+++ b/css/properties/orphans.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "9.2"
             },

--- a/css/properties/outline-color.json
+++ b/css/properties/outline-color.json
@@ -36,9 +36,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "7"
             },
@@ -86,9 +83,6 @@
               },
               "ie": {
                 "version_added": "8"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "7",

--- a/css/properties/outline-offset.json
+++ b/css/properties/outline-offset.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "9.5"
             },

--- a/css/properties/outline-style.json
+++ b/css/properties/outline-style.json
@@ -36,9 +36,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "opera": {
               "version_added": "7"
             },
@@ -84,9 +81,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/properties/outline-width.json
+++ b/css/properties/outline-width.json
@@ -36,9 +36,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "7"
             },

--- a/css/properties/outline.json
+++ b/css/properties/outline.json
@@ -37,9 +37,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": "8"
-            },
             "opera": {
               "version_added": "7"
             },

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -66,9 +66,6 @@
               "alternative_name": "word-wrap",
               "version_added": "5.5"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": [
               {
                 "version_added": true

--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -35,9 +35,6 @@
                 "version_added": "8"
               }
             ],
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "9.5"
             },

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -35,9 +35,6 @@
                 "version_added": "8"
               }
             ],
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "9.5"
             },

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -31,9 +31,6 @@
               "version_added": "4",
               "notes": "From version 4 to 6, Internet Explorer enlarges an element with <code>overflow: visible</code> (default value) to fit the content inside it. <code>height</code> and <code>width</code> behave like <code>min-height</code> and <code>min-width</code>, respectively."
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "7"
             },

--- a/css/properties/padding-block-end.json
+++ b/css/properties/padding-block-end.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/padding-block-start.json
+++ b/css/properties/padding-block-start.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/padding-bottom.json
+++ b/css/properties/padding-bottom.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -62,9 +62,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "alternative_name": "-webkit-padding-end",
               "version_added": "15"

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -62,9 +62,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "alternative_name": "-webkit-padding-end",
               "version_added": true

--- a/css/properties/padding-left.json
+++ b/css/properties/padding-left.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/padding-right.json
+++ b/css/properties/padding-right.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/padding-top.json
+++ b/css/properties/padding-top.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/padding.json
+++ b/css/properties/padding.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/properties/page-break-after.json
+++ b/css/properties/page-break-after.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "7"
             },

--- a/css/properties/page-break-before.json
+++ b/css/properties/page-break-before.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "7"
             },

--- a/css/properties/page-break-inside.json
+++ b/css/properties/page-break-inside.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "7"
             },

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -81,9 +81,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "8.1"
-            },
             "opera": {
               "prefix": "-webkit-",
               "version_added": "15"

--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -86,9 +86,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "8.1"
-            },
             "opera": {
               "prefix": "-webkit-",
               "version_added": "15"

--- a/css/properties/place-content.json
+++ b/css/properties/place-content.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/css/properties/place-items.json
+++ b/css/properties/place-items.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/css/properties/pointer-events.json
+++ b/css/properties/pointer-events.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "9"
             },
@@ -78,9 +75,6 @@
               },
               "ie": {
                 "version_added": "11"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "15"

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -31,9 +31,6 @@
               "version_added": "4",
               "notes": "In Internet Explorer, fixed positioning doesn't work if the document is in <a href='http://msdn.microsoft.com/en-us/library/ie/ms531140(v=vs.85).aspx'>quirks mode</a>."
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "4"
             },
@@ -81,9 +78,6 @@
               },
               "ie": {
                 "version_added": "7"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "4"
@@ -144,9 +138,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "43"
               },
@@ -196,9 +187,6 @@
                 "notes": "Firefox helps developers transition to the new behavior and detect any rendering issues it may cause on their sites by printing the following warning to the JavaScript console: &quot;Relative positioning of table rows and row groups is now supported. This site may need to be updated because it may depend on this feature having no effect.&quot;"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/properties/quotes.json
+++ b/css/properties/quotes.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "4"
             },

--- a/css/properties/resize.json
+++ b/css/properties/resize.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "12.1"
             },
@@ -79,9 +76,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/properties/right.json
+++ b/css/properties/right.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "5.5"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "5"
             },

--- a/css/properties/ruby-align.json
+++ b/css/properties/ruby-align.json
@@ -31,9 +31,6 @@
               "version_added": false,
               "notes": "Internet Explorer 9 and later supports an earlier draft of CSS Ruby with non-standard values for this property: <code>auto</code>, <code>left</code>, <code>center</code>, <code>right</code>, <code>distribute-letter</code>, <code>distribute-space</code>, and <code>line-edge</code>."
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/ruby-position.json
+++ b/css/properties/ruby-position.json
@@ -30,9 +30,6 @@
               "version_added": false,
               "notes": "Internet Explorer 9 and later support an old draft values: <code>inline</code> (equivalent of having <code>display: inline</code> on the ruby), and <code>above</code> (synonym of the modern <code>over</code>)."
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": null
             },
@@ -80,9 +77,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/scroll-behavior.json
+++ b/css/properties/scroll-behavior.json
@@ -34,9 +34,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": true,
               "flag": {
@@ -65,4 +62,3 @@
     }
   }
 }
-

--- a/css/properties/scroll-snap-coordinate.json
+++ b/css/properties/scroll-snap-coordinate.json
@@ -36,9 +36,6 @@
                 }
               }
             ],
-            "ie_mobile": {
-              "version_added": false
-            },
             "ie": {
               "version_added": false
             },
@@ -65,4 +62,3 @@
     }
   }
 }
-

--- a/css/properties/scroll-snap-destination.json
+++ b/css/properties/scroll-snap-destination.json
@@ -36,9 +36,6 @@
                 }
               }
             ],
-            "ie_mobile": {
-              "version_added": false
-            },
             "ie": {
               "version_added": false
             },
@@ -65,4 +62,3 @@
     }
   }
 }
-

--- a/css/properties/scroll-snap-points-x.json
+++ b/css/properties/scroll-snap-points-x.json
@@ -39,9 +39,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -67,4 +64,3 @@
     }
   }
 }
-

--- a/css/properties/scroll-snap-points-y.json
+++ b/css/properties/scroll-snap-points-y.json
@@ -39,9 +39,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -67,4 +64,3 @@
     }
   }
 }
-

--- a/css/properties/scroll-snap-type-x.json
+++ b/css/properties/scroll-snap-type-x.json
@@ -39,9 +39,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -65,4 +62,3 @@
     }
   }
 }
-

--- a/css/properties/scroll-snap-type-y.json
+++ b/css/properties/scroll-snap-type-y.json
@@ -39,9 +39,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -65,4 +62,3 @@
     }
   }
 }
-

--- a/css/properties/scroll-snap-type.json
+++ b/css/properties/scroll-snap-type.json
@@ -42,9 +42,6 @@
               "version_added": "10",
               "prefix": "-ms-"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -70,4 +67,3 @@
     }
   }
 }
-

--- a/css/properties/shape-image-threshold.json
+++ b/css/properties/shape-image-threshold.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "24"
             },

--- a/css/properties/shape-margin.json
+++ b/css/properties/shape-margin.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/properties/shape-outside.json
+++ b/css/properties/shape-outside.json
@@ -43,9 +43,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "24"
             },
@@ -94,9 +91,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -157,9 +151,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -216,9 +207,6 @@
                 }
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/tab-size.json
+++ b/css/properties/tab-size.json
@@ -40,9 +40,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "15"
@@ -101,9 +98,6 @@
                 "version_added": "53"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/table-layout.json
+++ b/css/properties/table-layout.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "5"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "7"
             },

--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -65,9 +65,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": true
             },

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "3"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -139,9 +133,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -190,9 +181,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -239,9 +227,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -98,9 +98,6 @@
               "version_added": "11",
               "alternative_name": "-ms-text-combine-horizontal"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": true
@@ -170,9 +167,6 @@
               },
               "ie": {
                 "version_added": true
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false

--- a/css/properties/text-decoration-color.json
+++ b/css/properties/text-decoration-color.json
@@ -43,9 +43,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "44"
             },

--- a/css/properties/text-decoration-line.json
+++ b/css/properties/text-decoration-line.json
@@ -43,9 +43,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": true
             },
@@ -98,9 +95,6 @@
                 "notes": "The <code>blink</code> value does not have any effect."
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/text-decoration-skip-ink.json
+++ b/css/properties/text-decoration-skip-ink.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "50"
             },

--- a/css/properties/text-decoration-skip.json
+++ b/css/properties/text-decoration-skip.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "44"
             },

--- a/css/properties/text-decoration-style.json
+++ b/css/properties/text-decoration-style.json
@@ -43,9 +43,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "44"
             },
@@ -93,9 +90,6 @@
                 "version_added": "6"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "3"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -94,10 +91,6 @@
                 }
               ],
               "ie": {
-                "version_added": true,
-                "notes": "The <code>blink</code> value does not have any effect."
-              },
-              "ie_mobile": {
                 "version_added": true,
                 "notes": "The <code>blink</code> value does not have any effect."
               },
@@ -169,9 +162,6 @@
               ],
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false

--- a/css/properties/text-emphasis-color.json
+++ b/css/properties/text-emphasis-color.json
@@ -53,9 +53,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "prefix": "-webkit-",
               "version_added": "15"

--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -63,9 +63,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": true
@@ -130,9 +127,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "49"

--- a/css/properties/text-emphasis-style.json
+++ b/css/properties/text-emphasis-style.json
@@ -53,9 +53,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "prefix": "-webkit-",
               "version_added": "15"

--- a/css/properties/text-emphasis.json
+++ b/css/properties/text-emphasis.json
@@ -53,9 +53,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "prefix": "-webkit-",
               "version_added": "15"

--- a/css/properties/text-indent.json
+++ b/css/properties/text-indent.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "3"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -77,9 +74,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -128,9 +122,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/text-justify.json
+++ b/css/properties/text-justify.json
@@ -44,9 +44,6 @@
               "version_added": "11",
               "notes": "Standard values <code>inter-character</code> and <code>none</code> are supported. The deprecated <code>distribute</code> value is also supported."
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": true,
               "flag": {

--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -69,9 +69,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "prefix": "-webkit-",
               "version_added": true
@@ -120,9 +117,6 @@
                 "notes": "<code>sideways-right</code> has become an alias of <code>sideways</code>."
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/text-overflow.json
+++ b/css/properties/text-overflow.json
@@ -37,9 +37,6 @@
                 "version_added": "8"
               }
             ],
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": [
               {
                 "version_added": "11"
@@ -93,9 +90,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -142,9 +136,6 @@
                 "version_added": "9"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -195,9 +186,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -244,9 +232,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/text-rendering.json
+++ b/css/properties/text-rendering.json
@@ -38,9 +38,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -88,9 +85,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -142,9 +136,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/text-shadow.json
+++ b/css/properties/text-shadow.json
@@ -35,9 +35,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "9.5",
               "notes": [

--- a/css/properties/text-size-adjust.json
+++ b/css/properties/text-size-adjust.json
@@ -66,16 +66,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": [
-              {
-                "prefix": "-ms-",
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "11"
-              }
-            ],
             "opera": {
               "version_added": "42"
             },
@@ -130,10 +120,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": true,
-                "notes": "If the viewport is set using <a href='https://developer.mozilla.org/docs/Web/HTML/Element/meta'><code>&lt;meta&gt;</code></a> element, the value of the CSS <code>text-size-adjust</code> property is ignored. See <a href='https://msdn.microsoft.com/library/windows/apps/ff462082(v=vs.105).aspx#BKMK_AdjustingTextSizewithCustomCSS'>detailed implementation hints on MSDN</a>."
               },
               "opera": {
                 "version_added": false

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "7",
               "notes": "Since Opera 15, the <code>text-transform</code> property does not work for <code>::first-line</code> pseudo-elements (nor for the one-colon syntax). See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
@@ -84,9 +81,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -133,9 +127,6 @@
                 "version_added": "19"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -186,9 +177,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -235,9 +223,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -288,9 +273,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -339,9 +321,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -388,9 +367,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "6"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": false
             },
@@ -78,9 +75,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false
@@ -131,9 +125,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -182,9 +173,6 @@
               "ie": {
                 "version_added": "5"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -232,9 +220,6 @@
               },
               "ie": {
                 "version_added": "6"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false

--- a/css/properties/top.json
+++ b/css/properties/top.json
@@ -30,9 +30,6 @@
               "version_added": "5",
               "notes": "In Internet Explorer versions before 7, when both <code>top</code> and <code>bottom</code> are specified, the element position is overconstrained and the <code>top</code> property has precedence; the computed value of <code>bottom</code> is set to <code>-top</code>, while its specified value is ignored."
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "6"
             },

--- a/css/properties/touch-action.json
+++ b/css/properties/touch-action.json
@@ -58,15 +58,6 @@
                 "prefix": "-ms-"
               }
             ],
-            "ie_mobile": [
-              {
-                "version_added": "11"
-              },
-              {
-                "version_added": "10",
-                "prefix": "-ms-"
-              }
-            ],
             "opera": {
               "version_added": "23"
             },
@@ -143,15 +134,6 @@
                   "prefix": "-ms-"
                 }
               ],
-              "ie_mobile": [
-                {
-                  "version_added": "11"
-                },
-                {
-                  "version_added": "10",
-                  "prefix": "-ms-"
-                }
-              ],
               "opera": {
                 "version_added": "23"
               },
@@ -197,15 +179,6 @@
                 "version_added": false
               },
               "ie": [
-                {
-                  "version_added": "11"
-                },
-                {
-                  "version_added": "10",
-                  "prefix": "-ms-"
-                }
-              ],
-              "ie_mobile": [
                 {
                   "version_added": "11"
                 },
@@ -269,15 +242,6 @@
                   "prefix": "-ms-"
                 }
               ],
-              "ie_mobile": [
-                {
-                  "version_added": "11"
-                },
-                {
-                  "version_added": "10",
-                  "prefix": "-ms-"
-                }
-              ],
               "opera": {
                 "version_added": "43"
               },
@@ -326,9 +290,6 @@
                 "notes": "See <a href='https://bugzil.la/1285685'>bug 1285685</a>."
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/transform-box.json
+++ b/css/properties/transform-box.json
@@ -67,9 +67,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "51"
             },

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -86,10 +86,6 @@
                 "version_added": "9"
               }
             ],
-            "ie_mobile": {
-              "prefix": "-webkit-",
-              "version_added": "8.1"
-            },
             "opera": [
               {
                 "version_added": "12.1"
@@ -143,9 +139,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false
@@ -207,9 +200,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": true

--- a/css/properties/transform-style.json
+++ b/css/properties/transform-style.json
@@ -81,9 +81,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "prefix": "-webkit-",
               "version_added": "15"

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -82,15 +82,6 @@
                 "notes": "Internet Explorer 5.5 or later supports a proprietary <a href='https://msdn.microsoft.com/en-us/library/ms533014(VS.85,loband).aspx'>Matrix Filter</a> which can be used to achieve a similar effect."
               }
             ],
-            "ie_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "11"
-              }
-            ],
             "opera": [
               {
                 "version_added": "12.1"
@@ -163,9 +154,6 @@
               "ie": {
                 "version_added": "10",
                 "notes": "Internet Explorer 9.0 or earlier has no support for 3D transforms. Mixing 3D and 2D transform functions, such as <code>-ms-transform:rotate(10deg) translateZ(0);</code>, will prevent the entire property from being applied."
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": "15"

--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -97,9 +97,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": [
               {
                 "version_added": "12.1"

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -97,9 +97,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": [
               {
                 "version_added": "12.1"

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -97,9 +97,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": [
               {
                 "version_added": "12.1"
@@ -169,9 +166,6 @@
               },
               "ie": {
                 "version_added": true
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": true

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -97,9 +97,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": [
               {
                 "version_added": "12.1"

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -107,9 +107,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "opera": [
               {
                 "version_added": "12.1"
@@ -189,9 +186,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "opera": {

--- a/css/properties/unicode-bidi.json
+++ b/css/properties/unicode-bidi.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "5.5"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "9.2"
             },
@@ -103,9 +100,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -180,9 +174,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -243,9 +234,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/properties/vertical-align.json
+++ b/css/properties/vertical-align.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "4"
             },

--- a/css/properties/visibility.json
+++ b/css/properties/visibility.json
@@ -33,9 +33,6 @@
                 "Up to Internet Explorer 7, descendants of <code>hidden</code> elements will still be invisible even if they have <code>visibility</code> set to <code>visible</code>."
               ]
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "4"
             },
@@ -91,9 +88,6 @@
                 "notes": "Firefox doesn't hide borders when hiding <a href='https://developer.mozilla.org/docs/Web/HTML/Element/col'><code>&lt;col&gt;</code></a> and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/colgroup'><code>&lt;colgroup&gt;</code></a> elements if <code>border-collapse: collapse</code> is set."
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "5.5"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "4"
             },
@@ -78,9 +75,6 @@
               },
               "ie": {
                 "version_added": "6"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "4"
@@ -137,9 +131,6 @@
                 "version_added": "8",
                 "notes": "From Internet Explorer 5.5 to 7, <code>word-wrap: break-word;</code> can be used for line breaks in <code>pre<code> elements."
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "8"
               },
@@ -187,9 +178,6 @@
               },
               "ie": {
                 "version_added": "8"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "9.5"
@@ -239,9 +227,6 @@
               "ie": {
                 "version_added": "5.5"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "4"
               },
@@ -288,9 +273,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/properties/widows.json
+++ b/css/properties/widows.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "9.2"
             },

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -77,9 +74,6 @@
                 "version_added": "16"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -135,9 +129,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -203,9 +194,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "prefix": "-webkit-",
                 "version_added": "15"
@@ -263,9 +251,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -313,9 +298,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -374,9 +356,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "prefix": "-webkit-",
                 "version_added": "15"
@@ -427,9 +406,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -478,9 +454,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -527,9 +500,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/properties/will-change.json
+++ b/css/properties/will-change.json
@@ -53,9 +53,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "24"
             },

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -37,9 +37,6 @@
                 "notes": "Don't use <code>-ms-word-break</code>, which is a synonym for <code>word-break</code>."
               }
             ],
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "15"
             },
@@ -87,9 +84,6 @@
               "ie": {
                 "version_added": "5.5"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "31"
               },
@@ -136,9 +130,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "6"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -78,9 +75,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false

--- a/css/properties/word-wrap.json
+++ b/css/properties/word-wrap.json
@@ -53,9 +53,6 @@
             "ie": {
               "version_added": "5.5"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": [
               {
                 "alternative_name": "overflow-wrap",

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -85,9 +85,6 @@
               "version_added": "9",
               "notes": "Internet Explorer's implementation differs from the specification."
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "prefix": "-webkit-",
               "version_added": "15"
@@ -139,9 +136,6 @@
                 "prefix": "-ms-",
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": true
               },
@@ -190,9 +184,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": true
               },
@@ -240,9 +231,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false

--- a/css/properties/z-index.json
+++ b/css/properties/z-index.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "4"
             },
@@ -78,9 +75,6 @@
               },
               "ie": {
                 "version_added": "4"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": "4"

--- a/css/selectors/active.json
+++ b/css/selectors/active.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": "6"
-            },
             "opera": {
               "version_added": "5"
             },
@@ -79,9 +76,6 @@
               },
               "ie": {
                 "version_added": "8"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "7"

--- a/css/selectors/adjacent_sibling.json
+++ b/css/selectors/adjacent_sibling.json
@@ -34,9 +34,6 @@
                 "In Internet Explorer 8, if an element is inserted dynamically by clicking on a link the first-child style isn't applied until the link loses focus."
               ]
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/css/selectors/after.json
+++ b/css/selectors/after.json
@@ -70,9 +70,6 @@
                 "version_added": "8"
               }
             ],
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": [
               {
                 "version_added": "7"
@@ -130,9 +127,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -44,9 +44,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "prefix": "-webkit-",
               "version_added": true

--- a/css/selectors/any.json
+++ b/css/selectors/any.json
@@ -33,9 +33,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/css/selectors/attribute.json
+++ b/css/selectors/attribute.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "7"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "9"
             },
@@ -78,9 +75,6 @@
                 "version_added": "47"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -39,9 +39,6 @@
               "prefix": "-ms-",
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -87,9 +84,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -139,9 +133,6 @@
               },
               "ie": {
                 "version_added": "11"
-              },
-              "ie_mobile": {
-                "version_added": false
               },
               "opera": {
                 "version_added": false

--- a/css/selectors/before.json
+++ b/css/selectors/before.json
@@ -82,9 +82,6 @@
                 "version_added": "8"
               }
             ],
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": [
               {
                 "version_added": "7"
@@ -142,9 +139,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/selectors/checked.json
+++ b/css/selectors/checked.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "9"
             },

--- a/css/selectors/child.json
+++ b/css/selectors/child.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "7"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/css/selectors/class.json
+++ b/css/selectors/class.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/css/selectors/cue.json
+++ b/css/selectors/cue.json
@@ -32,9 +32,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": null
             },

--- a/css/selectors/default.json
+++ b/css/selectors/default.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "10"
             },

--- a/css/selectors/descendant.json
+++ b/css/selectors/descendant.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -78,9 +75,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/selectors/dir.json
+++ b/css/selectors/dir.json
@@ -44,9 +44,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/selectors/disabled.json
+++ b/css/selectors/disabled.json
@@ -31,9 +31,6 @@
               "version_added": "9",
               "notes": "Internet Explorer does not recognize <code>:disabled</code> on the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/fieldset'><code>&lt;fieldset&gt;</code></a> element."
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "9"
             },

--- a/css/selectors/empty.json
+++ b/css/selectors/empty.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9.5"
-            },
             "opera": {
               "version_added": "9.5"
             },

--- a/css/selectors/enabled.json
+++ b/css/selectors/enabled.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "9"
             },

--- a/css/selectors/first-child.json
+++ b/css/selectors/first-child.json
@@ -34,13 +34,6 @@
                 "In Internet Explorer 8, if an element is inserted dynamically by clicking on a link, then the <code>:first-child</code> style isn't applied until the link loses focus."
               ]
             },
-            "ie_mobile": {
-              "version_added": "7",
-              "notes": [
-                "Internet Explorer 7 doesn't update  <code>:first-child</code> styles when elements are added dynamically.",
-                "In Internet Explorer 8, if an element is inserted dynamically by clicking on a link, then the <code>:first-child</code> style isn't applied until the link loses focus."
-              ]
-            },
             "opera": {
               "version_added": "9.5"
             },
@@ -86,9 +79,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/selectors/first-letter.json
+++ b/css/selectors/first-letter.json
@@ -66,9 +66,6 @@
                 "version_added": "5.5"
               }
             ],
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "7"
@@ -129,9 +126,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false

--- a/css/selectors/first-line.json
+++ b/css/selectors/first-line.json
@@ -68,9 +68,6 @@
                 "version_added": "5.5"
               }
             ],
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "7",

--- a/css/selectors/first-of-type.json
+++ b/css/selectors/first-of-type.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "9.5"
             },

--- a/css/selectors/first.json
+++ b/css/selectors/first.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "9.2"
             },

--- a/css/selectors/focus-within.json
+++ b/css/selectors/focus-within.json
@@ -32,9 +32,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "47"
             },

--- a/css/selectors/focus.json
+++ b/css/selectors/focus.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": "8"
-            },
             "opera": {
               "version_added": "7"
             },

--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -54,9 +54,6 @@
               "prefix": "-ms-",
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": null
             },
@@ -104,9 +101,6 @@
               },
               "ie": {
                 "version_added": "11"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null

--- a/css/selectors/general_sibling.json
+++ b/css/selectors/general_sibling.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "7"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "9"
             },

--- a/css/selectors/grammar-error.json
+++ b/css/selectors/grammar-error.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "4"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "4"
             },
@@ -80,9 +77,6 @@
               },
               "ie": {
                 "version_added": "4"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "4"
@@ -137,9 +131,6 @@
                   "In Internet Explorer 9 (and possibly earlier), if a <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>&lt;table&gt;</code></a> has a parent with a non-<code>auto</code> <a href='https://developer.mozilla.org/docs/Web/CSS/width'><code>width</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/overflow-x'><code>overflow-x</code></a><code>: auto;</code>, the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>&lt;table&gt;</code></a> has enough content to horizontally overflow its parent, and there are <a href='https://developer.mozilla.org/docs/Web/CSS/:hover'><code>:hover</code></a> styles set on elements within the table, then hovering over said elements will cause the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>&lt;table&gt;</code></a>'s height to increase. See <a href='http://jsbin.com/diwiqe'>a live demo that triggers the bug</a>. One workaround for the bug is to set <code>min-height: 0%;</code> (the <code>%</code> unit must be specified, since unitless and <code>px</code> don't work) on the <code>&lt;table&gt;</code>'s parent element."
                 ]
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "7"
               },
@@ -186,9 +177,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/selectors/id.json
+++ b/css/selectors/id.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/css/selectors/in-range.json
+++ b/css/selectors/in-range.json
@@ -33,9 +33,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "11",
               "notes": "Before Opera 39, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>Chromium bug 602568</a>). In Opera 39, it was changed to only match enabled read-write inputs."

--- a/css/selectors/indeterminate.json
+++ b/css/selectors/indeterminate.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": true
             },
@@ -79,9 +76,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "10.6"
@@ -133,9 +127,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": null
               },
@@ -185,9 +176,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null

--- a/css/selectors/invalid.json
+++ b/css/selectors/invalid.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "10"
             },
@@ -78,9 +75,6 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/selectors/lang.json
+++ b/css/selectors/lang.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": "8"
-            },
             "opera": {
               "version_added": "8"
             },

--- a/css/selectors/last-child.json
+++ b/css/selectors/last-child.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "9.5"
             },
@@ -78,9 +75,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/selectors/last-of-type.json
+++ b/css/selectors/last-of-type.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "9.5"
             },

--- a/css/selectors/left.json
+++ b/css/selectors/left.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "9.2"
             },

--- a/css/selectors/link.json
+++ b/css/selectors/link.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "3"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/css/selectors/namespace.json
+++ b/css/selectors/namespace.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "8"
             },

--- a/css/selectors/not.json
+++ b/css/selectors/not.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "9.5"
             },
@@ -78,9 +75,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/selectors/nth-child.json
+++ b/css/selectors/nth-child.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "9.5",
               "notes": "Before Opera 15, Opera does not handle dynamically inserted elements for <code>:nth-child()</code>."
@@ -84,9 +81,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -133,9 +127,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/selectors/nth-last-child.json
+++ b/css/selectors/nth-last-child.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9.5"
-            },
             "opera": {
               "version_added": "9"
             },
@@ -78,9 +75,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/selectors/nth-last-of-type.json
+++ b/css/selectors/nth-last-of-type.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "9.5"
             },

--- a/css/selectors/nth-of-type.json
+++ b/css/selectors/nth-of-type.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "9.5"
             },

--- a/css/selectors/only-child.json
+++ b/css/selectors/only-child.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "9.5"
             },
@@ -78,9 +75,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/css/selectors/only-of-type.json
+++ b/css/selectors/only-of-type.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "9.5"
             },

--- a/css/selectors/optional.json
+++ b/css/selectors/optional.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "10"
             },

--- a/css/selectors/out-of-range.json
+++ b/css/selectors/out-of-range.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "11"
             },

--- a/css/selectors/placeholder-shown.json
+++ b/css/selectors/placeholder-shown.json
@@ -46,9 +46,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "34"
             },
@@ -94,9 +91,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/selectors/placeholder.json
+++ b/css/selectors/placeholder.json
@@ -63,10 +63,6 @@
               "prefix": "-ms-",
               "version_added": "10"
             },
-            "ie_mobile": {
-              "prefix": "-ms-",
-              "version_added": "10"
-            },
             "opera": [
               {
                 "version_added": "44"

--- a/css/selectors/required.json
+++ b/css/selectors/required.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "10"
             },

--- a/css/selectors/right.json
+++ b/css/selectors/right.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "9.2"
             },

--- a/css/selectors/root.json
+++ b/css/selectors/root.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "9.5"
             },

--- a/css/selectors/scope.json
+++ b/css/selectors/scope.json
@@ -50,9 +50,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -98,9 +95,6 @@
                 "version_added": "32"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/selectors/selection.json
+++ b/css/selectors/selection.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "9.5"
             },

--- a/css/selectors/spelling-error.json
+++ b/css/selectors/spelling-error.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/css/selectors/target.json
+++ b/css/selectors/target.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "9.5"
             },

--- a/css/selectors/type.json
+++ b/css/selectors/type.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -79,9 +76,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": "8"

--- a/css/selectors/universal.json
+++ b/css/selectors/universal.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "7"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -79,9 +76,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": "8"

--- a/css/selectors/valid.json
+++ b/css/selectors/valid.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "10"
             },
@@ -78,9 +75,6 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/selectors/visited.json
+++ b/css/selectors/visited.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -79,9 +76,6 @@
               },
               "ie": {
                 "version_added": "8"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null

--- a/css/types/angle.json
+++ b/css/types/angle.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -79,9 +76,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": true
@@ -131,9 +125,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -182,9 +173,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -232,9 +220,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": true

--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": true
             },
@@ -82,9 +79,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -132,9 +126,6 @@
                 "version_added": "49"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/types/blend-mode.json
+++ b/css/types/blend-mode.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "22"
             },

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -83,9 +80,6 @@
               "ie": {
                 "prefix": "-ms-",
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": true
@@ -138,9 +132,6 @@
                 "notes": "<code>element()</code> is limited to <a href='https://developer.mozilla.org/docs/Web/CSS/background-image'><code>background-image</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/background'><code>background</code></a>."
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/css/types/integer.json
+++ b/css/types/integer.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/css/types/shape.json
+++ b/css/types/shape.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "5.5"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "9.5"
             },
@@ -80,9 +77,6 @@
               "ie": {
                 "version_added": "5.5",
                 "notes": "For Internet Explorer versions 5.5 through 7, the <code>rect()</code> function uses spaces (instead of commas) to separate parameters. For Internet Explorer 8 and later versions, only the standard comma-separated syntax is supported."
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "9.5"

--- a/css/types/transform-function.json
+++ b/css/types/transform-function.json
@@ -35,9 +35,6 @@
               "version_added": "9",
               "notes": "Internet Explorer 9 supports 2D but not 3D transforms. In version 9, mixing 2D and 3D transform functions invalidates the entire property."
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "10.5"
             },
@@ -84,9 +81,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": "15"

--- a/css/types/url.json
+++ b/css/types/url.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "3"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "3.5"
             },

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -78,9 +75,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -134,9 +128,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -183,9 +174,6 @@
                 "version_added": "20"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -235,9 +223,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -283,9 +268,6 @@
                   "version_added": "10"
                 },
                 "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
                   "version_added": true
                 },
                 "opera": {
@@ -336,9 +318,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -384,9 +363,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -446,9 +422,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -494,9 +467,6 @@
                 "version_added": "50"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -546,9 +516,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -594,9 +561,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -650,9 +614,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -700,9 +661,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -748,9 +706,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/abbr.json
+++ b/html/elements/abbr.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "7"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/acronym.json
+++ b/html/elements/acronym.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/address.json
+++ b/html/elements/address.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/applet.json
+++ b/html/elements/applet.json
@@ -34,9 +34,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": true,
               "notes": "Removal in Opera is <a href='https://www.chromestatus.com/features/6246781461463040'>under consideration</a>."
@@ -87,9 +84,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -138,9 +132,6 @@
               },
               "ie": {
                 "version_added": true
-              },
-              "ie_mobile": {
-                "version_added": false
               },
               "opera": {
                 "version_added": true
@@ -191,9 +182,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -242,9 +230,6 @@
               },
               "ie": {
                 "version_added": true
-              },
-              "ie_mobile": {
-                "version_added": false
               },
               "opera": {
                 "version_added": true
@@ -295,9 +280,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -346,9 +328,6 @@
               },
               "ie": {
                 "version_added": true
-              },
-              "ie_mobile": {
-                "version_added": false
               },
               "opera": {
                 "version_added": true
@@ -399,9 +378,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -450,9 +426,6 @@
               },
               "ie": {
                 "version_added": true
-              },
-              "ie_mobile": {
-                "version_added": false
               },
               "opera": {
                 "version_added": true
@@ -503,9 +476,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -554,9 +524,6 @@
               },
               "ie": {
                 "version_added": true
-              },
-              "ie_mobile": {
-                "version_added": false
               },
               "opera": {
                 "version_added": true
@@ -607,9 +574,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -658,9 +622,6 @@
               },
               "ie": {
                 "version_added": true
-              },
-              "ie_mobile": {
-                "version_added": false
               },
               "opera": {
                 "version_added": true
@@ -711,9 +672,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -763,9 +721,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -814,9 +769,6 @@
               },
               "ie": {
                 "version_added": true
-              },
-              "ie_mobile": {
-                "version_added": false
               },
               "opera": {
                 "version_added": true

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -176,9 +167,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -228,9 +216,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -276,9 +261,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -328,9 +310,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -376,9 +355,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -428,9 +404,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -476,9 +449,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -528,9 +498,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -576,9 +543,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -628,9 +592,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -676,9 +637,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -728,9 +686,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -776,9 +731,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/article.json
+++ b/html/elements/article.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "11.1"
             },

--- a/html/elements/aside.json
+++ b/html/elements/aside.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "11.1"
             },

--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "10.5"
             },
@@ -80,9 +77,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10.5"
               },
@@ -128,9 +122,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -180,9 +171,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10.5"
               },
@@ -230,9 +218,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10.5"
               },
@@ -278,9 +263,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -330,9 +312,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -379,9 +358,6 @@
               },
               "ie": {
                 "version_added": "11"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "46"
@@ -436,9 +412,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": [
                 {
@@ -501,9 +474,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10.5"
               },
@@ -549,9 +519,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/html/elements/b.json
+++ b/html/elements/b.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/base.json
+++ b/html/elements/base.json
@@ -30,9 +30,6 @@
               "version_added": true,
               "notes": "Before Internet Explorer 7, <code>&lt;base&gt;</code> can be positioned anywhere in the document and the nearest value of <code>&lt;base&gt;</code> is used."
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -77,9 +74,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -129,9 +123,6 @@
                 "ie": {
                   "version_added": true
                 },
-                "ie_mobile": {
-                  "version_added": true
-                },
                 "opera": {
                   "version_added": true
                 },
@@ -178,9 +169,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/basefont.json
+++ b/html/elements/basefont.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": false
             },

--- a/html/elements/bdi.json
+++ b/html/elements/bdi.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/html/elements/bdo.json
+++ b/html/elements/bdo.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/bgsound.json
+++ b/html/elements/bgsound.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": false
             },

--- a/html/elements/big.json
+++ b/html/elements/big.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/blink.json
+++ b/html/elements/blink.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "2",
               "version_removed": "15"

--- a/html/elements/blockquote.json
+++ b/html/elements/blockquote.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/body.json
+++ b/html/elements/body.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -176,9 +167,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -230,9 +218,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -282,9 +267,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -330,9 +312,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -382,9 +361,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -430,9 +406,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -482,9 +455,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -530,9 +500,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -582,9 +549,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -630,9 +594,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -682,9 +643,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -730,9 +688,6 @@
                 "version_added": "32"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -782,9 +737,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -830,9 +782,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -882,9 +831,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -930,9 +876,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -982,9 +925,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -1030,9 +970,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -1082,9 +1019,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -1130,9 +1064,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -1182,9 +1113,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -1230,9 +1158,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -1284,9 +1209,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -1332,9 +1254,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -1386,9 +1305,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -1434,9 +1350,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/br.json
+++ b/html/elements/br.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -77,9 +74,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "9.6"
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": false
               },
@@ -176,9 +167,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -228,9 +216,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -277,9 +262,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -328,9 +310,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10.6"
               },
@@ -378,9 +357,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -426,9 +402,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -478,9 +451,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -526,9 +496,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -578,9 +545,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -626,9 +590,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/canvas.json
+++ b/html/elements/canvas.json
@@ -39,9 +39,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "9"
             },
@@ -99,9 +96,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "9"
               },
@@ -148,9 +142,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -209,9 +200,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "9"

--- a/html/elements/caption.json
+++ b/html/elements/caption.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/center.json
+++ b/html/elements/center.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/cite.json
+++ b/html/elements/cite.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/code.json
+++ b/html/elements/code.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -128,9 +122,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -182,9 +173,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -234,9 +222,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -282,9 +267,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -336,9 +318,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -384,9 +363,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/colgroup.json
+++ b/html/elements/colgroup.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -128,9 +122,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -182,9 +173,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -234,9 +222,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -282,9 +267,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -336,9 +318,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -384,9 +363,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/command.json
+++ b/html/elements/command.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -78,9 +75,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -130,9 +124,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -178,9 +169,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -230,9 +218,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -280,9 +265,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -328,9 +310,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/html/elements/content.json
+++ b/html/elements/content.json
@@ -39,9 +39,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "26"
             },

--- a/html/elements/data.json
+++ b/html/elements/data.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "49"
             },

--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "9.5"
             },

--- a/html/elements/dd.json
+++ b/html/elements/dd.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -77,9 +74,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/del.json
+++ b/html/elements/del.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -126,9 +120,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/details.json
+++ b/html/elements/details.json
@@ -33,9 +33,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },
@@ -82,9 +79,6 @@
                 "version_added": "49"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/html/elements/dfn.json
+++ b/html/elements/dfn.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/dialog.json
+++ b/html/elements/dialog.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "24"
             },
@@ -80,9 +77,6 @@
                 "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/html/elements/dir.json
+++ b/html/elements/dir.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -76,9 +73,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/html/elements/div.json
+++ b/html/elements/div.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/dl.json
+++ b/html/elements/dl.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/dt.json
+++ b/html/elements/dt.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/element.json
+++ b/html/elements/element.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": null
             },

--- a/html/elements/em.json
+++ b/html/elements/em.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/embed.json
+++ b/html/elements/embed.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": true
             },
@@ -77,9 +74,6 @@
               },
               "ie": {
                 "version_added": true
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": true
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": true
               },
@@ -178,9 +169,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": true
               },
@@ -227,9 +215,6 @@
               },
               "ie": {
                 "version_added": true
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": true

--- a/html/elements/fieldset.json
+++ b/html/elements/fieldset.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -78,9 +75,6 @@
               "ie": {
                 "version_added": true,
                 "notes": "Not all form control descendants of a disabled fieldset are properly disabled in IE11; see IE <a href='https://connect.microsoft.com/IE/feedbackdetail/view/817488'>bug 817488: input[type='file'] not disabled inside disabled fieldset</a> and IE <a href='https://connect.microsoft.com/IE/feedbackdetail/view/962368/can-still-edit-input-type-text-within-fieldset-disabled'>bug 962368: Can still edit input[type='text'] within fieldset[disabled]</a>."
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "12"
@@ -129,9 +123,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -177,9 +168,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/figcaption.json
+++ b/html/elements/figcaption.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "11"
             },

--- a/html/elements/figure.json
+++ b/html/elements/figure.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "11"
             },

--- a/html/elements/font.json
+++ b/html/elements/font.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -176,9 +167,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/footer.json
+++ b/html/elements/footer.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "11.1"
             },

--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -178,9 +169,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -226,9 +214,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -279,9 +264,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -327,9 +309,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -379,9 +358,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -427,9 +403,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -479,9 +452,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -527,9 +497,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/frame.json
+++ b/html/elements/frame.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -176,9 +167,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -228,9 +216,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -276,9 +261,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -328,9 +310,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -376,9 +355,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/frameset.json
+++ b/html/elements/frameset.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -126,9 +120,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/h1.json
+++ b/html/elements/h1.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/h2.json
+++ b/html/elements/h2.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/h3.json
+++ b/html/elements/h3.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/h4.json
+++ b/html/elements/h4.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/h5.json
+++ b/html/elements/h5.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/h6.json
+++ b/html/elements/h6.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/head.json
+++ b/html/elements/head.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/header.json
+++ b/html/elements/header.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "11.1"
             },

--- a/html/elements/hgroup.json
+++ b/html/elements/hgroup.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "11.1"
             },

--- a/html/elements/hr.json
+++ b/html/elements/hr.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -176,9 +167,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -228,9 +216,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -276,9 +261,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/html.json
+++ b/html/elements/html.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -176,9 +167,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/i.json
+++ b/html/elements/i.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -151,9 +145,6 @@
                 "prefix": "ms",
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -213,9 +204,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -261,9 +249,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -313,9 +298,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -361,9 +343,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -413,9 +392,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -461,9 +437,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -513,9 +486,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -561,9 +531,6 @@
                 "version_added": "50"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -613,9 +580,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -663,9 +627,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "opera": {
                 "version_added": "15"
               },
@@ -711,9 +672,6 @@
                   "version_added": "27"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "opera": {
@@ -764,9 +722,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "opera": {
                   "version_added": "32"
                 },
@@ -813,9 +768,6 @@
                   "version_added": "49"
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "opera": {
@@ -866,9 +818,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "opera": {
                   "version_added": "40"
                 },
@@ -915,9 +864,6 @@
                   "version_added": null
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "opera": {
@@ -968,9 +914,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -1018,9 +961,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "15"
               },
@@ -1066,9 +1006,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/image.json
+++ b/html/elements/image.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -176,9 +167,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -228,9 +216,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -276,9 +261,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -328,9 +310,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -376,9 +355,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -428,9 +404,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -476,9 +449,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -528,9 +498,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": true
               },
@@ -576,9 +543,6 @@
                 "version_added": "50"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -628,9 +592,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -676,9 +637,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -750,9 +708,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "21"
               },
@@ -800,9 +755,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -848,9 +800,6 @@
                   "version_added": "53"
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "opera": {
@@ -901,9 +850,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -949,9 +895,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/ins.json
+++ b/html/elements/ins.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -126,9 +120,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/isindex.json
+++ b/html/elements/isindex.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -76,9 +73,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -126,9 +120,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/html/elements/kbd.json
+++ b/html/elements/kbd.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/keygen.json
+++ b/html/elements/keygen.json
@@ -32,9 +32,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "3"
             },

--- a/html/elements/label.json
+++ b/html/elements/label.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -128,9 +122,6 @@
                 "version_removed": "49"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/legend.json
+++ b/html/elements/legend.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/li.json
+++ b/html/elements/li.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -126,9 +120,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "15"
               },
@@ -178,9 +169,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": false
               },
@@ -226,9 +214,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -278,9 +263,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -326,9 +308,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -378,9 +357,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -426,9 +402,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": "4"
-              },
-              "ie_mobile": {
                 "version_added": "4"
               },
               "opera": {
@@ -478,9 +451,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "43"
               },
@@ -526,9 +496,6 @@
                 "version_added": "50"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -578,9 +545,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -626,9 +590,6 @@
                   "version_added": "4"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "opera": {
@@ -678,9 +639,6 @@
                 "ie": {
                   "version_added": null
                 },
-                "ie_mobile": {
-                  "version_added": null
-                },
                 "opera": {
                   "version_added": null
                 },
@@ -726,9 +684,6 @@
                   "version_added": null
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "opera": {
@@ -780,9 +735,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "opera": {
                   "version_added": null
                 },
@@ -828,9 +780,6 @@
                   "version_added": "4"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "opera": {
@@ -880,9 +829,6 @@
                 "ie": {
                   "version_added": null
                 },
-                "ie_mobile": {
-                  "version_added": null
-                },
                 "opera": {
                   "version_added": null
                 },
@@ -928,9 +874,6 @@
                   "version_added": "52"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "opera": {
@@ -980,9 +923,6 @@
                 "ie": {
                   "version_added": null
                 },
-                "ie_mobile": {
-                  "version_added": null
-                },
                 "opera": {
                   "version_added": null
                 },
@@ -1029,9 +969,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -1083,9 +1020,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -1131,9 +1065,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -1183,9 +1114,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -1231,9 +1159,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/listing.json
+++ b/html/elements/listing.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/html/elements/main.json
+++ b/html/elements/main.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "16"
             },

--- a/html/elements/map.json
+++ b/html/elements/map.json
@@ -33,9 +33,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/mark.json
+++ b/html/elements/mark.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "11"
             },

--- a/html/elements/marquee.json
+++ b/html/elements/marquee.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "2"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "7.2"
             },
@@ -77,9 +74,6 @@
               },
               "ie": {
                 "version_added": "2"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "7.2"
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": "2"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "7.2"
               },
@@ -177,9 +168,6 @@
               },
               "ie": {
                 "version_added": "2"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "7.2"
@@ -228,9 +216,6 @@
               "ie": {
                 "version_added": "2"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "7.2"
               },
@@ -276,9 +261,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -328,9 +310,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -377,9 +356,6 @@
               },
               "ie": {
                 "version_added": "2"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "7.2"
@@ -428,9 +404,6 @@
               "ie": {
                 "version_added": "2"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "7.2"
               },
@@ -477,9 +450,6 @@
               },
               "ie": {
                 "version_added": "4"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": false
@@ -528,9 +498,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -577,9 +544,6 @@
               },
               "ie": {
                 "version_added": "2"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "7.2"

--- a/html/elements/menu.json
+++ b/html/elements/menu.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": true,
               "flag": {
@@ -85,9 +82,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": null
               },
@@ -185,9 +176,6 @@
                 "notes": "Nested menus are not supported."
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -240,9 +228,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "opera": {
                   "version_added": true
                 },
@@ -289,9 +274,6 @@
                   "version_added": false
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "opera": {

--- a/html/elements/menuitem.json
+++ b/html/elements/menuitem.json
@@ -37,9 +37,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -92,9 +89,6 @@
                 ]
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -152,9 +146,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -210,9 +201,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -266,9 +254,6 @@
                 ]
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -331,9 +316,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -389,9 +371,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -445,9 +424,6 @@
                 ]
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -178,9 +169,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -225,9 +213,6 @@
                   "version_added": "4"
                 },
                 "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
                   "version_added": true
                 },
                 "opera": {
@@ -277,9 +262,6 @@
                 "ie": {
                   "version_added": true
                 },
-                "ie_mobile": {
-                  "version_added": true
-                },
                 "opera": {
                   "version_added": true
                 },
@@ -325,9 +307,6 @@
                   "version_added": "4"
                 },
                 "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
                   "version_added": true
                 },
                 "opera": {
@@ -377,9 +356,6 @@
                 "ie": {
                   "version_added": true
                 },
-                "ie_mobile": {
-                  "version_added": true
-                },
                 "opera": {
                   "version_added": true
                 },
@@ -425,9 +401,6 @@
                   "version_added": "4"
                 },
                 "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
                   "version_added": true
                 },
                 "opera": {
@@ -478,9 +451,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -525,9 +495,6 @@
                   "version_added": "4"
                 },
                 "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
                   "version_added": true
                 },
                 "opera": {
@@ -579,9 +546,6 @@
                   "notes": "The <code>referrer</code> value wasn't taken into account when navigation was happening via the context menu or middle click until Firefox 39."
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "opera": {

--- a/html/elements/meter.json
+++ b/html/elements/meter.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "11"
             },
@@ -76,9 +73,6 @@
                 "version_added": "16"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "11"
               },
@@ -176,9 +167,6 @@
                 "version_added": "16"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -228,9 +216,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "11"
               },
@@ -276,9 +261,6 @@
                 "version_added": "16"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -328,9 +310,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "11"
               },
@@ -376,9 +355,6 @@
                 "version_added": "16"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/html/elements/multicol.json
+++ b/html/elements/multicol.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/html/elements/nav.json
+++ b/html/elements/nav.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "11.1"
             },

--- a/html/elements/nextid.json
+++ b/html/elements/nextid.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/html/elements/nobr.json
+++ b/html/elements/nobr.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/html/elements/noembed.json
+++ b/html/elements/noembed.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/noscript.json
+++ b/html/elements/noscript.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/object.json
+++ b/html/elements/object.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -176,9 +167,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -228,9 +216,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -276,9 +261,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -328,9 +310,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -376,9 +355,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -428,9 +404,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -476,9 +449,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -528,9 +498,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -576,9 +543,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -628,9 +592,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -676,9 +637,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -728,9 +686,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -778,9 +733,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -826,9 +778,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/ol.json
+++ b/html/elements/ol.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -178,9 +169,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -226,9 +214,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/optgroup.json
+++ b/html/elements/optgroup.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -126,9 +120,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/html/elements/option.json
+++ b/html/elements/option.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -134,9 +128,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -184,9 +175,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -232,9 +220,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/output.json
+++ b/html/elements/output.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "11"
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -127,9 +121,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "opera": {
                   "version_added": "11"
                 },
@@ -174,9 +165,6 @@
                     "version_added": "4"
                   },
                   "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
                     "version_added": false
                   },
                   "opera": {

--- a/html/elements/p.json
+++ b/html/elements/p.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/param.json
+++ b/html/elements/param.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -178,9 +169,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -226,9 +214,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/picture.json
+++ b/html/elements/picture.json
@@ -51,9 +51,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "25"
             },

--- a/html/elements/plaintext.json
+++ b/html/elements/plaintext.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/html/elements/pre.json
+++ b/html/elements/pre.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -78,9 +75,6 @@
                 "version_removed": "29"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -138,10 +132,6 @@
                 "version_added": true,
                 "notes": "Specifying the <code>width</code> attribute has no layout effect."
               },
-              "ie_mobile": {
-                "version_added": true,
-                "notes": "Specifying the <code>width</code> attribute has no layout effect."
-              },
               "opera": {
                 "version_added": true,
                 "notes": "Specifying the <code>width</code> attribute has no layout effect."
@@ -191,9 +181,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/html/elements/progress.json
+++ b/html/elements/progress.json
@@ -37,9 +37,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "11"
             },
@@ -87,9 +84,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "11"
               },
@@ -136,9 +130,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": false
               },
               "opera": {
                 "version_added": "11"

--- a/html/elements/q.json
+++ b/html/elements/q.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/rp.json
+++ b/html/elements/rp.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "5"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "15"
             },

--- a/html/elements/rt.json
+++ b/html/elements/rt.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "5"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "15"
             },

--- a/html/elements/rtc.json
+++ b/html/elements/rtc.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/html/elements/ruby.json
+++ b/html/elements/ruby.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "5"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },

--- a/html/elements/s.json
+++ b/html/elements/s.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/samp.json
+++ b/html/elements/samp.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -77,9 +74,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -127,9 +121,6 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -182,9 +173,6 @@
                 "version_added": "10",
                 "notes": "In versions prior to Internet Explorer 10, it implemented &gt;script&lt; by a proprietary specification. Since version 10 it conforms to the W3C specification."
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -230,9 +218,6 @@
                 "version_added": "43"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -281,9 +266,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -343,9 +325,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -391,9 +370,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -443,9 +419,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -491,9 +464,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -550,9 +520,6 @@
                   }
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "opera": {

--- a/html/elements/section.json
+++ b/html/elements/section.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": "9"
-            },
             "opera": {
               "version_added": "11.1"
             },

--- a/html/elements/select.json
+++ b/html/elements/select.json
@@ -37,9 +37,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -86,9 +83,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -138,9 +132,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -186,9 +177,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -238,9 +226,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -286,9 +271,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -338,9 +320,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -386,9 +365,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/shadow.json
+++ b/html/elements/shadow.json
@@ -39,9 +39,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "26"
             },

--- a/html/elements/slot.json
+++ b/html/elements/slot.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "40"
             },
@@ -76,9 +73,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/html/elements/small.json
+++ b/html/elements/small.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": true
             },
@@ -79,9 +76,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": true
@@ -150,9 +144,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -199,9 +190,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": true
@@ -270,9 +258,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": null
               },
@@ -319,9 +304,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": true

--- a/html/elements/spacer.json
+++ b/html/elements/spacer.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/html/elements/span.json
+++ b/html/elements/span.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/strike.json
+++ b/html/elements/strike.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/strong.json
+++ b/html/elements/strong.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/style.json
+++ b/html/elements/style.json
@@ -29,10 +29,6 @@
             "ie": {
               "version_added": "3"
             },
-            "ie_mobile": {
-              "version_added": "9",
-              "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
-            },
             "opera": {
               "version_added": "3.5"
             },
@@ -78,10 +74,6 @@
               },
               "ie": {
                 "version_added": "3"
-              },
-              "ie_mobile": {
-                "version_added": "9",
-                "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
               },
               "opera": {
                 "version_added": "3.5"
@@ -130,10 +122,6 @@
               "ie": {
                 "version_added": "3"
               },
-              "ie_mobile": {
-                "version_added": "9",
-                "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
-              },
               "opera": {
                 "version_added": "3.5"
               },
@@ -180,10 +168,6 @@
               },
               "ie": {
                 "version_added": "3"
-              },
-              "ie_mobile": {
-                "version_added": "9",
-                "notes": "Mobile Internet Explorer (the previous branding of IE Phone - versions lower than 8) also has support."
               },
               "opera": {
                 "version_added": "3.5"
@@ -236,9 +220,6 @@
                 "version_added": "21"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/html/elements/sub.json
+++ b/html/elements/sub.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/summary.json
+++ b/html/elements/summary.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -81,9 +78,6 @@
                 "version_added": "49"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/html/elements/sup.json
+++ b/html/elements/sup.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/table.json
+++ b/html/elements/table.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -128,9 +122,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -176,9 +167,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -228,9 +216,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -276,9 +261,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -328,9 +310,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -376,9 +355,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -428,9 +404,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -476,9 +449,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/tbody.json
+++ b/html/elements/tbody.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -128,9 +122,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -182,9 +173,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -234,9 +222,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -284,9 +269,6 @@
                 "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/td.json
+++ b/html/elements/td.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -130,9 +124,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -180,9 +171,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -228,9 +216,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -282,9 +267,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -334,9 +316,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -382,9 +361,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -434,9 +410,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -482,9 +455,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -534,9 +504,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "opera": {
                   "version_added": false
                 },
@@ -583,9 +550,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -637,9 +601,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -685,9 +646,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": "15"
             },

--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -37,9 +37,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -85,9 +82,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -138,9 +132,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -189,9 +180,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": true
               },
@@ -237,9 +225,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -289,9 +274,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -337,9 +319,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -389,9 +368,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": true
               },
@@ -437,9 +413,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -489,9 +462,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -538,9 +508,6 @@
               },
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "11.5"
@@ -591,9 +558,6 @@
                 "ie": {
                   "version_added": "10"
                 },
-                "ie_mobile": {
-                  "version_added": null
-                },
                 "opera": {
                   "version_added": null
                 },
@@ -640,9 +604,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -692,9 +653,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -740,9 +698,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -792,9 +747,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -840,9 +792,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/tfoot.json
+++ b/html/elements/tfoot.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -128,9 +122,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -182,9 +173,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -234,9 +222,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -284,9 +269,6 @@
                 "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/th.json
+++ b/html/elements/th.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -130,9 +124,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -180,9 +171,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -228,9 +216,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -282,9 +267,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -334,9 +316,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -382,9 +361,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -434,9 +410,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": true
               },
@@ -482,9 +455,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -534,9 +504,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "opera": {
                   "version_added": false
                 },
@@ -583,9 +550,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -637,9 +601,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -685,9 +646,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/thead.json
+++ b/html/elements/thead.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -128,9 +122,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -182,9 +173,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -234,9 +222,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -284,9 +269,6 @@
                 "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/time.json
+++ b/html/elements/time.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": [
               {
                 "version_added": "49"
@@ -88,9 +85,6 @@
                 "version_added": "22"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": [

--- a/html/elements/title.json
+++ b/html/elements/title.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "1"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/tr.json
+++ b/html/elements/tr.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -128,9 +122,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -182,9 +173,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -234,9 +222,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": null
               },
@@ -284,9 +269,6 @@
                 "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/track.json
+++ b/html/elements/track.json
@@ -53,9 +53,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "12.1"
             },
@@ -123,9 +120,6 @@
               ],
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "12.1"
@@ -196,9 +190,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "12.1"
               },
@@ -267,9 +258,6 @@
               ],
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "12.1"
@@ -340,9 +328,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "12.1"
               },
@@ -390,9 +375,6 @@
                   "notes": "Before Firefox 50, setting the <code>src</code> didn't work, though it didn't raise an error."
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "opera": {
@@ -464,9 +446,6 @@
               ],
               "ie": {
                 "version_added": "10"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "12.1"

--- a/html/elements/tt.json
+++ b/html/elements/tt.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/u.json
+++ b/html/elements/u.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/ul.json
+++ b/html/elements/ul.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -76,9 +73,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {
@@ -126,9 +120,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "opera": {

--- a/html/elements/var.json
+++ b/html/elements/var.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "10.5"
             },
@@ -77,9 +74,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": "8.1"
               },
               "opera": {
                 "version_added": "10.5"
@@ -129,9 +123,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": true
               },
@@ -179,9 +170,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10.5"
               },
@@ -227,9 +215,6 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -279,9 +264,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10.5"
               },
@@ -328,9 +310,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": "8"
               },
               "opera": {
                 "version_added": "10.5"
@@ -379,9 +358,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": "8"
-              },
               "opera": {
                 "version_added": true
               },
@@ -427,9 +403,6 @@
                 "version_added": "15"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -479,9 +452,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10.5"
               },
@@ -528,9 +498,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": true
@@ -579,9 +546,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "10.5"
               },
@@ -628,9 +592,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": "10.5"

--- a/html/elements/wbr.json
+++ b/html/elements/wbr.json
@@ -30,9 +30,6 @@
               "version_added": "5.5",
               "version_removed": "7"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "11.6"
             },

--- a/html/elements/xmp.json
+++ b/html/elements/xmp.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/data-url.json
+++ b/http/data-url.json
@@ -32,10 +32,6 @@
             "version_added": "8",
             "notes": "The maximum size supported is 32kB"
           },
-          "ie_mobile": {
-            "version_added": true,
-            "notes": "The maximum size supported is 4GB"
-          },
           "opera": {
             "version_added": "7.2"
           },
@@ -95,10 +91,6 @@
                 "notes": "The maximum size supported is 4GB"
               }
             ],
-            "ie_mobile": {
-              "version_added": true,
-              "notes": "The maximum size supported is 4GB"
-            },
             "opera": {
               "version_added": "7.2"
             },
@@ -145,9 +137,6 @@
               "version_added": null
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "opera": {
@@ -199,10 +188,6 @@
             },
             "ie": {
               "version_added": "9",
-              "notes": "The maximum size supported is 4GB"
-            },
-            "ie_mobile": {
-              "version_added": true,
               "notes": "The maximum size supported is 4GB"
             },
             "opera": {

--- a/http/headers/accept-charset.json
+++ b/http/headers/accept-charset.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/accept-encoding.json
+++ b/http/headers/accept-encoding.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/accept-language.json
+++ b/http/headers/accept-language.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/accept-ranges.json
+++ b/http/headers/accept-ranges.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/accept.json
+++ b/http/headers/accept.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/access-control-allow-credentials.json
+++ b/http/headers/access-control-allow-credentials.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "12"
             },

--- a/http/headers/access-control-allow-headers.json
+++ b/http/headers/access-control-allow-headers.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "12"
             },

--- a/http/headers/access-control-allow-methods.json
+++ b/http/headers/access-control-allow-methods.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "12"
             },

--- a/http/headers/access-control-allow-origin.json
+++ b/http/headers/access-control-allow-origin.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "12"
             },

--- a/http/headers/access-control-expose-headers.json
+++ b/http/headers/access-control-expose-headers.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "12"
             },

--- a/http/headers/access-control-max-age.json
+++ b/http/headers/access-control-max-age.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "12"
             },

--- a/http/headers/access-control-request-headers.json
+++ b/http/headers/access-control-request-headers.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "12"
             },

--- a/http/headers/access-control-request-method.json
+++ b/http/headers/access-control-request-method.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "12"
             },

--- a/http/headers/age.json
+++ b/http/headers/age.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -77,9 +74,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -132,9 +126,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": false
               },
@@ -183,9 +174,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/http/headers/connection.json
+++ b/http/headers/connection.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/content-disposition.json
+++ b/http/headers/content-disposition.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/content-encoding.json
+++ b/http/headers/content-encoding.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -77,9 +74,6 @@
                 "version_added": "44"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/http/headers/content-language.json
+++ b/http/headers/content-language.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/content-length.json
+++ b/http/headers/content-length.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/content-location.json
+++ b/http/headers/content-location.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/content-range.json
+++ b/http/headers/content-range.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/content-security-policy-report-only.json
+++ b/http/headers/content-security-policy-report-only.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "15"
             },

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -33,9 +33,6 @@
                 "version_added": "10",
                 "notes": "Implemented as X-Content-Security-Policy header, only supporting 'sandbox' directive."
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "15"
               },
@@ -85,9 +82,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "opera": {
                   "version_added": true
                 },
@@ -134,9 +128,6 @@
                   "version_added": "50"
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "opera": {
@@ -188,9 +179,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "27"
               },
@@ -239,9 +227,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true
               },
@@ -288,9 +273,6 @@
                 "version_added": "45"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -342,9 +324,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "15"
               },
@@ -393,9 +372,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "15"
               },
@@ -441,9 +417,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -494,9 +467,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "15"
               },
@@ -543,9 +513,6 @@
                 "version_added": "36"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -598,9 +565,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "26"
               },
@@ -647,9 +611,6 @@
                 "version_added": "23"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -700,9 +661,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "15"
               },
@@ -749,9 +707,6 @@
                 "version_added": "41"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -802,9 +757,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "15"
               },
@@ -850,9 +802,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -903,9 +852,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "15"
               },
@@ -953,9 +899,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -1011,9 +954,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": true,
                 "version_removed": "43"
@@ -1063,9 +1003,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "opera": {
                 "version_added": "46"
               },
@@ -1111,9 +1048,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -1162,9 +1096,6 @@
                 "version_added": "23"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -1225,9 +1156,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "41"
               },
@@ -1274,9 +1202,6 @@
                 "version_added": "50"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "opera": {
@@ -1327,9 +1252,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "15"
               },
@@ -1375,9 +1297,6 @@
                   "version_added": null
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "opera": {
@@ -1428,9 +1347,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "39"
               },
@@ -1477,9 +1393,6 @@
                 "version_added": "23"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -1531,9 +1444,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "30"
               },
@@ -1580,9 +1490,6 @@
                 "version_added": "58"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/http/headers/content-type.json
+++ b/http/headers/content-type.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/cookie.json
+++ b/http/headers/cookie.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/cookie2.json
+++ b/http/headers/cookie2.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/http/headers/date.json
+++ b/http/headers/date.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/dnt.json
+++ b/http/headers/dnt.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/etag.json
+++ b/http/headers/etag.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/expect-ct.json
+++ b/http/headers/expect-ct.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "48"
             },

--- a/http/headers/expires.json
+++ b/http/headers/expires.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/from.json
+++ b/http/headers/from.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/host.json
+++ b/http/headers/host.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/if-match.json
+++ b/http/headers/if-match.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/if-modified-since.json
+++ b/http/headers/if-modified-since.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/if-none-match.json
+++ b/http/headers/if-none-match.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/if-range.json
+++ b/http/headers/if-range.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/if-unmodified-since.json
+++ b/http/headers/if-unmodified-since.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/keep-alive.json
+++ b/http/headers/keep-alive.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/large-allocation.json
+++ b/http/headers/large-allocation.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/http/headers/last-modified.json
+++ b/http/headers/last-modified.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/location.json
+++ b/http/headers/location.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/origin.json
+++ b/http/headers/origin.json
@@ -32,9 +32,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/pragma.json
+++ b/http/headers/pragma.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/public-key-pins-report-only.json
+++ b/http/headers/public-key-pins-report-only.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "33"
             },

--- a/http/headers/public-key-pins.json
+++ b/http/headers/public-key-pins.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": true
             },
@@ -79,9 +76,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {

--- a/http/headers/range.json
+++ b/http/headers/range.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/referer.json
+++ b/http/headers/referer.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/referrer-policy.json
+++ b/http/headers/referrer-policy.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },
@@ -77,9 +74,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {
@@ -130,9 +124,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "opera": {
                 "version_added": "48"
               },
@@ -179,9 +170,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/http/headers/retry-after.json
+++ b/http/headers/retry-after.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/http/headers/server.json
+++ b/http/headers/server.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -78,9 +75,6 @@
               },
               "ie": {
                 "version_added": "8"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "opera": {
                 "version_added": true
@@ -130,9 +124,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "opera": {
                 "version_added": "11"
               },
@@ -179,9 +170,6 @@
                 "version_added": "50"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "opera": {
@@ -232,9 +220,6 @@
                 "notes": "See <a href='https://bugzil.la/795346'>bug 795346</a> on Bugzilla."
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "opera": {

--- a/http/headers/set-cookie2.json
+++ b/http/headers/set-cookie2.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "opera": {
               "version_added": false
             },

--- a/http/headers/sourcemap.json
+++ b/http/headers/sourcemap.json
@@ -47,9 +47,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": null
             },

--- a/http/headers/strict-transport-security.json
+++ b/http/headers/strict-transport-security.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "12"
             },

--- a/http/headers/te.json
+++ b/http/headers/te.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/timing-allow-origin.json
+++ b/http/headers/timing-allow-origin.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/trailer.json
+++ b/http/headers/trailer.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/transfer-encoding.json
+++ b/http/headers/transfer-encoding.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/upgrade-insecure-requests.json
+++ b/http/headers/upgrade-insecure-requests.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": "31"
             },

--- a/http/headers/user-agent.json
+++ b/http/headers/user-agent.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/vary.json
+++ b/http/headers/vary.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/via.json
+++ b/http/headers/via.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/warning.json
+++ b/http/headers/warning.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/x-content-type-options.json
+++ b/http/headers/x-content-type-options.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },

--- a/http/headers/x-frame-options.json
+++ b/http/headers/x-frame-options.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": "10.5"
             },
@@ -78,9 +75,6 @@
               },
               "ie": {
                 "version_added": "8"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": null
@@ -132,9 +126,6 @@
               },
               "ie": {
                 "version_added": "8"
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "opera": {
                 "version_added": true,

--- a/http/headers/x-xss-protection.json
+++ b/http/headers/x-xss-protection.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "opera": {
               "version_added": true
             },

--- a/http/methods.json
+++ b/http/methods.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -81,9 +78,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "opera": {
@@ -137,9 +131,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -189,9 +180,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "opera": {
@@ -245,9 +233,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -299,9 +284,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -351,9 +333,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "opera": {

--- a/http/status.json
+++ b/http/status.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -81,9 +78,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "opera": {
@@ -137,9 +131,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -189,9 +180,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "opera": {
@@ -245,9 +233,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -297,9 +282,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "opera": {
@@ -353,9 +335,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -405,9 +384,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "opera": {
@@ -461,9 +437,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -513,9 +486,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "opera": {
@@ -569,9 +539,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -621,9 +588,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "opera": {
@@ -677,9 +641,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -729,9 +690,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "opera": {
@@ -785,9 +743,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -837,9 +792,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "opera": {
@@ -893,9 +845,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -945,9 +894,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "opera": {
@@ -1001,9 +947,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -1053,9 +996,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "opera": {
@@ -1109,9 +1049,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -1161,9 +1098,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "opera": {
@@ -1217,9 +1151,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -1271,9 +1202,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "opera": {
               "version_added": true
             },
@@ -1323,9 +1251,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "opera": {

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -82,9 +79,6 @@
               "ie": {
                 "version_added": "5.5"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -134,9 +128,6 @@
                 "version_added": "32"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -190,9 +181,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -244,9 +232,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -296,9 +281,6 @@
                 "version_added": "31"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -352,9 +334,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -404,9 +383,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -460,9 +436,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -514,9 +487,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -566,9 +536,6 @@
                 "version_added": "32"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -622,9 +589,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -675,9 +639,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "nodejs": {
                 "version_added": true
@@ -730,9 +691,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -784,9 +742,6 @@
               "ie": {
                 "version_added": "5.5"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -836,9 +791,6 @@
                 "version_added": "28"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -892,9 +844,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": "8.1"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -944,9 +893,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1000,9 +946,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1053,9 +996,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1109,9 +1049,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1163,9 +1100,6 @@
               "ie": {
                 "version_added": "5.5"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1215,9 +1149,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1271,9 +1202,6 @@
               "ie": {
                 "version_added": "5.5"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1324,9 +1252,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "nodejs": {
                 "version_added": true
@@ -1379,9 +1304,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1432,9 +1354,6 @@
               },
               "ie": {
                 "version_added": "5.5"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "nodejs": {
                 "version_added": true
@@ -1487,9 +1406,6 @@
               "ie": {
                 "version_added": "5.5"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1539,9 +1455,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1595,9 +1508,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1648,9 +1558,6 @@
               },
               "ie": {
                 "version_added": "5.5"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "nodejs": {
                 "version_added": true
@@ -1703,9 +1610,6 @@
               "ie": {
                 "version_added": "5.5"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1755,9 +1659,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1810,9 +1711,6 @@
                 "ie": {
                   "version_added": null
                 },
-                "ie_mobile": {
-                  "version_added": null
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -1862,9 +1760,6 @@
                   "version_added": false
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -1919,9 +1814,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -1971,9 +1863,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -2028,9 +1917,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -2082,9 +1968,6 @@
               "ie": {
                 "version_added": "5.5"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2135,9 +2018,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -2205,9 +2085,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2259,9 +2136,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -2311,9 +2185,6 @@
                 "version_added": "48"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -82,9 +79,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -134,9 +128,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "nodejs": {
@@ -190,9 +181,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": "11"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -242,9 +230,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "nodejs": {
@@ -300,9 +285,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": "11"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -354,9 +336,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -406,9 +385,6 @@
                 "version_added": "48"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {

--- a/javascript/builtins/AsyncFunction.json
+++ b/javascript/builtins/AsyncFunction.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": null
             },
@@ -80,9 +77,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -78,9 +78,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": false
             },
@@ -179,9 +176,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -285,9 +279,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -387,9 +378,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -493,9 +481,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -595,9 +580,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -701,9 +683,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -803,9 +782,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -909,9 +885,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -1011,9 +984,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1117,9 +1087,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -1221,9 +1188,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -1323,9 +1287,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/builtins/Boolean.json
+++ b/javascript/builtins/Boolean.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -190,9 +181,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -242,9 +230,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -82,9 +79,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -134,9 +128,6 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
@@ -190,9 +181,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -241,9 +229,6 @@
                   "version_added": "55"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -298,9 +283,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -350,9 +332,6 @@
                 "version_added": "15"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "nodejs": {
@@ -406,9 +385,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -458,9 +434,6 @@
                 "version_added": "15"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "nodejs": {
@@ -514,9 +487,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -566,9 +536,6 @@
                 "version_added": "15"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "nodejs": {
@@ -622,9 +589,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -674,9 +638,6 @@
                 "version_added": "15"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "nodejs": {
@@ -730,9 +691,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -782,9 +740,6 @@
                 "version_added": "15"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "nodejs": {
@@ -838,9 +793,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -890,9 +842,6 @@
                 "version_added": "15"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "nodejs": {
@@ -946,9 +895,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -998,9 +944,6 @@
                 "version_added": "15"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "nodejs": {
@@ -1054,9 +997,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1106,9 +1046,6 @@
                 "version_added": "15"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "nodejs": {
@@ -1162,9 +1099,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1216,9 +1150,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1268,9 +1199,6 @@
                 "version_added": "15"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "nodejs": {

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -30,9 +30,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -85,9 +82,6 @@
                 "version_added": true,
                 "notes": "The <a href='https://docs.microsoft.com/en-us/scripting/javascript/date-and-time-strings-javascript'>ISO8601 Date Format</a> is not supported in Internet Explorer 8."
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -137,9 +131,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -193,9 +184,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -245,9 +233,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -301,9 +286,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -353,9 +335,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -409,9 +388,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -461,9 +437,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -517,9 +490,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -569,9 +539,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -625,9 +592,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -679,9 +643,6 @@
               "ie": {
                 "version_added": "5"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -731,9 +692,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -787,9 +745,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -839,9 +794,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -895,9 +847,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -947,9 +896,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1003,9 +949,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1055,9 +998,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1111,9 +1051,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1163,9 +1100,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1219,9 +1153,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1273,9 +1204,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1325,9 +1253,6 @@
                 },
                 "ie": {
                   "version_added": "9"
-                },
-                "ie_mobile": {
-                  "version_added": true
                 },
                 "nodejs": {
                   "version_added": null
@@ -1381,9 +1306,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1432,9 +1354,6 @@
                   "version_added": "41"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -1489,9 +1408,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1541,9 +1457,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1597,9 +1510,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1649,9 +1559,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1705,9 +1612,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1757,9 +1661,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1813,9 +1714,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1865,9 +1763,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1921,9 +1816,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1973,9 +1865,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -2029,9 +1918,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2081,9 +1967,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -2137,9 +2020,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2189,9 +2069,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -2245,9 +2122,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2297,9 +2171,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -2353,9 +2224,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2405,9 +2273,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -2461,9 +2326,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2514,9 +2376,6 @@
               },
               "ie": {
                 "version_added": "8"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "nodejs": {
                 "version_added": true
@@ -2569,9 +2428,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -2620,9 +2476,6 @@
                 },
                 "ie": {
                   "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -2674,9 +2527,6 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -2726,9 +2576,6 @@
                   "version_added": false
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -2785,9 +2632,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -2839,9 +2683,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -2890,9 +2731,6 @@
                 },
                 "ie": {
                   "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -2944,9 +2782,6 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -2996,9 +2831,6 @@
                   "version_added": false
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -3053,9 +2885,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -3104,9 +2933,6 @@
                 },
                 "ie": {
                   "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -3158,9 +2984,6 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -3210,9 +3033,6 @@
                   "version_added": false
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -3267,9 +3087,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -3319,9 +3136,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -3375,9 +3189,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -3429,9 +3240,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -3481,9 +3289,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "6"
             },
-            "ie_mobile": {
-              "version_added": "8.1"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -82,9 +79,6 @@
               "ie": {
                 "version_added": "6"
               },
-              "ie_mobile": {
-                "version_added": "8.1"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -134,9 +128,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -190,9 +181,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -242,9 +230,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -298,9 +283,6 @@
               "ie": {
                 "version_added": "6"
               },
-              "ie_mobile": {
-                "version_added": "8.1"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -351,9 +333,6 @@
               },
               "ie": {
                 "version_added": "6"
-              },
-              "ie_mobile": {
-                "version_added": "8.1"
               },
               "nodejs": {
                 "version_added": true
@@ -406,9 +385,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -458,9 +434,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -513,9 +486,6 @@
               },
               "ie": {
                 "version_added": "6"
-              },
-              "ie_mobile": {
-                "version_added": "8.1"
               },
               "nodejs": {
                 "version_added": true

--- a/javascript/builtins/EvalError.json
+++ b/javascript/builtins/EvalError.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -81,9 +78,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "nodejs": {
                 "version_added": true
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -188,9 +179,6 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -81,9 +78,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "nodejs": {
                 "version_added": true
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -188,9 +179,6 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -190,9 +181,6 @@
               "ie": {
                 "version_added": "8"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -242,9 +230,6 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
@@ -298,9 +283,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -349,9 +331,6 @@
                   "version_added": "37"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -406,9 +385,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -457,9 +433,6 @@
                   "version_added": "38"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -511,9 +484,6 @@
                   "version_added": "53"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -568,9 +538,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -622,9 +589,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -673,9 +637,6 @@
                   "version_added": "4"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -730,9 +691,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -782,9 +740,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -840,9 +795,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -892,9 +844,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -948,9 +897,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -999,9 +945,6 @@
                   "version_added": "54"
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {

--- a/javascript/builtins/Generator.json
+++ b/javascript/builtins/Generator.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
                 "version_added": "26"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -188,9 +179,6 @@
                 "version_added": "26"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/builtins/GeneratorFunction.json
+++ b/javascript/builtins/GeneratorFunction.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": null
             },
@@ -80,9 +77,6 @@
                 "version_added": "26"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -81,9 +78,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "nodejs": {
                 "version_added": true
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -188,9 +179,6 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -81,9 +78,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "nodejs": {
                 "version_added": true
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -188,9 +179,6 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -81,9 +78,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "nodejs": {
                 "version_added": true
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -188,9 +179,6 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {

--- a/javascript/builtins/InternalError.json
+++ b/javascript/builtins/InternalError.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": false
             },

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": null
             },
@@ -80,9 +77,6 @@
                 "version_added": "56"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -187,9 +178,6 @@
                   "version_added": "56"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -243,9 +231,6 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -296,9 +281,6 @@
                 },
                 "ie": {
                   "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -351,9 +333,6 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -404,9 +383,6 @@
                 },
                 "ie": {
                   "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -460,9 +436,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -513,9 +486,6 @@
                 "ie": {
                   "version_added": null
                 },
-                "ie_mobile": {
-                  "version_added": null
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -564,9 +534,6 @@
                   "version_added": "58"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -620,9 +587,6 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -673,9 +637,6 @@
                 },
                 "ie": {
                   "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -738,9 +699,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": true
                 },
@@ -792,9 +750,6 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -843,9 +798,6 @@
                     "version_added": "56"
                   },
                   "ie": {
-                    "version_added": false
-                  },
-                  "ie_mobile": {
                     "version_added": false
                   },
                   "nodejs": {
@@ -900,9 +852,6 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -955,9 +904,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -1007,9 +953,6 @@
                 },
                 "ie": {
                   "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -1061,9 +1004,6 @@
                 },
                 "ie": {
                   "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -1126,9 +1066,6 @@
                 "ie": {
                   "version_added": null
                 },
-                "ie_mobile": {
-                  "version_added": null
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -1180,9 +1117,6 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -1233,9 +1167,6 @@
                 },
                 "ie": {
                   "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -1289,9 +1220,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -1340,9 +1268,6 @@
                   "version_added": "58"
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -1396,9 +1321,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": false
                 },
@@ -1450,9 +1372,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": false
                 },
@@ -1502,9 +1421,6 @@
                   "version_added": "58"
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "8"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -81,9 +78,6 @@
               },
               "ie": {
                 "version_added": "8"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "nodejs": {
                 "version_added": true
@@ -135,9 +129,6 @@
               },
               "ie": {
                 "version_added": "8"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "nodejs": {
                 "version_added": true

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -84,9 +81,6 @@
                 "partial_implementation": true,
                 "notes": "Only supports arrays of key/value pairs, such as <code>new Map([ ['foo', 'bar'] ])</code>."
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -136,9 +130,6 @@
                 "version_added": "37"
               },
               "ie": {
-                "version_added": "11"
-              },
-              "ie_mobile": {
                 "version_added": "11"
               },
               "nodejs": {
@@ -192,9 +183,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": "11"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -244,9 +232,6 @@
                 "version_added": "29"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -300,9 +285,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": "11"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -352,9 +334,6 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": "11"
-              },
-              "ie_mobile": {
                 "version_added": "11"
               },
               "nodejs": {
@@ -408,9 +387,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -460,9 +436,6 @@
                 "version_added": "25"
               },
               "ie": {
-                "version_added": "11"
-              },
-              "ie_mobile": {
                 "version_added": "11"
               },
               "nodejs": {
@@ -516,9 +489,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": "11"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -568,9 +538,6 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": "11"
-              },
-              "ie_mobile": {
                 "version_added": "11"
               },
               "nodejs": {
@@ -624,9 +591,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -676,9 +640,6 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": "11"
-              },
-              "ie_mobile": {
                 "version_added": "11"
               },
               "nodejs": {
@@ -734,9 +695,6 @@
                 "partial_implementation": true,
                 "notes": "Returns 'undefined' instead of the 'Map' object."
               },
-              "ie_mobile": {
-                "version_added": "11"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -790,9 +748,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": "11"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -842,9 +797,6 @@
                 "version_added": "20"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -926,9 +878,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -980,9 +929,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -1032,9 +978,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -30,9 +30,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -82,9 +79,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -138,9 +132,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -190,9 +181,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -246,9 +234,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -298,9 +283,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -354,9 +336,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -406,9 +385,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -462,9 +438,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -514,9 +487,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -570,9 +540,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -622,9 +589,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -678,9 +642,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -730,9 +691,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -786,9 +744,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -838,9 +793,6 @@
                 "version_added": "25"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -894,9 +846,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -946,9 +895,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1002,9 +948,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1054,9 +997,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1110,9 +1050,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1162,9 +1099,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1218,9 +1152,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1270,9 +1201,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1326,9 +1254,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1378,9 +1303,6 @@
                 "version_added": "27"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1434,9 +1356,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1486,9 +1405,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1542,9 +1458,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1594,9 +1507,6 @@
                 "version_added": "25"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1650,9 +1560,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1702,9 +1609,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1758,9 +1662,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1810,9 +1711,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1866,9 +1764,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1918,9 +1813,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1974,9 +1866,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2026,9 +1915,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -2082,9 +1968,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2134,9 +2017,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -2190,9 +2070,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2244,9 +2121,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2296,9 +2170,6 @@
                 "version_added": "25"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -30,9 +30,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -82,9 +79,6 @@
                 "version_added": "31"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -138,9 +132,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -190,9 +181,6 @@
                 "version_added": "31"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -246,9 +234,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -298,9 +283,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -354,9 +336,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -406,9 +385,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -462,9 +438,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -514,9 +487,6 @@
                 "version_added": "16"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -570,9 +540,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -622,9 +589,6 @@
                 "version_added": "15"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -678,9 +642,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -730,9 +691,6 @@
                 "version_added": "25"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -786,9 +744,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -838,9 +793,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -894,9 +846,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -946,9 +895,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1004,9 +950,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -1058,9 +1001,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1109,9 +1049,6 @@
                 },
                 "ie": {
                   "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": true
@@ -1162,9 +1099,6 @@
                 },
                 "ie": {
                   "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": true
@@ -1218,9 +1152,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1270,9 +1201,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1326,9 +1254,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1378,9 +1303,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -135,9 +129,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -194,9 +185,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -247,9 +235,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -304,9 +289,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -356,9 +338,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -412,9 +391,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -466,9 +442,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -519,9 +492,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "nodejs": {
                 "version_added": true
@@ -575,9 +545,6 @@
                 "version_added": "9",
                 "notes": "Also supported in Internet Explorer 8, but only on DOM objects and with some non-standard behaviors."
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -628,9 +595,6 @@
                 "version_added": "47"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -684,9 +648,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -737,9 +698,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -793,9 +751,6 @@
               "ie": {
                 "version_added": "8"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -845,9 +800,6 @@
                 "version_added": "50"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -901,9 +853,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -953,9 +902,6 @@
                 "version_added": "36"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1009,9 +955,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1061,9 +1004,6 @@
                 "version_added": "22"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1117,9 +1057,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1170,9 +1107,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "nodejs": {
                 "version_added": true
@@ -1225,9 +1159,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1278,9 +1209,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "nodejs": {
                 "version_added": true
@@ -1334,9 +1262,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -1388,9 +1313,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1440,9 +1362,6 @@
                 },
                 "ie": {
                   "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": true
                 },
                 "nodejs": {
                   "version_added": true
@@ -1498,9 +1417,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1554,9 +1470,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1608,9 +1521,6 @@
               },
               "ie": {
                 "version_added": "11"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "nodejs": {
                 "version_added": true
@@ -1664,9 +1574,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1716,9 +1623,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1772,9 +1676,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1824,9 +1725,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1880,9 +1778,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1932,9 +1827,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1988,9 +1880,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -2040,9 +1929,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -2098,9 +1984,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -2150,9 +2033,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -2208,9 +2088,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -2262,9 +2139,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2315,9 +2189,6 @@
               },
               "ie": {
                 "version_added": "11"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "nodejs": {
                 "version_added": true
@@ -2371,9 +2242,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -2423,9 +2291,6 @@
                 "version_added": "47"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -32,9 +32,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": "0.12",
                 "notes": "Constructor requires a new operator since version 4."
@@ -89,9 +86,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": "0.12"
               },
@@ -141,9 +135,6 @@
                 "version_added": "29"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -197,9 +188,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": "0.12"
               },
@@ -249,9 +237,6 @@
                 "version_added": "58"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -305,9 +290,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": "0.12"
               },
@@ -357,9 +339,6 @@
                 "version_added": "29"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -413,9 +392,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": "0.12"
               },
@@ -465,9 +441,6 @@
                 "version_added": "29"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/builtins/Proxy.json
+++ b/javascript/builtins/Proxy.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
                 "version_added": "34"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -137,9 +131,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": true
                 },
@@ -189,9 +180,6 @@
                   "version_added": "18"
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -245,9 +233,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": true
                 },
@@ -297,9 +282,6 @@
                   "version_added": "18"
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -355,9 +337,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": false
                 },
@@ -407,9 +386,6 @@
                   "version_added": "18"
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -463,9 +439,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": true
                 },
@@ -515,9 +488,6 @@
                   "version_added": "49"
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -571,9 +541,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": true
                 },
@@ -623,9 +590,6 @@
                   "version_added": "31"
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -681,9 +645,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": true
                 },
@@ -733,9 +694,6 @@
                   "version_added": "22"
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -789,9 +747,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": true
                 },
@@ -841,9 +796,6 @@
                   "version_added": "49"
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {

--- a/javascript/builtins/RangeError.json
+++ b/javascript/builtins/RangeError.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/builtins/ReferenceError.json
+++ b/javascript/builtins/ReferenceError.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/builtins/Reflect.json
+++ b/javascript/builtins/Reflect.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
                 "version_added": "42"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -188,9 +179,6 @@
                 "version_added": "42"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -244,9 +232,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -296,9 +281,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -352,9 +334,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -404,9 +383,6 @@
                 "version_added": "42"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -460,9 +436,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -512,9 +485,6 @@
                 "version_added": "42"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -568,9 +538,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -620,9 +587,6 @@
                 "version_added": "42"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -676,9 +640,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -730,9 +691,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -782,9 +740,6 @@
                 "version_added": "42"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -188,9 +179,6 @@
                 "version_added": "37"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -244,9 +232,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -295,9 +280,6 @@
                   "version_added": "38"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -352,9 +334,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -403,9 +382,6 @@
                   "version_added": "38"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -461,9 +437,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -513,9 +486,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -570,9 +540,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -623,9 +590,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -680,9 +644,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -734,9 +695,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -785,9 +743,6 @@
                   "version_added": "38"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -843,9 +798,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -895,9 +847,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -952,9 +901,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1006,9 +952,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1057,9 +1000,6 @@
                   "version_added": "41"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -1113,9 +1053,6 @@
                 "ie": {
                   "version_added": null
                 },
-                "ie_mobile": {
-                  "version_added": null
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -1165,9 +1102,6 @@
                   "version_added": "38"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -1222,9 +1156,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1273,9 +1204,6 @@
                   "version_added": "38"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -1327,9 +1255,6 @@
                   "version_added": "44"
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -1384,9 +1309,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1436,9 +1358,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1492,9 +1411,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1543,9 +1459,6 @@
                   "version_added": "38"
                 },
                 "ie": {
-                  "version_added": true
-                },
-                "ie_mobile": {
                   "version_added": true
                 },
                 "nodejs": {
@@ -1597,9 +1510,6 @@
                   "version_added": "39"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -1655,9 +1565,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1707,9 +1614,6 @@
                 "version_added": "49"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1763,9 +1667,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1815,9 +1716,6 @@
                 "version_added": "49"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1871,9 +1769,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1923,9 +1818,6 @@
                 "version_added": "49"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": "11"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -190,9 +181,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": "11"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -242,9 +230,6 @@
                 "version_added": "29"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -300,9 +285,6 @@
                 "partial_implementation": true,
                 "notes": "Returns 'undefined' instead of the 'Set' object."
               },
-              "ie_mobile": {
-                "version_added": "11"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -352,9 +334,6 @@
                 "version_added": "19"
               },
               "ie": {
-                "version_added": "11"
-              },
-              "ie_mobile": {
                 "version_added": "11"
               },
               "nodejs": {
@@ -408,9 +387,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": "11"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -460,9 +436,6 @@
                 "version_added": "24"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -516,9 +489,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": "11"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -570,9 +540,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": "11"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -622,9 +589,6 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": "11"
-              },
-              "ie_mobile": {
                 "version_added": "11"
               },
               "nodejs": {
@@ -680,9 +644,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": "11"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -732,9 +693,6 @@
                 "version_added": "24"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -816,9 +774,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -868,9 +823,6 @@
                 "version_added": "41"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -78,9 +78,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": false
             },
@@ -179,9 +176,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -285,9 +279,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -389,9 +380,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -491,9 +479,6 @@
                 }
               ],
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -44,9 +44,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -98,9 +95,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -149,9 +143,6 @@
                   "version_added": true
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -207,9 +198,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -259,9 +247,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -315,9 +300,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -367,9 +349,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -423,9 +402,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -475,9 +451,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -531,9 +504,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -583,9 +553,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -639,9 +606,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -691,9 +655,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -747,9 +708,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -799,9 +757,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -855,9 +810,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -907,9 +859,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -977,9 +926,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1029,9 +975,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1085,9 +1028,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1139,9 +1079,6 @@
               "ie": {
                 "version_added": "6"
               },
-              "ie_mobile": {
-                "version_added": "8.1"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1191,9 +1128,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1247,9 +1181,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1301,9 +1232,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1352,9 +1280,6 @@
                 },
                 "ie": {
                   "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -1405,9 +1330,6 @@
                 },
                 "ie": {
                   "version_added": "11"
-                },
-                "ie_mobile": {
-                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -1461,9 +1383,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1512,9 +1431,6 @@
                   "version_added": false
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -1569,9 +1485,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1621,9 +1534,6 @@
                 "version_added": "48"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1677,9 +1587,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -1729,9 +1636,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -1787,9 +1691,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -1839,9 +1740,6 @@
                 "version_added": "34"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1895,9 +1793,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1949,9 +1844,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2000,9 +1892,6 @@
                   "version_added": false
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -2057,9 +1946,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2108,9 +1994,6 @@
                   "version_added": false
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -2165,9 +2048,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2217,9 +2097,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -2273,9 +2150,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2325,9 +2199,6 @@
                 "version_added": "17"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -2381,9 +2252,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2433,9 +2301,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -2489,9 +2354,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2541,9 +2403,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -2597,9 +2456,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2651,9 +2507,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2701,9 +2554,6 @@
                   "version_added": "55"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -2758,9 +2608,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2808,9 +2655,6 @@
                   "version_added": "55"
                 },
                 "ie": {
-                  "version_added": null
-                },
-                "ie_mobile": {
                   "version_added": null
                 },
                 "nodejs": {
@@ -2865,9 +2709,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -2917,9 +2758,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -2973,9 +2811,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -3025,9 +2860,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -3081,9 +2913,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -3133,9 +2962,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -3189,9 +3015,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -3241,9 +3064,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },
@@ -81,9 +78,6 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -137,9 +131,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -189,9 +180,6 @@
                 "version_added": "50"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -245,9 +233,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -297,9 +282,6 @@
                 "version_added": "36"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -353,9 +335,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -405,9 +384,6 @@
                 "version_added": "40"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -461,9 +437,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -513,9 +486,6 @@
                 "version_added": "49"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -569,9 +539,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -621,9 +588,6 @@
                 "version_added": "41"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -677,9 +641,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -729,9 +690,6 @@
                 "version_added": "44"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -785,9 +743,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -837,9 +792,6 @@
                 "version_added": "36"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -893,9 +845,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -945,9 +894,6 @@
                 "version_added": "48"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1001,9 +947,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1053,9 +996,6 @@
                 "version_added": "44"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/builtins/SyntaxError.json
+++ b/javascript/builtins/SyntaxError.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/builtins/TypeError.json
+++ b/javascript/builtins/TypeError.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
@@ -139,9 +133,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "nodejs": {
                 "version_added": null,
                 "notes": "-1 and similar are not considered as indexed properties and therefore return the value of the prototype property."
@@ -192,9 +183,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
@@ -248,9 +236,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -300,9 +285,6 @@
                 "version_added": "44"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
@@ -356,9 +338,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -408,9 +387,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "nodejs": {
@@ -464,9 +440,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -516,9 +489,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "nodejs": {
@@ -572,9 +542,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -624,9 +591,6 @@
                 "version_added": "37"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -680,9 +644,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -732,9 +693,6 @@
                 "version_added": "37"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -788,9 +746,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -840,9 +795,6 @@
                 "version_added": "37"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -896,9 +848,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -948,9 +897,6 @@
                 "version_added": "38"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1004,9 +950,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -1056,9 +999,6 @@
                 "version_added": "43"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1114,9 +1054,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -1168,9 +1105,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -1220,9 +1154,6 @@
                 "version_added": "37"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1278,9 +1209,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -1332,9 +1260,6 @@
               "ie": {
                 "version_added": "10"
               },
-              "ie_mobile": {
-                "version_added": "10"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1384,9 +1309,6 @@
                 "version_added": "38"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1444,9 +1366,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -1496,9 +1415,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "nodejs": {
@@ -1552,9 +1468,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -1604,9 +1517,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "nodejs": {
@@ -1660,9 +1570,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -1712,9 +1619,6 @@
                 "version_added": "37"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1768,9 +1672,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -1820,9 +1721,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "nodejs": {
@@ -1876,9 +1774,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -1928,9 +1823,6 @@
                 "version_added": "37"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1984,9 +1876,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -2036,9 +1925,6 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": "10"
-              },
-              "ie_mobile": {
                 "version_added": "10"
               },
               "nodejs": {
@@ -2092,9 +1978,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -2146,9 +2029,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -2198,9 +2078,6 @@
                 "version_added": "37"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -2268,9 +2145,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -2320,9 +2194,6 @@
                 "version_added": "48"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {

--- a/javascript/builtins/URIError.json
+++ b/javascript/builtins/URIError.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -81,9 +78,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "nodejs": {
                 "version_added": true
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -188,9 +179,6 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -81,9 +78,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "nodejs": {
                 "version_added": true
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -188,9 +179,6 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -81,9 +78,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "nodejs": {
                 "version_added": true
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -188,9 +179,6 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "10"
             },
-            "ie_mobile": {
-              "version_added": "10"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -81,9 +78,6 @@
               },
               "ie": {
                 "version_added": false
-              },
-              "ie_mobile": {
-                "version_added": null
               },
               "nodejs": {
                 "version_added": true
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": null
               },
-              "ie_mobile": {
-                "version_added": null
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -188,9 +179,6 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
                 "version_added": "36"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": "11"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -188,9 +179,6 @@
                 "version_added": "42"
               },
               "ie": {
-                "version_added": "11"
-              },
-              "ie_mobile": {
                 "version_added": "11"
               },
               "nodejs": {
@@ -247,9 +235,6 @@
                 "version_removed": "46"
               },
               "ie": {
-                "version_added": "11"
-              },
-              "ie_mobile": {
                 "version_added": "11"
               },
               "nodejs": {
@@ -309,9 +294,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": "11"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -363,9 +345,6 @@
                 "notes": "Prior to Firefox 38, this method threw a <code>TypeError</code> when the key parameter was not an object. However, the ES2015 specification specifies to return <code>undefined</code> instead. Furthermore, <code>WeakMap.prototype.get</code> accepted an optional second argument as a fallback value, which is not part of the standard. Both non-standard behaviors are removed in version 38 and higher."
               },
               "ie": {
-                "version_added": "11"
-              },
-              "ie_mobile": {
                 "version_added": "11"
               },
               "nodejs": {
@@ -421,9 +400,6 @@
               "ie": {
                 "version_added": "11"
               },
-              "ie_mobile": {
-                "version_added": "11"
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -473,9 +449,6 @@
                 "version_added": "6"
               },
               "ie": {
-                "version_added": "11"
-              },
-              "ie_mobile": {
                 "version_added": "11"
               },
               "nodejs": {
@@ -532,9 +505,6 @@
                 "version_added": "11",
                 "partial_implementation": true,
                 "notes": "Returns 'undefined' instead of the 'Map' object."
-              },
-              "ie_mobile": {
-                "version_added": "11"
               },
               "nodejs": {
                 "version_added": true

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
                 "version_added": "34"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -136,9 +130,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -188,9 +179,6 @@
                 "version_added": "34"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -249,9 +237,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -305,9 +290,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -359,9 +341,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -411,9 +390,6 @@
                 "version_added": "34"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/builtins/WebAssembly.json
+++ b/javascript/builtins/WebAssembly.json
@@ -35,9 +35,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": null
             },
@@ -92,9 +89,6 @@
                 "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -154,9 +148,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -211,9 +202,6 @@
                   "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -271,9 +259,6 @@
                   "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -334,9 +319,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -394,9 +376,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -451,9 +430,6 @@
                   "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -513,9 +489,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -571,9 +544,6 @@
                   "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -634,9 +604,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -691,9 +658,6 @@
                   "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -753,9 +717,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -813,9 +774,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -871,9 +829,6 @@
                   "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -934,9 +889,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -994,9 +946,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -1051,9 +1000,6 @@
                   "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -1113,9 +1059,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -1171,9 +1114,6 @@
                   "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -1233,9 +1173,6 @@
                 "ie": {
                   "version_added": false
                 },
-                "ie_mobile": {
-                  "version_added": false
-                },
                 "nodejs": {
                   "version_added": null
                 },
@@ -1291,9 +1228,6 @@
                   "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
                 },
                 "ie": {
-                  "version_added": false
-                },
-                "ie_mobile": {
                   "version_added": false
                 },
                 "nodejs": {
@@ -1354,9 +1288,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -1406,9 +1337,6 @@
                 "version_added": "58"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1468,9 +1396,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -1520,9 +1445,6 @@
                 "version_added": "58"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1580,9 +1502,6 @@
                 "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/builtins/globals.json
+++ b/javascript/builtins/globals.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -81,9 +78,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {
@@ -137,9 +131,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -189,9 +180,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {
@@ -245,9 +233,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -299,9 +284,6 @@
             "ie": {
               "version_added": "5.5"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -351,9 +333,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {
@@ -407,9 +386,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -459,9 +435,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {
@@ -515,9 +488,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -567,9 +537,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {
@@ -623,9 +590,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -677,9 +641,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -729,9 +690,6 @@
               },
               "ie": {
                 "version_added": "9"
-              },
-              "ie_mobile": {
-                "version_added": true
               },
               "nodejs": {
                 "version_added": true
@@ -785,9 +743,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -839,9 +794,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -891,9 +843,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "nodejs": {

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -29,9 +29,6 @@
           "ie": {
             "version_added": false
           },
-          "ie_mobile": {
-            "version_added": false
-          },
           "nodejs": {
             "version_added": "4"
           },
@@ -81,9 +78,6 @@
               "version_added": "45"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "nodejs": {
@@ -138,9 +132,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": "4"
             },
@@ -191,9 +182,6 @@
               "version_added": "45"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "nodejs": {

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -28,9 +28,6 @@
           "ie": {
             "version_added": true
           },
-          "ie_mobile": {
-            "version_added": true
-          },
           "nodejs": {
             "version_added": true
           },
@@ -79,9 +76,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {
@@ -133,9 +127,6 @@
               },
               "ie": {
                 "version_added": "6"
-              },
-              "ie_mobile": {
-                "version_added": "8.1"
               },
               "nodejs": {
                 "version_added": true
@@ -189,9 +180,6 @@
                 "version_added": true,
                 "version_removed": "9"
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": false
               },
@@ -243,9 +231,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -295,9 +280,6 @@
                 "version_added": "46"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -361,9 +343,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },
@@ -412,9 +391,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -469,9 +445,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "nodejs": {
               "version_added": null
             },
@@ -524,9 +497,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },
@@ -575,9 +545,6 @@
                 "version_added": "26"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -629,9 +596,6 @@
                 "version_added": "41"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -687,9 +651,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },
@@ -738,9 +699,6 @@
                 "version_added": "43"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -794,9 +752,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -846,9 +801,6 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -904,9 +856,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },
@@ -955,9 +904,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1012,9 +958,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -1063,9 +1006,6 @@
                 "version_added": "34"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1120,9 +1060,6 @@
             "ie": {
               "version_added": "9"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -1171,9 +1108,6 @@
                 "version_added": "34"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -83,9 +80,6 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
-            },
-            "ie_mobile": {
               "version_added": null
             },
             "nodejs": {
@@ -140,9 +134,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -193,9 +184,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {
@@ -250,9 +238,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -303,9 +288,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {
@@ -360,9 +342,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -413,9 +392,6 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
-            },
-            "ie_mobile": {
               "version_added": null
             },
             "nodejs": {
@@ -470,9 +446,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -523,9 +496,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {
@@ -580,9 +550,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -635,9 +602,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },
@@ -687,9 +651,6 @@
               "version_added": "33"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "nodejs": {
@@ -744,9 +705,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },
@@ -795,9 +753,6 @@
                 "version_added": "53"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -853,9 +808,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -906,9 +858,6 @@
               "ie": {
                 "version_added": "9"
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -958,9 +907,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/operators/arithmetic.json
+++ b/javascript/operators/arithmetic.json
@@ -31,9 +31,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -84,9 +81,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -141,9 +135,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -194,9 +185,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -251,9 +239,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -304,9 +289,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -361,9 +343,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -414,9 +393,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -471,9 +447,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -524,9 +497,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {

--- a/javascript/operators/array_comprehensions.json
+++ b/javascript/operators/array_comprehensions.json
@@ -32,9 +32,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": false
             },

--- a/javascript/operators/assignment.json
+++ b/javascript/operators/assignment.json
@@ -31,9 +31,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -84,9 +81,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -141,9 +135,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -194,9 +185,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -251,9 +239,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -304,9 +289,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -361,9 +343,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -414,9 +393,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -471,9 +447,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -524,9 +497,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -581,9 +551,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -636,9 +603,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -689,9 +653,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {

--- a/javascript/operators/async_function_expression.json
+++ b/javascript/operators/async_function_expression.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": null
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "nodejs": {
               "version_added": null
             },

--- a/javascript/operators/bitwise.json
+++ b/javascript/operators/bitwise.json
@@ -31,9 +31,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -84,9 +81,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -141,9 +135,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -194,9 +185,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -251,9 +239,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -306,9 +291,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -359,9 +341,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {

--- a/javascript/operators/class.json
+++ b/javascript/operators/class.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/operators/comma.json
+++ b/javascript/operators/comma.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "3"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/operators/comparison.json
+++ b/javascript/operators/comparison.json
@@ -31,9 +31,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -84,9 +81,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -141,9 +135,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -194,9 +185,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -251,9 +239,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -304,9 +289,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -361,9 +343,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -414,9 +393,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {

--- a/javascript/operators/conditional.json
+++ b/javascript/operators/conditional.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/operators/delete.json
+++ b/javascript/operators/delete.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
                 "version_added": "36"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {

--- a/javascript/operators/destructuring.json
+++ b/javascript/operators/destructuring.json
@@ -32,9 +32,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },
@@ -83,9 +80,6 @@
                 "version_added": "34"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -147,9 +141,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -199,9 +190,6 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/operators/expression_closures.json
+++ b/javascript/operators/expression_closures.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": false
             },

--- a/javascript/operators/function.json
+++ b/javascript/operators/function.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -80,9 +77,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/operators/function_star.json
+++ b/javascript/operators/function_star.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },
@@ -81,9 +78,6 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {

--- a/javascript/operators/generator_comprehensions.json
+++ b/javascript/operators/generator_comprehensions.json
@@ -32,9 +32,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": false
             },

--- a/javascript/operators/grouping.json
+++ b/javascript/operators/grouping.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/operators/in.json
+++ b/javascript/operators/in.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/operators/instanceof.json
+++ b/javascript/operators/instanceof.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/operators/legacy_generator_function.json
+++ b/javascript/operators/legacy_generator_function.json
@@ -32,9 +32,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": false
             },

--- a/javascript/operators/logical.json
+++ b/javascript/operators/logical.json
@@ -31,9 +31,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -86,9 +83,6 @@
               "ie": {
                 "version_added": true
               },
-              "ie_mobile": {
-                "version_added": true
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -139,9 +133,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {

--- a/javascript/operators/new.json
+++ b/javascript/operators/new.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/operators/new_target.json
+++ b/javascript/operators/new_target.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/operators/object_initializer.json
+++ b/javascript/operators/object_initializer.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": "1"
             },
-            "ie_mobile": {
-              "version_added": "1"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -81,9 +78,6 @@
                 "version_added": "34"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -137,9 +131,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -191,9 +182,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -243,9 +231,6 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/operators/pipeline.json
+++ b/javascript/operators/pipeline.json
@@ -38,9 +38,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": false
             },

--- a/javascript/operators/property_accessors.json
+++ b/javascript/operators/property_accessors.json
@@ -30,9 +30,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -31,9 +31,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -84,9 +81,6 @@
                 "version_added": "27"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -140,9 +134,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -192,9 +183,6 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/operators/super.json
+++ b/javascript/operators/super.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/operators/this.json
+++ b/javascript/operators/this.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/operators/typeof.json
+++ b/javascript/operators/typeof.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/operators/void.json
+++ b/javascript/operators/void.json
@@ -29,9 +29,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/operators/yield.json
+++ b/javascript/operators/yield.json
@@ -31,9 +31,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },
@@ -82,9 +79,6 @@
                 "version_added": "29"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {

--- a/javascript/operators/yield_star.json
+++ b/javascript/operators/yield_star.json
@@ -32,9 +32,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -32,9 +32,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": false
             },
@@ -85,9 +82,6 @@
               "version_added": "52"
             },
             "ie": {
-              "version_added": false
-            },
-            "ie_mobile": {
               "version_added": false
             },
             "nodejs": {
@@ -141,9 +135,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -193,9 +184,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {
@@ -249,9 +237,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": null
             },
@@ -300,9 +285,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -354,9 +336,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -419,9 +398,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": "11"
-            },
             "nodejs": {
               "version_added": true
             },
@@ -471,9 +447,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {
@@ -527,9 +500,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -581,9 +551,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
-              },
-              "ie_mobile": {
                 "version_added": true
               },
               "nodejs": {
@@ -655,9 +622,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": null
               },
@@ -711,9 +675,6 @@
             "ie": {
               "version_added": "6"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -764,9 +725,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {
@@ -837,9 +795,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": null
             },
@@ -889,9 +844,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {
@@ -948,9 +900,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": false
             },
@@ -1002,9 +951,6 @@
             },
             "ie": {
               "version_added": "6"
-            },
-            "ie_mobile": {
-              "version_added": true
             },
             "nodejs": {
               "version_added": true
@@ -1059,9 +1005,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },
@@ -1110,9 +1053,6 @@
                 "version_added": "53"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1167,9 +1107,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -1218,9 +1155,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
@@ -1272,9 +1206,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
@@ -1330,9 +1261,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": true
             },
@@ -1381,9 +1309,6 @@
                 "version_added": "29"
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -1437,9 +1362,6 @@
               "ie": {
                 "version_added": false
               },
-              "ie_mobile": {
-                "version_added": false
-              },
               "nodejs": {
                 "version_added": true
               },
@@ -1489,9 +1411,6 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
-              },
-              "ie_mobile": {
                 "version_added": null
               },
               "nodejs": {
@@ -1545,9 +1464,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {
@@ -1618,9 +1534,6 @@
             "ie": {
               "version_added": false
             },
-            "ie_mobile": {
-              "version_added": false
-            },
             "nodejs": {
               "version_added": null
             },
@@ -1670,9 +1583,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {
@@ -1736,9 +1646,6 @@
             "ie": {
               "version_added": "11"
             },
-            "ie_mobile": {
-              "version_added": null
-            },
             "nodejs": {
               "version_added": true
             },
@@ -1788,9 +1695,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {
@@ -1844,9 +1748,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -1896,9 +1797,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {
@@ -1953,9 +1851,6 @@
             "ie": {
               "version_added": "6"
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -2004,9 +1899,6 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": false
-              },
-              "ie_mobile": {
                 "version_added": false
               },
               "nodejs": {
@@ -2061,9 +1953,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -2115,9 +2004,6 @@
             "ie": {
               "version_added": true
             },
-            "ie_mobile": {
-              "version_added": true
-            },
             "nodejs": {
               "version_added": true
             },
@@ -2167,9 +2053,6 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
-            },
-            "ie_mobile": {
               "version_added": true
             },
             "nodejs": {

--- a/test/sample-data.json
+++ b/test/sample-data.json
@@ -41,9 +41,6 @@
               "version_added": "9",
               "version_removed": null
             },
-            "ie_mobile": {
-              "version_added": "7"
-            },
             "opera": {
               "version_added": "10.5"
             },
@@ -103,9 +100,6 @@
             },
             "ie": {
               "version_added": "9"
-            },
-            "ie_mobile": {
-              "version_added": "7"
             },
             "opera": {
               "version_added": "10.5"
@@ -214,10 +208,6 @@
               "ie": {
                 "version_added": "9",
                 "version_removed": true
-              },
-              "ie_mobile": {
-                "version_added": "7",
-                "version_removed": null
               },
               "opera": {
                 "version_added": true,


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/issues/659 for the reasoning.

I'm not sure when is the right timing for this (to avoid merge conflicts), but as ` ie_mobile` has been removed on the KumaScript side on MDN prod already, this is mergable at any time.

New PRs need to omit `ie_mobile` as this also removes it from the schema.