### PR TITLE
Add wrong-interface notes to early Firefoxes

### DIFF
--- a/html/elements/b.json
+++ b/html/elements/b.json
@@ -21,7 +21,8 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."
             },
             "firefox_android": {
               "version_added": "4"

--- a/html/elements/u.json
+++ b/html/elements/u.json
@@ -21,7 +21,8 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."
             },
             "firefox_android": {
               "version_added": "4"


### PR DESCRIPTION
Early versions of Firefox (prior to 4.0) used the
HTMLSpanElement interface instead of HTMLElement for
the `<b>` and `<u>` elements. This patch adds a note to
that effect.

This is the same text as I've used other elements that
needed the same note applied.