### PR TITLE
Add safari_ios validation

### DIFF
--- a/browsers/browsers.json
+++ b/browsers/browsers.json
@@ -1442,6 +1442,88 @@
       }
     }
   },
+  "safari_ios": {
+    "releases": {
+      "1": {
+        "status": "retired"
+      },
+      "2": {
+        "status": "retired"
+      },
+      "3": {
+        "status": "retired"
+      },
+      "3.1": {
+        "status": "retired"
+      },
+      "3.2": {
+        "status": "retired"
+      },
+      "4": {
+        "status": "retired"
+      },
+      "4.2": {
+        "status": "retired"
+      },
+      "4.3": {
+        "status": "retired"
+      },
+      "5": {
+        "status": "retired"
+      },
+      "5.1": {
+        "status": "retired"
+      },
+      "6": {
+        "status": "retired"
+      },
+      "6.1": {
+        "status": "retired"
+      },
+      "7": {
+        "status": "retired"
+      },
+      "7.1": {
+        "status": "retired"
+      },
+      "8": {
+        "status": "retired"
+      },
+      "8.1": {
+        "status": "retired"
+      },
+      "8.4": {
+        "status": "retired"
+      },
+      "9": {
+        "status": "retired"
+      },
+      "9.1": {
+        "status": "retired"
+      },
+      "9.2": {
+        "status": "retired"
+      },
+      "9.3": {
+        "status": "retired"
+      },
+      "10": {
+        "status": "retired"
+      },
+      "10.1": {
+        "status": "retired"
+      },
+      "10.2": {
+        "status": "retired"
+      },
+      "10.3": {
+        "status": "retired"
+      },
+      "11": {
+        "status": "current"
+      }
+    }
+  },
   "samsunginternet_android": {
     "releases": {
       "1.0": {

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -79,7 +79,7 @@
               }
             ],
             "safari_ios": {
-              "version_added": ""
+              "version_added": true
             }
           },
           "status": {

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -143,7 +143,7 @@
                 "version_added": "5"
               },
               "safari_ios": {
-                "version_added": "iOS 4"
+                "version_added": "4"
               }
             },
             "status": {


### PR DESCRIPTION
This adds `safari_ios` to the version validation. It does so by adding all versions we have in the current data set. While I guess that there have been all these` safari_ios` releases, I'm not sure if they are major releases where web facing features got added.
I can't find a good source of `safari_ios` releases / versions, so this is hard to get right. I think having these versions based on our data is a good start, though. If we later identify that versions like "9.2" or the like aren't actually releases that added web facing features (but instead it should be 9.0, for example), we can adjust.

There was no need to correct compat data with this approach, of course. Just two entries, where it wasn't using a proper version at all. 