### PR TITLE
Add compat data for CanvasPattern

### DIFF
--- a/api/CanvasPattern.json
+++ b/api/CanvasPattern.json
@@ -47,7 +47,7 @@
           "deprecated": false
         }
       },
-      "addColorStop": {
+      "setTransform": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasPattern/setTransform",
           "support": {

--- a/api/CanvasPattern.json
+++ b/api/CanvasPattern.json
@@ -23,13 +23,10 @@
             "version_added": "3.6"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
-          },
-          "ie_mobile": {
-            "version_added": null
           },
           "opera": {
             "version_added": "9"
@@ -76,9 +73,6 @@
               "version_added": "33"
             },
             "ie": {
-              "version_added": null
-            },
-            "ie_mobile": {
               "version_added": null
             },
             "opera": {

--- a/api/CanvasPattern.json
+++ b/api/CanvasPattern.json
@@ -1,0 +1,106 @@
+{
+  "api": {
+    "CanvasPattern": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasPattern",
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": "4"
+          },
+          "chrome_android": {
+            "version_added": "2.1"
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "3.6"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "ie_mobile": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "9"
+          },
+          "opera_android": {
+            "version_added": "10.0"
+          },
+          "safari": {
+            "version_added": "3.1"
+          },
+          "safari_ios": {
+            "version_added": "3.2"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "addColorStop": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasPattern/setTransform",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "ie_mobile": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "9"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
*Notes*

* As the linter does not allow version numbers for `firefox-android` below `4`, I replaced `1.0` with `null`.

* I also omitted the Gecko version (given in brackets in the compat table here https://developer.mozilla.org/en-US/docs/Web/API/CanvasPattern)

* Worth noting that data exists for CanvasPattern.setTransform() both at https://developer.mozilla.org/en-US/docs/Web/API/CanvasPattern and at https://developer.mozilla.org/en-US/docs/Web/API/CanvasPattern/setTransform. I used the former as it it appeared to be more comprehensive.