### PR TITLE
Update text-decoration-skip.json

### DIFF
--- a/css/properties/text-decoration-skip.json
+++ b/css/properties/text-decoration-skip.json
@@ -16,7 +16,7 @@
               "notes": "Only supports the deprecated <code>ink</code> value."
             },
             "chrome_android": {
-              "version_added": "57"
+              "version_added": "57",
               "version_removed": "64",
               "notes": "Only supports the deprecated <code>ink</code> value."
             },
@@ -36,12 +36,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "44"
+              "version_added": "44",
               "version_removed": "51",
               "notes": "Only supports the deprecated <code>ink</code> value."
             },
             "opera_android": {
-              "version_added": "44"
+              "version_added": "44",
               "version_removed": "51",
               "notes": "Only supports the deprecated <code>ink</code> value."
             },

--- a/css/properties/text-decoration-skip.json
+++ b/css/properties/text-decoration-skip.json
@@ -37,12 +37,12 @@
             },
             "opera": {
               "version_added": "44",
-              "version_removed": "51",
+              "version_removed": "50",
               "notes": "Only supports the deprecated <code>ink</code> value."
             },
             "opera_android": {
               "version_added": "44",
-              "version_removed": "51",
+              "version_removed": "50",
               "notes": "Only supports the deprecated <code>ink</code> value."
             },
             "safari": {

--- a/css/properties/text-decoration-skip.json
+++ b/css/properties/text-decoration-skip.json
@@ -6,13 +6,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-skip",
           "support": {
             "webview_android": {
-              "version_added": "57"
+              "version_added": "57",
+              "version_removed": "64",
+              "notes": "Only supports the deprecated <code>ink</code> value."
             },
             "chrome": {
-              "version_added": "57"
+              "version_added": "57",
+              "version_removed": "64",
+              "notes": "Only supports the deprecated <code>ink</code> value."
             },
             "chrome_android": {
               "version_added": "57"
+              "version_removed": "64",
+              "notes": "Only supports the deprecated <code>ink</code> value."
             },
             "edge": {
               "version_added": false
@@ -31,9 +37,13 @@
             },
             "opera": {
               "version_added": "44"
+              "version_removed": "51",
+              "notes": "Only supports the deprecated <code>ink</code> value."
             },
             "opera_android": {
               "version_added": "44"
+              "version_removed": "51",
+              "notes": "Only supports the deprecated <code>ink</code> value."
             },
             "safari": {
               "version_added": "8",


### PR DESCRIPTION
only the `ink` value is supported by these. and it's gone with the latest version completely. 

New support is now with the longer text-decoration-skip-ink