### PR TITLE
Add compat data for global CSS keywords: inherit, initial, revert, and unset

### DIFF
--- a/css/types/global_keywords.json
+++ b/css/types/global_keywords.json
@@ -1,0 +1,271 @@
+{
+  "css": {
+    "types": {
+      "global_keywords": {
+        "__compat": {
+          "description": "Global keywords",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "inherit": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inherit",
+            "description": "<code>inherit</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "1"
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "opera": {
+                "version_added": "4"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "initial": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/initial",
+            "description": "<code>initial</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "1"
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": [
+                {
+                  "version_added": "19"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1",
+                  "version_removed": "24"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "19"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4",
+                  "version_removed": "24"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "1.2"
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "revert": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/revert",
+            "description": "<code>revert</code>",
+            "support": {
+              "webview_android": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/579788'>bug 579788</a>."
+              },
+              "chrome": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/579788'>bug 579788</a>."
+              },
+              "chrome_android": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/579788'>bug 579788</a>."
+              },
+              "edge": {
+                "version_added": false,
+                "notes": "See <a href='https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10469316-the-css4-revert-value'>this enhancement request</a>."
+              },
+              "edge_mobile": {
+                "version_added": false,
+                "notes": "See <a href='https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10469316-the-css4-revert-value'>this enhancement request</a>."
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See bug <a href='https://bugzil.la/1215878'>bug 1215878</a>."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See bug <a href='https://bugzil.la/1215878'>bug 1215878</a>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "9.1"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "unset": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/unset",
+            "description": "<code>unset</code>",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "41"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "27"
+              },
+              "firefox_android": {
+                "version_added": "27"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "9.1"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates data for the following CSS keywords:

* [`inherit`](https://developer.mozilla.org/docs/Web/CSS/inherit)
* [`initial`](https://developer.mozilla.org/docs/Web/CSS/initial)
* [`revert`](https://developer.mozilla.org/docs/Web/CSS/revert)
* [`unset`](https://developer.mozilla.org/docs/Web/CSS/unset)

If at least one keyword was supported, then I set basic support to be `true` or the first release of that browser (if I knew it had support in that release).

Filling in the gaps here seemed like a good idea (and pretty easy), so I made a few changes to the original data:

`inherit`:
- Assumed Edge support since 12, since IE supported it
- Assumed Chrome for Android is `true`, since Chrome and Android WebView have it
- Assumed Opera for Android is `true`, based on Opera, Chrome, and Android WebView support

`initial`:
- Assumed Chrome for Android is `true`, since Chrome and Android WebView have it
- Edge is `true`, though I couldn't figure out the first version to support it
- Assumed Opera for Android is `true`, since the other Blink browsers have it

`revert`:
- Assumed IE is `false` because Edge doesn't support it
- Assumed Opera is `false` based on other Blink browsers

`unset`:
- Android WebView and Chrome for Android are `true` based on https://crbug.com/431689
- [Edge ships it](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/cssunsetvalue/)
- Opera is `true` based on the Edge page and inferred from Blink browsers

This should fix #819.