### PR TITLE
Remove IE mobile from render output

### DIFF
--- a/test/render.js
+++ b/test/render.js
@@ -33,7 +33,6 @@ const browsers = {
     chrome_android: s_chrome_android,
     edge_mobile: 'Edge mobile',
     firefox_android: s_firefox_android,
-    ie_mobile: 'IE mobile',
     opera_android: 'Opera Android',
     safari_ios: 'iOS Safari',
   },


### PR DESCRIPTION
Since #827, I figure we don't need IE mobile in the output from `render.js`.