### PR TITLE
Add data for show_matches and hide_matches

### DIFF
--- a/webextensions/manifest/page_action.json
+++ b/webextensions/manifest/page_action.json
@@ -49,6 +49,48 @@
               }
             }
           }
+        },
+        "hide_matches": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "59"
+              },
+              "firefox_android": {
+                "version_added": "59"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "show_matches": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "59"
+              },
+              "firefox_android": {
+                "version_added": "59"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
"hide_matches" and "show_matches" are new properties for the page_action manifest key:

https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/page_action
https://bugzilla.mozilla.org/show_bug.cgi?id=1419842
