### PR TITLE
Add compat data for `@viewport` CSS at-rule and some descriptors

### DIFF
--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -95,6 +95,68 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "width": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport/width",
+            "description": "<code>width</code> descriptor",
+            "support": {
+              "webview_android": {
+                "version_added": "4.4"
+              },
+              "chrome": {
+                "version_added": "29"
+              },
+              "chrome_android": {
+                "version_added": "29"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "prefix": "-ms-",
+                "version_added": "10"
+              },
+              "opera": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "11.1",
+                  "version_removed": "15"
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "11.1",
+                  "version_removed": "15"
+                }
+              ],
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -96,6 +96,62 @@
             "deprecated": false
           }
         },
+        "min-width": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport/min-width",
+            "description": "<code>min-width</code> descriptor",
+            "support": {
+              "webview_android": {
+                "version_added": "4.4"
+              },
+              "chrome": {
+                "version_added": "29"
+              },
+              "chrome_android": {
+                "version_added": "29"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "prefix": "-ms-",
+                "version_added": "10"
+              },
+              "opera": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "11.1",
+                  "version_removed": "15"
+                }
+              ],
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "width": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport/width",

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -1,0 +1,102 @@
+{
+  "css": {
+    "at-rules": {
+      "viewport": {
+        "__compat": {
+          "description": "<code>@viewport</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport",
+          "support": {
+            "webview_android": {
+              "version_added": "4.4"
+            },
+            "chrome": {
+              "version_added": "29",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-experimental-webkit-features"
+                },
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-viewport"
+                }
+              ],
+              "notes": "See Chromium <a href='https://crbug.com/235457'>bug 235457</a>."
+            },
+            "chrome_android": {
+              "version_added": "29"
+            },
+            "edge": {
+              "prefix": "-ms-",
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable @-ms-viewport rules"
+                }
+              ]
+            },
+            "edge_mobile": {
+              "prefix": "-ms-",
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable @-ms-viewport rules"
+                }
+              ]
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "See Firefox <a href='https://bugzil.la/747754'>bug 747754</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "See Firefox <a href='https://bugzil.la/747754'>bug 747754</a>."
+            },
+            "ie": {
+              "prefix": "-ms-",
+              "version_added": "10"
+            },
+            "opera": [
+              {
+                "version_added": "16",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--enable-experimental-webkit-features"
+                  },
+                  {
+                    "type": "runtime_flag",
+                    "name": "--enable-viewport"
+                  }
+                ]
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "11.1",
+                "version_removed": "15"
+              }
+            ],
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "See WebKit <a href='https://bugs.webkit.org/show_bug.cgi?id=95959'>bug 95959</a>."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "See WebKit <a href='https://bugs.webkit.org/show_bug.cgi?id=95959'>bug 95959</a>."
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -152,9 +152,9 @@
               }
             },
             "status": {
-              "experimental": null,
-              "standard_track": null,
-              "deprecated": null
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -96,6 +96,68 @@
             "deprecated": false
           }
         },
+        "max-width": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport/max-width",
+            "description": "<code>max-width</code> descriptor",
+            "support": {
+              "webview_android": {
+                "version_added": "4.4"
+              },
+              "chrome": {
+                "version_added": "29"
+              },
+              "chrome_android": {
+                "version_added": "29"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "prefix": "-ms-",
+                "version_added": "10"
+              },
+              "opera": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "11.1",
+                  "version_removed": "15"
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "11.1",
+                  "version_removed": "15"
+                }
+              ],
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": null,
+              "standard_track": null,
+              "deprecated": null
+            }
+          }
+        },
         "min-width": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport/min-width",


### PR DESCRIPTION
This PR starts the migration of [`@viewport`](https://developer.mozilla.org/docs/Web/CSS/@viewport), including [`max-width`](https://developer.mozilla.org/docs/Web/CSS/@viewport/max-width), [`min-width`](https://developer.mozilla.org/docs/Web/CSS/@viewport/min-width), and [`width`](https://developer.mozilla.org/docs/Web/CSS/@viewport/width) descriptors.

Unlike some of the other descriptors, the data here seems pretty straightforward. The one big exception is Opera for Android, which I couldn't make sense of because of the flags.