### PR TITLE
Add compat data for CSS `attr()` function

### DIFF
--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -48,6 +48,55 @@
             "deprecated": false
           }
         },
+        "attr": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/attr",
+            "description": "<code>attr()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "2.1"
+              },
+              "chrome": {
+                "version_added": "2"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "opera": {
+                "version_added": "9"
+              },
+              "opera_android": {
+                "version_added": "10"
+              },
+              "safari": {
+                "version_added": "3.1"
+              },
+              "safari_ios": {
+                "version_added": "3.1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "url": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url",


### PR DESCRIPTION
This PR migrates the compat data for the CSS `content` property's [`attr()` function](https://developer.mozilla.org/docs/Web/CSS/attr). Let me know if you want to see any changes. Thanks!