### PR TITLE
Add compat data for CSS calc() type

### DIFF
--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -1,0 +1,239 @@
+{
+  "css": {
+    "types": {
+      "calc": {
+        "__compat": {
+          "description": "<code>&lt;calc()&gt;</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/calc",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "19"
+              }
+            ],
+            "chrome_android": {
+              "version_added": "28"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "16",
+                "notes": [
+                  "Before Firefox 57 <code>calc(1*2*3)</code> is not parsed successfully.",
+                  "Firefox 57 increased the number of places <code>calc()</code> could substitute another value. See <a href='https://bugzil.la/1350857'>bug 1350857</a>."
+                ]
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4",
+                "version_removed": "53"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "16",
+                "notes": [
+                  "Before Firefox 57 <code>calc(1*2*3)</code> is not parsed successfully.",
+                  "Firefox 57 increased the number of places <code>calc()</code> could substitute another value. See <a href='https://bugzil.la/1350857'>bug 1350857</a>."
+                ]
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4",
+                "version_removed": "53"
+              }
+            ],
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "21"
+            },
+            "safari": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "6"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "6"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "gradient_color_stops": {
+          "__compat": {
+            "description": "Gradient color stops support",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "19"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "19"
+              },
+              "firefox_android": {
+                "version_added": "19"
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "6"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "nested": {
+          "__compat": {
+            "description": "Nested <code>calc()</code> support",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "51"
+              },
+              "chrome_android": {
+                "version_added": "51"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "number_values": {
+          "__compat": {
+            "description": "<code>&gt;number&lt;</code> values support",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`calc()`](https://developer.mozilla.org/docs/Web/CSS/calc). Let me know if you want to see any changes. Thanks!