### PR TITLE
Add compat data for <number> CSS type

### DIFF
--- a/css/types/number.json
+++ b/css/types/number.json
@@ -1,0 +1,103 @@
+{
+  "css": {
+    "types": {
+      "number": {
+        "__compat": {
+          "description": "&lt;number&gt;",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/number",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "5"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "scientific_notation": {
+          "__compat": {
+            "description": "Scientific notation",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "43"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "29"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "11"
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`<number>`](https://developer.mozilla.org/docs/Web/CSS/number). Let me know if you want to see any changes. Thanks!