### PR TITLE
Add compat data for strings in browserAction.setBadgeBackgroundColor

### DIFF
--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -243,6 +243,31 @@
               }
             }
           },
+          "string": {
+            "__compat": {
+              "description": "The <code>color</code> property of the <code>details</code> parameter can be set to a string.",
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": true,
+                  "notes": [
+                    "Before Firefox 59, invalid color strings behaved as <code>null</code>."
+                  ]
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": null
+                }
+              }
+            }
+          },
           "null": {
             "__compat": {
               "description": "The <code>color</code> property of the <code>details</code> parameter can be set to <code>null</code>.",


### PR DESCRIPTION
Fixes #754 and documents [bug 1427107](https://bugzilla.mozilla.org/show_bug.cgi?id=1427107)