### PR TITLE
Edge doesn't currently support requestBody for webRequest

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -1677,7 +1677,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": true
+                    "version_added": false
                   },
                   "firefox": {
                     "version_added": "53"


### PR DESCRIPTION
Edge doesn't currently support requestBody for webRequest.onBeforeRequest, see https://docs.microsoft.com/en-us/microsoft-edge/extensions/api-support/supported-apis#webrequest