### PR TITLE
Update support for theme color forms

### DIFF
--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -33,7 +33,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "55"
+                  "version_added": "55",
+                  "notes": [
+                    "Before version 59, the RGB array form was not supported for this property."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": false
@@ -48,7 +51,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": [
+                    "The CSS color form is not supported for this property."
+                  ]
                 },
                 "edge": {
                   "version_added": false
@@ -69,13 +75,19 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": [
+                    "The CSS color form is not supported for this property."
+                  ]
                 },
                 "edge": {
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "58"
+                  "version_added": "58",
+                  "notes": [
+                    "Before version 59, the RGB array form was not supported for this property."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": false
@@ -90,13 +102,19 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": [
+                    "The CSS color form is not supported for this property."
+                  ]
                 },
                 "edge": {
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "55"
+                  "version_added": "55",
+                  "notes": [
+                    "Before version 59, the CSS color form was not supported for this property."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": false
@@ -111,7 +129,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": [
+                    "The CSS color form is not supported for this property."
+                  ]
                 },
                 "edge": {
                   "version_added": false
@@ -132,7 +153,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": [
+                    "The CSS color form is not supported for this property."
+                  ]
                 },
                 "edge": {
                   "version_added": false
@@ -153,7 +177,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": [
+                    "The CSS color form is not supported for this property."
+                  ]
                 },
                 "edge": {
                   "version_added": false
@@ -174,7 +201,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": [
+                    "The CSS color form is not supported for this property."
+                  ]
                 },
                 "edge": {
                   "version_added": false
@@ -195,7 +225,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": [
+                    "The CSS color form is not supported for this property."
+                  ]
                 },
                 "edge": {
                   "version_added": false
@@ -216,7 +249,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": [
+                    "The CSS color form is not supported for this property."
+                  ]
                 },
                 "edge": {
                   "version_added": false
@@ -237,7 +273,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": [
+                    "The CSS color form is not supported for this property."
+                  ]
                 },
                 "edge": {
                   "version_added": false
@@ -258,13 +297,19 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": [
+                    "The CSS color form is not supported for this property."
+                  ]
                 },
                 "edge": {
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "55"
+                  "version_added": "55",
+                  "notes": [
+                    "Before version 59, the CSS color form was not supported for this property."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": false
@@ -285,7 +330,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "55"
+                  "version_added": "55",
+                  "notes": [
+                    "Before version 59, the RGB array form was not supported for this property."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": false
@@ -300,13 +348,19 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": [
+                    "The CSS color form is not supported for this property."
+                  ]
                 },
                 "edge": {
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "57"
+                  "version_added": "57",
+                  "notes": [
+                    "Before version 59, the RGB array form was not supported for this property."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": false
@@ -327,7 +381,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "58"
+                  "version_added": "58",
+                  "notes": [
+                    "Before version 59, the RGB array form was not supported for this property."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": false
@@ -348,7 +405,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "57"
+                  "version_added": "57",
+                  "notes": [
+                    "Before version 59, the RGB array form was not supported for this property."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": false
@@ -369,7 +429,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "57"
+                  "version_added": "57",
+                  "notes": [
+                    "Before version 59, the RGB array form was not supported for this property."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": false
@@ -390,7 +453,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "57"
+                  "version_added": "57",
+                  "notes": [
+                    "Before version 59, the RGB array form was not supported for this property."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": false
@@ -411,7 +477,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "58"
+                  "version_added": "58",
+                  "notes": [
+                    "Before version 59, the RGB array form was not supported for this property."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": false
@@ -432,7 +501,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "58"
+                  "version_added": "58",
+                  "notes": [
+                    "Before version 59, the RGB array form was not supported for this property."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": false


### PR DESCRIPTION
See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1415878

https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/theme#Chrome_compatibility

There are 2 ways to specify a color in a theme:
* the old Chrome way, as an array of RGB values
* as a CSS color

Chrome only supports the RGB array form.

Firefox supports both forms from 59 onwards. Before 59 it only supported the CSS form for all properties except `frame` and `tab_text`, and for those 2 properties it only supported the RGB form.


