### PR TITLE
Add ByteLengthQueuingStrategy and CountQueuingStrategy compat data

### DIFF
--- a/api/ByteLengthQueuingStrategy.json
+++ b/api/ByteLengthQueuingStrategy.json
@@ -1,0 +1,221 @@
+{
+  "api": {
+    "ByteLengthQueuingStrategy": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ByteLengthQueuingStrategy",
+        "support": {
+          "webview_android": {
+            "version_added": "59"
+          },
+          "chrome": {
+            "version_added": "59"
+          },
+          "chrome_android": {
+            "version_added": "59"
+          },
+          "edge": {
+            "version_added": "16"
+          },
+          "edge_mobile": {
+            "version_added": "16"
+          },
+          "firefox": {
+            "version_added": "57",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.streams.enabled",
+                "value_to_set": "true"
+              },
+              {
+                "type": "preference",
+                "name": "javascript.options.streams",
+                "value_to_set": "true"
+              }
+            ]
+          },
+          "firefox_android": {
+            "version_added": "57",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.streams.enabled",
+                "value_to_set": "true"
+              },
+              {
+                "type": "preference",
+                "name": "javascript.options.streams",
+                "value_to_set": "true"
+              }
+            ]
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "47"
+          },
+          "opera_android": {
+            "version_added": "47"
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "ByteLengthQueuingStrategy": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ByteLengthQueuingStrategy/ByteLengthQueuingStrategy",
+          "description": "<code>ByteLengthQueuingStrategy()</code> constructor",
+          "support": {
+            "webview_android": {
+              "version_added": "59"
+            },
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "57",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "javascript.options.streams",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "57",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "javascript.options.streams",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "47"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "size": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ByteLengthQueuingStrategy/size",
+          "support": {
+            "webview_android": {
+              "version_added": "59"
+            },
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "57",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "javascript.options.streams",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "57",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "javascript.options.streams",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "47"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/ByteLengthQueuingStrategy.json
+++ b/api/ByteLengthQueuingStrategy.json
@@ -53,10 +53,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "47"
+            "version_added": "46"
           },
           "opera_android": {
-            "version_added": "47"
+            "version_added": "46"
           },
           "safari": {
             "version_added": null
@@ -125,10 +125,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "47"
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": "47"
+              "version_added": "46"
             },
             "safari": {
               "version_added": null
@@ -197,10 +197,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "47"
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": "47"
+              "version_added": "46"
             },
             "safari": {
               "version_added": null

--- a/api/CountQueuingStrategy.json
+++ b/api/CountQueuingStrategy.json
@@ -1,0 +1,221 @@
+{
+  "api": {
+    "CountQueuingStrategy": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CountQueuingStrategy",
+        "support": {
+          "webview_android": {
+            "version_added": "59"
+          },
+          "chrome": {
+            "version_added": "59"
+          },
+          "chrome_android": {
+            "version_added": "59"
+          },
+          "edge": {
+            "version_added": "16"
+          },
+          "edge_mobile": {
+            "version_added": "16"
+          },
+          "firefox": {
+            "version_added": "57",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.streams.enabled",
+                "value_to_set": "true"
+              },
+              {
+                "type": "preference",
+                "name": "javascript.options.streams",
+                "value_to_set": "true"
+              }
+            ]
+          },
+          "firefox_android": {
+            "version_added": "57",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.streams.enabled",
+                "value_to_set": "true"
+              },
+              {
+                "type": "preference",
+                "name": "javascript.options.streams",
+                "value_to_set": "true"
+              }
+            ]
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "47"
+          },
+          "opera_android": {
+            "version_added": "47"
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "CountQueuingStrategy": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CountQueuingStrategy/CountQueuingStrategy",
+          "description": "<code>CountQueuingStrategy()</code> constructor",
+          "support": {
+            "webview_android": {
+              "version_added": "59"
+            },
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "57",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "javascript.options.streams",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "57",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "javascript.options.streams",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "47"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "size": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CountQueuingStrategy/size",
+          "support": {
+            "webview_android": {
+              "version_added": "59"
+            },
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "57",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "javascript.options.streams",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "57",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "javascript.options.streams",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "47"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/CountQueuingStrategy.json
+++ b/api/CountQueuingStrategy.json
@@ -53,10 +53,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "47"
+            "version_added": "46"
           },
           "opera_android": {
-            "version_added": "47"
+            "version_added": "46"
           },
           "safari": {
             "version_added": null
@@ -125,10 +125,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "47"
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": "47"
+              "version_added": "46"
             },
             "safari": {
               "version_added": null
@@ -197,10 +197,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "47"
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": "47"
+              "version_added": "46"
             },
             "safari": {
               "version_added": null


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/ByteLengthQueuingStrategy
https://developer.mozilla.org/en-US/docs/Web/API/CountQueuingStrategy

I'm unsure whether these were introduced with ReadableStreams or WritableStreams, thus the chromium versions might be wrong.