### PR TITLE
Add compat data for CSS height descriptors for @viewport

### DIFF
--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -96,6 +96,68 @@
             "deprecated": false
           }
         },
+        "height": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport/height",
+            "description": "<code>height</code> descriptor",
+            "support": {
+              "webview_android": {
+                "version_added": "4.4"
+              },
+              "chrome": {
+                "version_added": "29"
+              },
+              "chrome_android": {
+                "version_added": "29"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "prefix": "-ms-",
+                "version_added": "10"
+              },
+              "opera": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "11.1",
+                  "version_removed": "15"
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "11.1",
+                  "version_removed": "15"
+                }
+              ],
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "max-width": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport/max-width",

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -158,6 +158,68 @@
             }
           }
         },
+        "max-height": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport/max-height",
+            "description": "<code>max-height</code> descriptor",
+            "support": {
+              "webview_android": {
+                "version_added": "4.4"
+              },
+              "chrome": {
+                "version_added": "29"
+              },
+              "chrome_android": {
+                "version_added": "29"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "prefix": "-ms-",
+                "version_added": "10"
+              },
+              "opera": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "11.1",
+                  "version_removed": "15"
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "11.1",
+                  "version_removed": "15"
+                }
+              ],
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "max-width": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport/max-width",

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -158,6 +158,68 @@
             }
           }
         },
+        "min-height": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport/min-height",
+            "description": "<code>min-height</code> descriptor",
+            "support": {
+              "webview_android": {
+                "version_added": "4.4"
+              },
+              "chrome": {
+                "version_added": "29"
+              },
+              "chrome_android": {
+                "version_added": "29"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "prefix": "-ms-",
+                "version_added": "10"
+              },
+              "opera": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "11.1",
+                  "version_removed": "15"
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "11.1",
+                  "version_removed": "15"
+                }
+              ],
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "min-width": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport/min-width",


### PR DESCRIPTION
This PR migrates the data for the following `@viewport` descriptors:

* [`height`](https://developer.mozilla.org/docs/Web/CSS/@viewport/height)
* [`max-height`](https://developer.mozilla.org/docs/Web/CSS/@viewport/max-height)
* [`min-height`](https://developer.mozilla.org/docs/Web/CSS/@viewport/min-height)

These are the remaining easy `@viewport` descriptors (they mirror the data from `@viewport` itself). `zoom` and `orientation` will get their own PRs (they're different) and the others don't have any data to migrate.

Let me know if you want to see any changes. Thanks!