### PR TITLE
Add compat data for CSS <ratio> type

### DIFF
--- a/css/types/ratio.json
+++ b/css/types/ratio.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "types": {
+      "ratio": {
+        "__compat": {
+          "description": "&lt;ratio&gt;",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/ratio",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "9.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`<ratio>`](https://developer.mozilla.org/docs/Web/CSS/ratio). Let me know if you want to see any changes. Thanks!