### PR TITLE
Update Array.json

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -587,7 +587,7 @@
                 "version_added": "43"
               },
               "ie": {
-                "version_added": false
+                "version_added": "9"
               },
               "nodejs": {
                 "version_added": true


### PR DESCRIPTION
changed the Browser compatibility in IE for Array.includes from not supported to since version "9"