### PR TITLE
IE11 doesn't support Map(iterable) constructor

### DIFF
--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -76,6 +76,9 @@
               "firefox_android": {
                 "version_added": "14"
               },
+              "ie": {
+                "version_added": false
+              },
               "nodejs": {
                 "version_added": true
               },

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -76,11 +76,6 @@
               "firefox_android": {
                 "version_added": "14"
               },
-              "ie": {
-                "version_added": false,
-                "partial_implementation": true,
-                "notes": "Only supports arrays of key/value pairs, such as <code>new Map([ ['foo', 'bar'] ])</code>."
-              },
               "nodejs": {
                 "version_added": true
               },


### PR DESCRIPTION
The data here claimed IE11 has partial support for Map(iterable) constructor when the iterable is an array, but kangx compat tables and repeatable tests contradict that claim.

Test to verify: https://jsfiddle.net/rbew03rk/1/