### PR TITLE
Add compat data for @viewport's zoom descriptor

### DIFF
--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -468,10 +468,10 @@
             "description": "<code>zoom</code> descriptor",
             "support": {
               "webview_android": {
-                "version_added": "2.1"
+                "version_added": "4.4"
               },
               "chrome": {
-                "version_added": "4"
+                "version_added": "29"
               },
               "chrome_android": {
                 "version_added": "61"
@@ -489,16 +489,17 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": "6"
+                "prefix": "-ms-",
+                "version_added": "10"
               },
               "opera": {
-                "version_added": "15"
+                "version_added": "16"
               },
               "opera_android": {
                 "version_added": "37"
               },
               "safari": {
-                "version_added": "4"
+                "version_added": false
               },
               "safari_ios": {
                 "version_added": null

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -461,6 +461,55 @@
               "deprecated": false
             }
           }
+        },
+        "zoom": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport/zoom",
+            "description": "<code>zoom</code> descriptor",
+            "support": {
+              "webview_android": {
+                "version_added": "2.1"
+              },
+              "chrome": {
+                "version_added": "4"
+              },
+              "chrome_android": {
+                "version_added": "61"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": "6"
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "37"
+              },
+              "safari": {
+                "version_added": "4"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This PR migrates the data for `@viewport`'s [`zoom`](https://developer.mozilla.org/docs/Web/CSS/@viewport/zoom) descriptor. That said, this is a direct migration of the table data, even though it looks a bit dubious. For example, I'm not sure what it means if a descriptor is supported in a version before the version where the actual at-rule is supported.

Let me know if you want to see any changes. Thanks!