### PR TITLE
Add compat data for <resolution> CSS type

### DIFF
--- a/css/types/resolution.json
+++ b/css/types/resolution.json
@@ -1,0 +1,117 @@
+{
+  "css": {
+    "types": {
+      "resolution": {
+        "__compat": {
+          "description": "&lt;resolution&gt;",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/resolution",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "29"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "9.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "dppx": {
+          "__compat": {
+            "description": "<code>dppx</code> units",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "29"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "16"
+              },
+              "firefox_android": {
+                "version_added": "16"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "12.1"
+              },
+              "opera_android": {
+                "version_added": "12.1"
+              },
+              "safari": [
+                {
+                  "alternative_name": "device-piexl-ratio",
+                  "version_added": true
+                },
+                {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=16832'>bug 16832</a>."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "alternative_name": "device-piexl-ratio",
+                  "version_added": true
+                },
+                {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=16832'>bug 16832</a>."
+                }
+              ]
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`<resolution>`](https://developer.mozilla.org/docs/Web/CSS/resolution). Let me know if you want to see any changes. Thanks!