### PR TITLE
Add compat data for <time> CSS type

### DIFF
--- a/css/types/time.json
+++ b/css/types/time.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "types": {
+      "time": {
+        "__compat": {
+          "description": "&lt;time&gt;",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/time",
+          "support": {
+            "webview_android": {
+              "version_added": "62"
+            },
+            "chrome": {
+              "version_added": "62"
+            },
+            "chrome_android": {
+              "version_added": "62"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "49"
+            },
+            "opera_android": {
+              "version_added": "49"
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`<time>`](https://developer.mozilla.org/docs/Web/CSS/time). Let me know if you want to see any changes. Thanks!