### PR TITLE
Add compat data for ImageBitmapRenderingContext

### DIFF
--- a/api/ImageBitmapRenderingContext.json
+++ b/api/ImageBitmapRenderingContext.json
@@ -1,0 +1,94 @@
+{
+  "api": {
+    "ImageBitmapRenderingContext": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageBitmapRenderingContext",
+        "support": {
+          "webview_android": {
+            "version_added": "55"
+          },
+          "chrome": {
+            "version_added": "55"
+          },
+          "chrome_android": {
+            "version_added": "55"
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "46"
+          },
+          "firefox_android": {
+            "version_added": "46"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "42"
+          },
+          "opera_android": {
+            "version_added": "42"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": false,
+          "deprecated": false
+        }
+      },
+      "transferImageBitmap() -> transferFromImageBitmap()": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/ImageBitmapRenderingContext.json
+++ b/api/ImageBitmapRenderingContext.json
@@ -47,8 +47,9 @@
           "deprecated": false
         }
       },
-      "transferImageBitmap() -> transferFromImageBitmap()": {
+      "transferFromImageBitmap": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageBitmapRenderingContext/transferFromImageBitmap",
           "support": {
             "webview_android": {
               "version_added": null
@@ -65,12 +66,26 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "52"
-            },
-            "firefox_android": {
-              "version_added": "52"
-            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "46",
+                "version_removed": "52",
+                "alternative_name": "transferImageBitmap"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "46",
+                "version_removed": "52",
+                "alternative_name": "transferImageBitmap"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -86,6 +101,11 @@
             "safari_ios": {
               "version_added": null
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
Wondering if there is a better way to represent : 

`transferImageBitmap() -> transferFromImageBitmap()`

Also as there was no Safari 55.0 - I assumed that data point was incorrect (https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmapRenderingContext)