### PR TITLE
Add compat data for track size `fit-content()`

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -296,6 +296,55 @@
               "deprecated": false
             }
           }
+        },
+        "fit-content": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/fit-content",
+            "description": "<code>fit-content()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "29"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": "16"
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": {
+                "version_added": "51"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "44"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -296,6 +296,55 @@
               "deprecated": false
             }
           }
+        },
+        "fit-content": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/fit-content",
+            "description": "<code>fit-content()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "29"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": "16"
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": {
+                "version_added": "51"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "44"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This PR migrates the data for [`fit-content`](https://developer.mozilla.org/docs/Web/CSS/fit-content), as it's used in `grid-template-*`. Let me know if you want to see any changes. Thanks!