### PR TITLE
Add compat data for Path2D

### DIFF
--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -49,6 +49,7 @@
       },
       "Path2D": {
         "__compat": {
+          "description": "<code>Path2D()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Path2D/Path2D",
           "support": {
             "webview_android": {

--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -1,0 +1,148 @@
+{
+  "api": {
+    "Path2D": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Path2D",
+        "support": {
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "31"
+          },
+          "firefox_android": {
+            "version_added": "31"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": "10"
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "Path2D": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Path2D/Path2D",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "addPath": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Path2D/addPath",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Note:

There is conflicting info about the `addPath` method:
https://developer.mozilla.org/en-US/docs/Web/API/Path2D
and
https://developer.mozilla.org/en-US/docs/Web/API/Path2D/addPath
esp. regarding Chrome.

I choose the data that seemed most sensible (ie if `webview_android` and `chrome_android` are supported then it's extremely likely that `chrome` is too).