### PR TITLE
Add compat data for TextMetrics

### DIFF
--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -95,15 +95,21 @@
           }
         }
       },
-      "actualBoundingBoxLeft, actualBoundingBoxRight, fontBoundingBoxAscent, fontBoundingBoxDescent, actualBoundingBoxAscent, actualBoundingBoxDescent, emHeightAscent, emHeightDescent, hangingBaseline, alphabeticBaseline, ideographicBaseline": {
+      "advanced_text_metrics": {
         "__compat": {
+          "description": "Advanced text metrics properties",
           "support": {
             "webview_android": {
               "version_added": null
             },
             "chrome": {
               "version_added": true,
-              "notes": "To turn on advanced text metrics, set the flag <code>ExperimentalCanvasFeatures</code> to <code>true</code>."
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "ExperimentalCanvasFeatures"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": null

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -1,0 +1,145 @@
+{
+  "api": {
+    "TextMetrics": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics",
+        "support": {
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome": {
+            "version_added": "4"
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "1.5"
+          },
+          "firefox_android": {
+            "version_added": "31"
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": "9"
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": "3.1"
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "width": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/width",
+          "support": {
+            "webview_android": {
+              "version_added": "2.1"
+            },
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "1.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "9"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "actualBoundingBoxLeft, actualBoundingBoxRight, fontBoundingBoxAscent, fontBoundingBoxDescent, actualBoundingBoxAscent, actualBoundingBoxDescent, emHeightAscent, emHeightDescent, hangingBaseline, alphabeticBaseline, ideographicBaseline": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": true,
+              "notes": "To turn on advanced text metrics, set the flag <code>ExperimentalCanvasFeatures</code> to <code>true</code>."
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Note:

I added ```actualBoundingBoxLeft,
actualBoundingBoxRight,
fontBoundingBoxAscent,
fontBoundingBoxDescent,
actualBoundingBoxAscent,
actualBoundingBoxDescent,
emHeightAscent,
emHeightDescent,
hangingBaseline,
alphabeticBaseline,
ideographicBaseline``` as one field reflecting the table here : https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics

But happy to separate into individual entries.