### PR TITLE
IntersectionObserver: order Firefox compat data correctly

### DIFF
--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -12,6 +12,9 @@
           },
           "firefox": [
             {
+              "version_added": "55"
+            },
+            {
               "version_added": "53",
               "version_removed": "55",
               "flags": [
@@ -21,9 +24,6 @@
                   "value_to_set": "true"
                 }
               ]
-            },
-            {
-              "version_added": "55"
             }
           ],
           "ie": {
@@ -58,6 +58,9 @@
             },
             "firefox": [
               {
+                "version_added": "55"
+              },
+              {
                 "version_added": "53",
                 "version_removed": "55",
                 "flags": [
@@ -67,9 +70,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "55"
               }
             ],
             "ie": {
@@ -104,6 +104,9 @@
             },
             "firefox": [
               {
+                "version_added": "55"
+              },
+              {
                 "version_added": "53",
                 "version_removed": "55",
                 "flags": [
@@ -113,9 +116,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "55"
               }
             ],
             "ie": {
@@ -150,6 +150,9 @@
             },
             "firefox": [
               {
+                "version_added": "55"
+              },
+              {
                 "version_added": "53",
                 "version_removed": "55",
                 "flags": [
@@ -159,9 +162,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "55"
               }
             ],
             "ie": {
@@ -196,6 +196,9 @@
             },
             "firefox": [
               {
+                "version_added": "55"
+              },
+              {
                 "version_added": "53",
                 "version_removed": "55",
                 "flags": [
@@ -205,9 +208,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "55"
               }
             ],
             "ie": {
@@ -243,6 +243,9 @@
             },
             "firefox": [
               {
+                "version_added": "55"
+              },
+              {
                 "version_added": "53",
                 "version_removed": "55",
                 "flags": [
@@ -252,9 +255,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "55"
               }
             ],
             "ie": {
@@ -289,6 +289,9 @@
             },
             "firefox": [
               {
+                "version_added": "55"
+              },
+              {
                 "version_added": "53",
                 "version_removed": "55",
                 "flags": [
@@ -298,9 +301,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "55"
               }
             ],
             "ie": {
@@ -336,6 +336,9 @@
             },
             "firefox": [
               {
+                "version_added": "55"
+              },
+              {
                 "version_added": "53",
                 "version_removed": "55",
                 "flags": [
@@ -345,9 +348,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "55"
               }
             ],
             "ie": {
@@ -383,6 +383,9 @@
             },
             "firefox": [
               {
+                "version_added": "55"
+              },
+              {
                 "version_added": "53",
                 "version_removed": "55",
                 "flags": [
@@ -392,9 +395,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "55"
               }
             ],
             "ie": {

--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -12,6 +12,9 @@
           },
           "firefox": [
             {
+              "version_added": "55"
+            },
+            {
               "version_added": "53",
               "version_removed": "55",
               "flags": [
@@ -21,9 +24,6 @@
                   "value_to_set": "true"
                 }
               ]
-            },
-            {
-              "version_added": "55"
             }
           ],
           "ie": {
@@ -57,6 +57,9 @@
             },
             "firefox": [
               {
+                "version_added": "55"
+              },
+              {
                 "version_added": "53",
                 "version_removed": "55",
                 "flags": [
@@ -66,9 +69,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "55"
               }
             ],
             "ie": {
@@ -103,6 +103,9 @@
             },
             "firefox": [
               {
+                "version_added": "55"
+              },
+              {
                 "version_added": "53",
                 "version_removed": "55",
                 "flags": [
@@ -112,9 +115,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "55"
               }
             ],
             "ie": {
@@ -149,6 +149,9 @@
             },
             "firefox": [
               {
+                "version_added": "55"
+              },
+              {
                 "version_added": "53",
                 "version_removed": "55",
                 "flags": [
@@ -158,9 +161,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "55"
               }
             ],
             "ie": {
@@ -195,6 +195,9 @@
             },
             "firefox": [
               {
+                "version_added": "55"
+              },
+              {
                 "version_added": "53",
                 "version_removed": "55",
                 "flags": [
@@ -204,9 +207,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "55"
               }
             ],
             "ie": {
@@ -241,6 +241,9 @@
             },
             "firefox": [
               {
+                "version_added": "55"
+              },
+              {
                 "version_added": "53",
                 "version_removed": "55",
                 "flags": [
@@ -250,9 +253,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "55"
               }
             ],
             "ie": {
@@ -287,6 +287,9 @@
             },
             "firefox": [
               {
+                "version_added": "55"
+              },
+              {
                 "version_added": "53",
                 "version_removed": "55",
                 "flags": [
@@ -296,9 +299,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "55"
               }
             ],
             "ie": {
@@ -333,6 +333,9 @@
             },
             "firefox": [
               {
+                "version_added": "55"
+              },
+              {
                 "version_added": "53",
                 "version_removed": "55",
                 "flags": [
@@ -342,9 +345,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "55"
               }
             ],
             "ie": {


### PR DESCRIPTION
This should fix https://github.com/mdn/browser-compat-data/issues/864