### PR TITLE
Mark CSS time type as shipped in Chromia.

### DIFF
--- a/css/types/time.json
+++ b/css/types/time.json
@@ -7,13 +7,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/time",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": true
             },
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -31,10 +31,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true

--- a/css/types/time.json
+++ b/css/types/time.json
@@ -7,13 +7,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/time",
           "support": {
             "webview_android": {
-              "version_added": true
+              "version_added": false
             },
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -31,10 +31,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false
             },
             "safari": {
               "version_added": true

--- a/css/types/time.json
+++ b/css/types/time.json
@@ -7,13 +7,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/time",
           "support": {
             "webview_android": {
-              "version_added": "62"
+              "version_added": false
             },
             "chrome": {
-              "version_added": "62"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "62"
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -31,10 +31,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "49"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "49"
+              "version_added": false
             },
             "safari": {
               "version_added": true


### PR DESCRIPTION
This can't be in 62/49 because the Intent to Ship was only [published yesterday](https://groups.google.com/a/chromium.org/d/topic/blink-dev/6ai8np0DSOA/discussion). 