### PR TITLE
Add compat data for @viewport's orientation descriptor

### DIFF
--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -400,6 +400,57 @@
             }
           }
         },
+        "orientation": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport/orientation",
+            "description": "<code>orientation</code> descriptor",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "prefix": "-ms-",
+                "version_added": "10"
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "prefix": "-o-",
+                "version_added": "8"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "width": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport/width",


### PR DESCRIPTION
This PR migrates the data for `@viewport`'s [`orientation` descriptor](https://developer.mozilla.org/docs/Web/CSS/@viewport/orientation). This is the last of the `@viewport`-related tables that has data to migrate (the others have no data). Let me know if you want to see any changes. Thanks!