### PR TITLE
Add compat data for <percentage> CSS type

### DIFF
--- a/css/types/percentage.json
+++ b/css/types/percentage.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "types": {
+      "percentage": {
+        "__compat": {
+          "description": "<code>&lt;percentage&gt;</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/percentage",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`<percentage>`](https://developer.mozilla.org/docs/Web/CSS/percentage). Let me know if you want to see any changes. Thanks!