### PR TITLE
Update section on calc in media query expressions

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -252,12 +252,16 @@
         },
         "63": {
           "release_date": "2017-12-06",
-          "status": "current"
+          "status": "retired"
         },
         "64": {
-          "status": "beta"
+          "release_date": "2018-01-23",
+          "status": "current"
         },
         "65": {
+          "status": "beta"
+        },
+        "66": {
           "status": "nightly"
         }
       }

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -286,15 +286,20 @@
         "49": {
           "release_date": "2017-11-08",
           "release_notes": "https://dev.opera.com/blog/opera-49/",
-          "status": "current"
+          "status": "retired"
         },
         "50": {
-          "status": "planned"
+          "release_date": "2018-01-04",
+          "release_notes": "https://dev.opera.com/blog/opera-50/",
+          "status": "current"
         },
         "51": {
-          "status": "planned"
+          "status": "beta"
         },
         "52": {
+          "status": "nightly"
+        },
+        "53": {
           "status": "planned"
         }
       }

--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -283,16 +283,16 @@
         },
         "media_query_values": {
           "__compat": {
-            "description": "Removal of <a href='https://developer.mozilla.org/docs/Web/CSS/Media_Queries'>Media query</a> value support",
+            "description": "<a href='https://developer.mozilla.org/docs/Web/CSS/Media_Queries'>Media query</a> value support",
             "support": {
               "webview_android": {
                 "version_added": false
               },
               "chrome": {
-                "version_added": false
+                "version_added": "66"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "66"
               },
               "edge": {
                 "version_added": false
@@ -301,9 +301,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "57",
-                "version_removed": "59",
-                "notes": "<code>calc()</code> was temporarily disabled in media query values due to the changeover to Stylo. In Firefox 59, support was added back in again."
+                "version_added": "59"
               },
               "firefox_android": {
                 "version_added": false
@@ -312,10 +310,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "53"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "53"
               },
               "safari": {
                 "version_added": false


### PR DESCRIPTION
Since support was never enabled in Firefox until Firefox 57, and was disabled before reaching stable, I don't think there's a reason to note the addition/removal cycle. Also add in versions for Chrome, Opera, and Android support.

Additionally, update the version history of browsers in browsers.json.