### PR TITLE
Add compat data for -*-appearance prefixed CSS properties

### DIFF
--- a/css/properties/-moz-appearance.json
+++ b/css/properties/-moz-appearance.json
@@ -1,0 +1,60 @@
+{
+  "css": {
+    "properties": {
+      "-moz-appearance": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-appearance",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "54"
+              },
+              {
+                "partial_implementation": true,
+                "version_added": "1"
+              }
+            ],
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-webkit-appearance.json
+++ b/css/properties/-webkit-appearance.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "-webkit-appearance": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-appearance",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`-moz-appearance`](https://developer.mozilla.org/docs/Web/CSS/-moz-appearance)/[`-webkit-appearance`](https://developer.mozilla.org/docs/Web/CSS/-webkit-appearance). I realize that it's a bit weird that they're not `alternative_name`s, but since there's no standard name yet, this seemed like the right approach. Let me know if you want to see any changes. Thanks!