### PR TITLE
Add compat data for -moz-context-properties CSS property

### DIFF
--- a/css/properties/-moz-context-properties.json
+++ b/css/properties/-moz-context-properties.json
@@ -1,0 +1,70 @@
+{
+  "css": {
+    "properties": {
+      "-moz-context-properties": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-context-properties",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "55",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "svg.context-properties.content.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "With the preference set to <code>false</code>, the property still works with SVGs via <code>chrome://</code> or <code>resource://</code> URLs"
+            },
+            "firefox_android": {
+              "version_added": "55",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "svg.context-properties.content.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "With the preference set to <code>false</code>, the property still works with SVGs via <code>chrome://</code> or <code>resource://</code> URLs"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`-moz-context-properties`](https://developer.mozilla.org/docs/Web/CSS/-moz-context-properties). Let me know if you want to see any changes. Thanks!