### PR TITLE
Further restrict identifiers

### DIFF
--- a/html/elements/td.json
+++ b/html/elements/td.json
@@ -476,7 +476,7 @@
               "deprecated": false
             }
           },
-          "rowspan=0": {
+          "rowspan_zero": {
             "__compat": {
               "description": "<code>rowspan</code> attribute with value <code>0</code> (extend to the end of the row group)",
               "support": {

--- a/html/elements/th.json
+++ b/html/elements/th.json
@@ -476,7 +476,7 @@
               "deprecated": false
             }
           },
-          "rowspan=0": {
+          "rowspan_zero": {
             "__compat": {
               "description": "<code>rowspan</code> attribute with value <code>0</code> (extend to the end of the row group)",
               "support": {

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -112,7 +112,7 @@
         "__compat": { "$ref": "#/definitions/compat_statement" }
       },
       "patternProperties":{
-        "^(?!__compat|.*\\.).+$" : { "$ref": "#/definitions/identifier" }
+        "^(?!__compat)[a-zA-Z_0-9-$@]*$" : { "$ref": "#/definitions/identifier" }
       },
       "additionalProperties": false
     },
@@ -127,7 +127,7 @@
 
   "type": "object",
   "patternProperties": {
-    "^(?!__compat|.*\\.).+$": { "$ref": "#/definitions/identifier" }
+    "^(?!__compat)[a-zA-Z_0-9-$@]*$": { "$ref": "#/definitions/identifier" }
   },
   "additionalProperties": false
 }

--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -45,7 +45,7 @@
                 }
               }
             },
-            "inspect()": {
+            "inspect": {
               "__compat": {
                 "support": {
                   "chrome": {


### PR DESCRIPTION
This should fix issue https://github.com/mdn/browser-compat-data/issues/887.

The goal of this PR is to restrict identifiers to only allow:
- a-z, A-Z
- 1-9 (for features containing numbers [Int8Array etc])
- $ (for "$0" properties etc)
- @ (for @@iterator symbols etc).
- "-" and "_"

Still disallowed at all is:
- `"__compat"`

This should avoid that we will end up with description-like identifiers and helps to have data accessed more easily. Also, this will catch things we've asked to correct in PR reviews before:
- `"Returns a DOMMatrix":` -> `"DOMMatrix_return_value"`
- `"addHitRegion()":` -> ` "addHitRegion"`
 