### PR TITLE
Add compat data for Body (Fetch API)

### DIFF
--- a/api/Body.json
+++ b/api/Body.json
@@ -7,9 +7,20 @@
           "webview_android": {
             "version_added": "42"
           },
-          "chrome": {
-            "version_added": "42"
-          },
+          "chrome": [
+            {
+              "version_added": "42"
+            },
+            {
+              "version_added": "41",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            }
+          ],
           "chrome_android": {
             "version_added": "42"
           },
@@ -28,7 +39,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": ""
+                  "name": "dom.fetch.enabled"
                 }
               ]
             }
@@ -57,8 +68,7 @@
       },
       "body": {
         "__compat": {
-          "description": "The <code>body</code> read-only property",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/Body/body",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/body",
           "support": {
             "webview_android": {
               "version_added": "52"
@@ -126,7 +136,7 @@
       },
       "bodyUsed": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/Body/bodyUsed",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/bodyUsed",
           "support": {
             "webview_android": {
               "version_added": false
@@ -140,7 +150,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -163,7 +173,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "dom.fetch.enabled"
                   }
                 ]
               }
@@ -183,7 +193,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -207,7 +217,7 @@
       },
       "arrayBuffer": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/Body/arrayBuffer",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/arrayBuffer",
           "support": {
             "webview_android": {
               "version_added": false
@@ -221,7 +231,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -244,7 +254,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "dom.fetch.enabled"
                   }
                 ]
               }
@@ -264,7 +274,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -288,7 +298,7 @@
       },
       "blob": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/Body/blob",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/blob",
           "support": {
             "webview_android": {
               "version_added": false
@@ -302,7 +312,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -325,7 +335,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "dom.fetch.enabled"
                   }
                 ]
               }
@@ -345,7 +355,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -369,7 +379,7 @@
       },
       "formData": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/Body/formData",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/formData",
           "support": {
             "webview_android": {
               "version_added": "60"
@@ -395,7 +405,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "dom.fetch.enabled"
                   }
                 ]
               }
@@ -428,7 +438,7 @@
       },
       "json": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/Body/json",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/json",
           "support": {
             "webview_android": {
               "version_added": false
@@ -442,7 +452,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -465,7 +475,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "dom.fetch.enabled"
                   }
                 ]
               }
@@ -485,7 +495,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -509,7 +519,7 @@
       },
       "text": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/Body/text",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/text",
           "support": {
             "webview_android": {
               "version_added": false
@@ -523,7 +533,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -546,7 +556,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "dom.fetch.enabled"
                   }
                 ]
               }
@@ -566,7 +576,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }

--- a/api/Body.json
+++ b/api/Body.json
@@ -1,0 +1,593 @@
+{
+  "api": {
+    "Body": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body",
+        "support": {
+          "webview_android": {
+            "version_added": "42"
+          },
+          "chrome": {
+            "version_added": "42"
+          },
+          "chrome_android": {
+            "version_added": "42"
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": [
+            {
+              "version_added": "39"
+            },
+            {
+              "version_added": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": ""
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "29"
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "body": {
+        "__compat": {
+          "description": "The <code>body</code> read-only property",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/Body/body",
+          "support": {
+            "webview_android": {
+              "version_added": "52"
+            },
+            "chrome": {
+              "version_added": "52"
+            },
+            "chrome_android": {
+              "version_added": "52"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.enabled"
+                },
+                {
+                  "type": "preference",
+                  "name": "javascript.options.streams"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": false,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.enabled"
+                },
+                {
+                  "type": "preference",
+                  "name": "javascript.options.streams"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "39"
+            },
+            "opera_android": {
+              "version_added": "39"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "bodyUsed": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/Body/bodyUsed",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "39"
+              },
+              {
+                "version_added": "34",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "arrayBuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/Body/arrayBuffer",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "39"
+              },
+              {
+                "version_added": "34",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "blob": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/Body/blob",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "39"
+              },
+              {
+                "version_added": "34",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "formData": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/Body/formData",
+          "support": {
+            "webview_android": {
+              "version_added": "60"
+            },
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "39"
+              },
+              {
+                "version_added": "34",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "47"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "json": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/Body/json",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "39"
+              },
+              {
+                "version_added": "34",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "text": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/Body/text",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "39"
+              },
+              {
+                "version_added": "34",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I'm not sure how to represent the preferences when current data is given like so:

```
[1] Behind a preference in version 41.

[2] Behind a preference starting with version 34.

[3] Behind a preference in version 28.
```
(https://developer.mozilla.org/en-US/docs/Web/API/Body/bodyUsed)

The `flags.name` field is required and cannot be null. As a temporary measure I have left it as an empty string.