### PR TITLE
Add bcd for :defined pseudo class (Web components)

### DIFF
--- a/css/selectors/defined.json
+++ b/css/selectors/defined.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "defined": {
+        "__compat": {
+          "description": "<code>:defined</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:defined",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Not supported in Firefox yet, but it is supported in Chrome/Opera/Safari. I couldn't find much information about exact versions, etc.