### PR TITLE
Add compat info for <optgroup> for Chrome, Fx, and IE

### DIFF
--- a/html/elements/optgroup.json
+++ b/html/elements/optgroup.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -21,13 +21,13 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": true
@@ -55,7 +55,7 @@
                 "version_added": true
               },
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -67,13 +67,13 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
-                "version_added": false
+                "version_added": "8"
               },
               "opera": {
                 "version_added": true
@@ -102,7 +102,7 @@
                 "version_added": true
               },
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": true
@@ -114,13 +114,13 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
-                "version_added": false
+                "version_added": "5.5"
               },
               "opera": {
                 "version_added": true


### PR DESCRIPTION
Per bug 1433377, compat versions for Chrome, Firefox,
and IE are added to the optgroup element here.