### PR TITLE
Add compat data for -webkit-overflow-scrolling CSS property

### DIFF
--- a/css/properties/-webkit-overflow-scrolling.json
+++ b/css/properties/-webkit-overflow-scrolling.json
@@ -44,7 +44,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-overflow-scrolling.json
+++ b/css/properties/-webkit-overflow-scrolling.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "-webkit-overflow-scrolling": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-overflow-scrolling",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": "5"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`-webkit-overflow-scrolling`](https://developer.mozilla.org/docs/Web/CSS/-webkit-overflow-scrolling). Let me know if you want to see any changes. Thanks!