### PR TITLE
Add data for toolbar_field_border

### DIFF
--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -419,6 +419,27 @@
               }
             }
           },
+          "toolbar_field_border": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "59"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
           "toolbar_field_text": {
             "__compat": {
               "support": {


### PR DESCRIPTION
Bug 1418603 adds a new property to the `theme` manifest key, `toolbar_field_border`.

https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/theme
https://bugzilla.mozilla.org/show_bug.cgi?id=1418603
https://searchfox.org/mozilla-central/diff/4aa48e5d9cd2c3ed2bc83771d35ba9845dc675d1/toolkit/components/extensions/schemas/theme.json#114