### PR TITLE
Add data for upgradeToSecure

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -22,6 +22,28 @@
                 "version_added": true
               }
             }
+          },
+          "upgradeToSecure": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/BlockingResponse",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "59"
+                },
+                "firefox_android": {
+                  "version_added": "59"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "HttpHeaders": {


### PR DESCRIPTION
Bug 1149250 adds a new property `upgradeToSecure` to `webRequest.BlockingResponse`:

https://bugzilla.mozilla.org/show_bug.cgi?id=1149250
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webRequest/BlockingResponse
https://searchfox.org/mozilla-central/diff/76ee06b33105a7ed059c2abefb24817852728f9c/toolkit/components/extensions/schemas/web_request.json#155
