### PR TITLE
Add compat data for Headers (Fetch API)

### DIFF
--- a/api/Headers.json
+++ b/api/Headers.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers",
         "support": {
           "webview_android": {
-            "version_added": "40"
+            "version_added": "42"
           },
           "chrome": {
-            "version_added": "52"
+            "version_added": "42"
           },
           "chrome_android": {
-            "version_added": "40"
+            "version_added": "42"
           },
           "edge": {
             "version_added": true
@@ -121,10 +121,10 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": "42"
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": "44"
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -209,9 +209,20 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/Headers",
           "description": "<code>Headers()</code> constructor",
           "support": {
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "chrome": [
               {
                 "version_added": "42"
@@ -226,9 +237,20 @@
                 ]
               }
             ],
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -269,9 +291,20 @@
                 ]
               }
             ],
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "safari": {
               "version_added": "10.1"
             },
@@ -290,9 +323,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/append",
           "support": {
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "chrome": [
               {
                 "version_added": "42"
@@ -307,9 +351,20 @@
                 ]
               }
             ],
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": true
             },
@@ -350,9 +405,20 @@
                 ]
               }
             ],
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "safari": {
               "version_added": "10.1"
             },
@@ -371,9 +437,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/delete",
           "support": {
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "chrome": [
               {
                 "version_added": "42"
@@ -388,9 +465,20 @@
                 ]
               }
             ],
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": true
             },
@@ -431,9 +519,20 @@
                 ]
               }
             ],
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "safari": {
               "version_added": "10.1"
             },
@@ -500,9 +599,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/get",
           "support": {
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "chrome": [
               {
                 "version_added": "42"
@@ -517,9 +627,20 @@
                 ]
               }
             ],
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": true
             },
@@ -564,9 +685,20 @@
                 ]
               }
             ],
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "safari": {
               "version_added": "10.1"
             },
@@ -649,9 +781,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/get",
           "support": {
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "chrome": [
               {
                 "version_added": "42"
@@ -666,9 +809,20 @@
                 ]
               }
             ],
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": true
             },
@@ -709,9 +863,20 @@
                 ]
               }
             ],
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "safari": {
               "version_added": false
             },
@@ -778,9 +943,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/set",
           "support": {
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "chrome": [
               {
                 "version_added": "42"
@@ -795,9 +971,20 @@
                 ]
               }
             ],
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": true
             },
@@ -838,9 +1025,20 @@
                 ]
               }
             ],
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
             "safari": {
               "version_added": false
             },

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -4,15 +4,48 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers",
         "support": {
-          "webview_android": {
-            "version_added": "42"
-          },
-          "chrome": {
-            "version_added": "42"
-          },
-          "chrome_android": {
-            "version_added": "42"
-          },
+          "webview_android": [
+            {
+              "version_added": "42"
+            },
+            {
+              "version_added": "41",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            }
+          ],
+          "chrome": [
+            {
+              "version_added": "42"
+            },
+            {
+              "version_added": "41",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "42"
+            },
+            {
+              "version_added": "41",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            }
+          ],
           "edge": {
             "version_added": true
           },
@@ -21,10 +54,6 @@
           },
           "firefox": [
             {
-              "version_added": "52",
-              "notes": "Prior to Firefox 52, <code>get()</code> only returned the first value in the specified header, with <code>getAll()</code> returning all values. From 52 onwards, <code>get()</code> now returns all values and <code>getAll()</code> has been deleted."
-            },
-            {
               "version_added": "39"
             },
             {
@@ -32,7 +61,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": ""
+                  "name": "dom.fetch.enabled"
                 }
               ]
             }
@@ -43,12 +72,34 @@
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": "29"
-          },
-          "opera_android": {
-            "version_added": "29"
-          },
+          "opera": [
+            {
+              "version_added": "29"
+            },
+            {
+              "version_added": "28",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "29"
+            },
+            {
+              "version_added": "28",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            }
+          ],
           "safari": {
             "version_added": "10.1"
           },
@@ -60,57 +111,6 @@
           "experimental": false,
           "standard_track": true,
           "deprecated": false
-        }
-      },
-      "advanced_header_methods": {
-        "__compat": {
-          "description": "advanced Header methods",
-          "support": {
-            "webview_android": {
-              "version_added": true,
-              "notes": "<code>entries()</code>, <code>keys()</code>, <code>values()</code>, and support of <code>for...of</code>"
-            },
-            "chrome": {
-              "version_added": true,
-              "notes": "<code>entries()</code>, <code>keys()</code>, <code>values()</code>, and support of <code>for...of</code>"
-            },
-            "chrome_android": {
-              "version_added": true,
-              "notes": "<code>entries()</code>, <code>keys()</code>, <code>values()</code>, and support of <code>for...of</code>"
-            },
-            "edge": {
-              "version_added": "16",
-              "notes": "<code>entries()</code>, <code>keys()</code>, <code>values()</code>, and support of <code>for...of</code>"
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "44",
-              "notes": "<code>entries()</code>, <code>keys()</code>, <code>values()</code>, and support of <code>for...of</code>"
-            },
-            "firefox_android": {
-              "version_added": "44",
-              "notes": "<code>entries()</code>, <code>keys()</code>, <code>values()</code>, and support of <code>for...of</code>"
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": true,
-              "notes": "<code>entries()</code>, <code>keys()</code>, <code>values()</code>, and support of <code>for...of</code>"
-            },
-            "opera_android": {
-              "version_added": true,
-              "notes": "<code>entries()</code>, <code>keys()</code>, <code>values()</code>, and support of <code>for...of</code>"
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            }
-          }
         }
       },
       "lexicographical_sorting": {
@@ -156,54 +156,6 @@
           }
         }
       },
-      "getall_removed": {
-        "__compat": {
-          "description": "getAll() removed",
-          "support": {
-            "webview_android": {
-              "version_added": "60"
-            },
-            "chrome": {
-              "version_added": "60"
-            },
-            "chrome_android": {
-              "version_added": "60"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": "45"
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": "47"
-            },
-            "opera_android": {
-              "version_added": "47"
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "headers": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/Headers",
@@ -218,7 +170,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -232,7 +184,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -246,7 +198,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -266,7 +218,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "dom.fetch.enabled"
                   }
                 ]
               }
@@ -286,7 +238,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -332,7 +284,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -346,7 +298,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -360,7 +312,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -380,7 +332,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "dom.fetch.enabled"
                   }
                 ]
               }
@@ -400,7 +352,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -414,7 +366,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -446,7 +398,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -460,7 +412,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -474,7 +426,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -494,7 +446,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "dom.fetch.enabled"
                   }
                 ]
               }
@@ -514,7 +466,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -528,7 +480,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -608,7 +560,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -622,7 +574,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -636,7 +588,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -660,7 +612,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "dom.fetch.enabled"
                   }
                 ]
               }
@@ -680,7 +632,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -694,7 +646,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -737,14 +689,15 @@
             },
             "firefox": [
               {
-                "version_added": "39"
+                "version_added": "39",
+                "version_removed": "52"
               },
               {
                 "version_added": "34",
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "dom.fetch.enabled"
                   }
                 ]
               }
@@ -790,7 +743,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -804,7 +757,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -818,7 +771,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -838,7 +791,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "dom.fetch.enabled"
                   }
                 ]
               }
@@ -858,7 +811,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -872,7 +825,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -952,7 +905,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -966,7 +919,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -980,7 +933,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -1000,7 +953,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "dom.fetch.enabled"
                   }
                 ]
               }
@@ -1020,7 +973,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }
@@ -1034,7 +987,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": ""
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               }

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -1,0 +1,908 @@
+{
+  "api": {
+    "Headers": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers",
+        "support": {
+          "webview_android": {
+            "version_added": "40"
+          },
+          "chrome": {
+            "version_added": "52"
+          },
+          "chrome_android": {
+            "version_added": "40"
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": [
+            {
+              "version_added": "52",
+              "notes": "Prior to Firefox 52, <code>get()</code> only returned the first value in the specified header, with <code>getAll()</code> returning all values. From 52 onwards, <code>get()</code> now returns all values and <code>getAll()</code> has been deleted."
+            },
+            {
+              "version_added": "39"
+            },
+            {
+              "version_added": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": ""
+                }
+              ]
+            }
+          ],
+          "firefox_android": {
+            "version_added": "44"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "29"
+          },
+          "opera_android": {
+            "version_added": "29"
+          },
+          "safari": {
+            "version_added": "10.1"
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "advanced_header_methods": {
+        "__compat": {
+          "description": "advanced Header methods",
+          "support": {
+            "webview_android": {
+              "version_added": true,
+              "notes": "<code>entries()</code>, <code>keys()</code>, <code>values()</code>, and support of <code>for...of</code>"
+            },
+            "chrome": {
+              "version_added": true,
+              "notes": "<code>entries()</code>, <code>keys()</code>, <code>values()</code>, and support of <code>for...of</code>"
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "<code>entries()</code>, <code>keys()</code>, <code>values()</code>, and support of <code>for...of</code>"
+            },
+            "edge": {
+              "version_added": "16",
+              "notes": "<code>entries()</code>, <code>keys()</code>, <code>values()</code>, and support of <code>for...of</code>"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "44",
+              "notes": "<code>entries()</code>, <code>keys()</code>, <code>values()</code>, and support of <code>for...of</code>"
+            },
+            "firefox_android": {
+              "version_added": "44",
+              "notes": "<code>entries()</code>, <code>keys()</code>, <code>values()</code>, and support of <code>for...of</code>"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true,
+              "notes": "<code>entries()</code>, <code>keys()</code>, <code>values()</code>, and support of <code>for...of</code>"
+            },
+            "opera_android": {
+              "version_added": true,
+              "notes": "<code>entries()</code>, <code>keys()</code>, <code>values()</code>, and support of <code>for...of</code>"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          }
+        }
+      },
+      "lexicographical_sorting": {
+        "__compat": {
+          "description": "Lexicographical sorting, and values from duplicate header names combined when iterated.",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "42"
+            },
+            "chrome_android": {
+              "version_added": "44"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "44"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "getall_removed": {
+        "__compat": {
+          "description": "getAll() removed",
+          "support": {
+            "webview_android": {
+              "version_added": "60"
+            },
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "45"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "47"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "headers": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/Headers",
+          "description": "<code>Headers()</code> constructor",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "39"
+              },
+              {
+                "version_added": "34",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "append": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/append",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "39"
+              },
+              {
+                "version_added": "34",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "delete": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/delete",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "39"
+              },
+              {
+                "version_added": "34",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "entries": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/entries",
+          "support": {
+            "webview_android": {
+              "version_added": "45"
+            },
+            "chrome": {
+              "version_added": "45"
+            },
+            "chrome_android": {
+              "version_added": "45"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "44"
+            },
+            "firefox_android": {
+              "version_added": "44"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "32"
+            },
+            "opera_android": {
+              "version_added": "32"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "get": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/get",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "52",
+                "notes": "Prior to Firefox 52, <code>get()</code> only returned the first value in the specified header, with <code>getAll()</code> returning all values. From 52 onwards, <code>get()</code> now returns all values and <code>getAll()</code> has been deleted."
+              },
+              {
+                "version_added": "39"
+              },
+              {
+                "version_added": "34",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getAll": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/getAll",
+          "support": {
+            "webview_android": {
+              "version_added": "42",
+              "version_removed": "60"
+            },
+            "chrome": {
+              "version_added": "42",
+              "version_removed": "60"
+            },
+            "chrome_android": {
+              "version_added": "42",
+              "version_removed": "60"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "39"
+              },
+              {
+                "version_added": "34",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29",
+              "version_removed": "47"
+            },
+            "opera_android": {
+              "version_added": "29",
+              "version_removed": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "has": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/get",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "39"
+              },
+              {
+                "version_added": "34",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keys": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/keys",
+          "support": {
+            "webview_android": {
+              "version_added": "45"
+            },
+            "chrome": {
+              "version_added": "45"
+            },
+            "chrome_android": {
+              "version_added": "45"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "44"
+            },
+            "firefox_android": {
+              "version_added": "44"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "32"
+            },
+            "opera_android": {
+              "version_added": "32"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "set": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/set",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "39"
+              },
+              {
+                "version_added": "34",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": ""
+                  }
+                ]
+              }
+            ],
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "values": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/values",
+          "support": {
+            "webview_android": {
+              "version_added": "45"
+            },
+            "chrome": {
+              "version_added": "45"
+            },
+            "chrome_android": {
+              "version_added": "45"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "44"
+            },
+            "firefox_android": {
+              "version_added": "44"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "32"
+            },
+            "opera_android": {
+              "version_added": "32"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This one is a little odd as it contains an entry for both "`getAll()` removed" (see the table here 
https://developer.mozilla.org/en-US/docs/Web/API/Headers)  and `getAll()`. I'm pretty sure the former is redundant - but am leaving it in just in case.
