### PR TITLE
Add compat data for -webkit-text-stroke-color CSS property

### DIFF
--- a/css/properties/-webkit-text-stroke-color.json
+++ b/css/properties/-webkit-text-stroke-color.json
@@ -1,0 +1,78 @@
+{
+  "css": {
+    "properties": {
+      "-webkit-text-stroke-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-text-stroke-color",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_added": "48",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_added": "48",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the data for [`-webkit-text-stroke-color`](https://developer.mozilla.org/docs/Web/CSS/-webkit-text-stroke-color). Let me know if you want to see any changes. Thanks!