### PR TITLE
Update String method support in Node.js

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -45,7 +45,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4"
               },
               "opera": {
                 "version_added": false
@@ -1537,7 +1537,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "8"
               },
               "opera": {
                 "version_added": "44"
@@ -1588,7 +1588,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "8"
               },
               "opera": {
                 "version_added": "44"
@@ -1743,7 +1743,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4"
               },
               "opera": {
                 "version_added": false
@@ -2965,7 +2965,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4"
               },
               "opera": {
                 "version_added": null
@@ -3016,7 +3016,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4"
               },
               "opera": {
                 "version_added": null


### PR DESCRIPTION
Adds version numbers reflecting the support for various String methods within Node.js

Tested by doing for e.g.:

`npx node@8 -e 'console.log(typeof String.prototype.padStart === 'function')'`