### PR TITLE
Mark basic JS features as supported in Fx 1 and FxA 4

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -836,10 +836,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -887,10 +887,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1143,10 +1143,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1653,10 +1653,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1806,10 +1806,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -1857,10 +1857,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/javascript/builtins/Boolean.json
+++ b/javascript/builtins/Boolean.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -71,10 +71,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -122,10 +122,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -173,10 +173,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -224,10 +224,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -73,10 +73,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true,
@@ -125,10 +125,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -176,10 +176,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -227,10 +227,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -278,10 +278,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -329,10 +329,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -380,10 +380,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -431,10 +431,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -482,10 +482,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -533,10 +533,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -584,10 +584,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -635,10 +635,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "5"
@@ -686,10 +686,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -737,10 +737,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -788,10 +788,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -839,10 +839,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -890,10 +890,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -941,10 +941,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -992,10 +992,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1043,10 +1043,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1094,10 +1094,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1148,7 +1148,7 @@
                 "version_added": "3"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -1196,10 +1196,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1249,7 +1249,7 @@
                   "version_added": "4"
                 },
                 "firefox_android": {
-                  "version_added": true
+                  "version_added": "4"
                 },
                 "ie": {
                   "version_added": "9"
@@ -1298,10 +1298,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1400,10 +1400,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1451,10 +1451,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1502,10 +1502,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1553,10 +1553,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1604,10 +1604,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1655,10 +1655,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1706,10 +1706,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1757,10 +1757,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1808,10 +1808,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1859,10 +1859,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1910,10 +1910,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1961,10 +1961,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2012,10 +2012,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2063,10 +2063,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2114,10 +2114,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2165,10 +2165,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2216,10 +2216,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2267,10 +2267,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2318,10 +2318,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -2369,10 +2369,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "8"
@@ -2420,10 +2420,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2675,10 +2675,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2877,10 +2877,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -3079,10 +3079,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -3130,10 +3130,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -3181,10 +3181,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -3232,10 +3232,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -3283,10 +3283,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "6"
@@ -71,10 +71,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "6"
@@ -122,10 +122,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -173,10 +173,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -224,10 +224,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -275,10 +275,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "6"
@@ -326,10 +326,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "6"
@@ -377,10 +377,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
@@ -428,10 +428,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -479,10 +479,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "6"

--- a/javascript/builtins/EvalError.json
+++ b/javascript/builtins/EvalError.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -122,10 +122,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -71,10 +71,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -122,10 +122,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -275,10 +275,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -377,10 +377,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -530,10 +530,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -581,10 +581,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -734,10 +734,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -838,10 +838,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -889,10 +889,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/javascript/builtins/InternalError.json
+++ b/javascript/builtins/InternalError.json
@@ -21,10 +21,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -22,10 +22,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -73,10 +73,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -124,10 +124,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -175,10 +175,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -226,10 +226,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -277,10 +277,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -328,10 +328,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -379,10 +379,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -430,10 +430,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -481,10 +481,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -583,10 +583,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -685,10 +685,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -736,10 +736,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -889,10 +889,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -991,10 +991,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1093,10 +1093,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1195,10 +1195,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1399,10 +1399,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1603,10 +1603,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1654,10 +1654,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1705,10 +1705,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1756,10 +1756,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1807,10 +1807,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1909,10 +1909,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2011,10 +2011,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2062,10 +2062,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -124,10 +124,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -226,10 +226,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -277,10 +277,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -328,10 +328,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -379,10 +379,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -430,10 +430,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -787,10 +787,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -838,10 +838,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -889,10 +889,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -993,10 +993,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1144,10 +1144,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1195,10 +1195,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -1246,10 +1246,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1297,10 +1297,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -71,10 +71,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -175,11 +175,11 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true,
+                "version_added": "1",
                 "version_removed": "43"
               },
               "firefox_android": {
-                "version_added": true,
+                "version_added": "4",
                 "version_removed": "43"
               },
               "ie": {
@@ -281,10 +281,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "11"
@@ -332,10 +332,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -386,7 +386,7 @@
                 "version_added": "34"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "34"
               },
               "ie": {
                 "version_added": false
@@ -488,7 +488,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -643,7 +643,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -746,7 +746,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "8"
@@ -848,7 +848,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -1052,7 +1052,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -1103,7 +1103,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -1154,7 +1154,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -1205,7 +1205,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -1308,7 +1308,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -1408,11 +1408,11 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true,
+                "version_added": "1",
                 "notes": "Starting with Firefox 48, this method can no longer be called at the global scope without any object. A <code>TypeError</code> will be thrown otherwise. Previously, the global object was used in these cases automatically, but this is no longer the case."
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "11"
@@ -1461,11 +1461,11 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true,
+                "version_added": "1",
                 "notes": "Starting with Firefox 48, this method can no longer be called at the global scope without any object. A <code>TypeError</code> will be thrown otherwise. Previously, the global object was used in these cases automatically, but this is no longer the case."
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "11"
@@ -1514,10 +1514,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "11"
@@ -1566,10 +1566,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "11"
@@ -1668,10 +1668,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1821,10 +1821,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1872,10 +1872,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -1923,10 +1923,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2027,10 +2027,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2134,7 +2134,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -2185,7 +2185,7 @@
                 "version_added": "31"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "31"
               },
               "ie": {
                 "version_added": "11"

--- a/javascript/builtins/RangeError.json
+++ b/javascript/builtins/RangeError.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/builtins/ReferenceError.json
+++ b/javascript/builtins/ReferenceError.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -71,10 +71,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -122,10 +122,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -224,10 +224,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -326,10 +326,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -429,10 +429,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -480,10 +480,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -532,10 +532,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -584,10 +584,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -636,10 +636,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -687,10 +687,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -790,10 +790,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -841,10 +841,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -893,10 +893,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -944,10 +944,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1301,10 +1301,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1352,10 +1352,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -1403,10 +1403,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -87,10 +87,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -140,7 +140,7 @@
                   "version_added": "40"
                 },
                 "firefox_android": {
-                  "version_added": true
+                  "version_added": "40"
                 },
                 "ie": {
                   "version_added": null
@@ -189,11 +189,11 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true,
+                "version_added": "1",
                 "notes": "Starting with version 17, the quotation mark (\") is replaced by its HTML reference character (<code>&quot;</code>) in strings supplied for the <code>name</code> parameter."
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -241,10 +241,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -292,10 +292,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -343,10 +343,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -394,10 +394,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -445,10 +445,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -547,10 +547,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -649,10 +649,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -700,10 +700,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -751,10 +751,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -802,10 +802,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -856,7 +856,7 @@
                 "version_added": "29"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "29"
               },
               "ie": {
                 "version_added": false
@@ -969,10 +969,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1020,10 +1020,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1071,10 +1071,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "6"
@@ -1122,10 +1122,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1173,10 +1173,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1224,10 +1224,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1375,10 +1375,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1424,11 +1424,12 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": true,
+                  "version_added": "1",
                   "version_removed": "49"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "4",
+                  "version_removed": "49"
                 },
                 "ie": {
                   "version_added": false
@@ -1480,7 +1481,7 @@
                 "version_added": "31"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "31"
               },
               "ie": {
                 "version_added": false
@@ -1630,10 +1631,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1681,11 +1682,11 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true,
+                "version_added": "1",
                 "version_removed": "37"
               },
               "firefox_android": {
-                "version_added": true,
+                "version_added": "4",
                 "version_removed": "37"
               },
               "ie": {
@@ -1836,10 +1837,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1885,11 +1886,12 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": true,
+                  "version_added": "1",
                   "version_removed": "49"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "4",
+                  "version_removed": "49"
                 },
                 "ie": {
                   "version_added": false
@@ -1938,10 +1940,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1987,11 +1989,12 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": true,
+                  "version_added": "1",
                   "version_removed": "49"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "4",
+                  "version_removed": "49"
                 },
                 "ie": {
                   "version_added": false
@@ -2040,10 +2043,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2091,10 +2094,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2142,10 +2145,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2244,10 +2247,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2295,10 +2298,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2346,10 +2349,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2397,10 +2400,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2448,10 +2451,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2499,10 +2502,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2600,10 +2603,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2701,10 +2704,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2752,10 +2755,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -2803,10 +2806,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2854,10 +2857,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -2908,7 +2911,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
@@ -2959,7 +2962,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -3010,7 +3013,7 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -3058,10 +3061,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/javascript/builtins/SyntaxError.json
+++ b/javascript/builtins/SyntaxError.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/builtins/TypeError.json
+++ b/javascript/builtins/TypeError.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/builtins/URIError.json
+++ b/javascript/builtins/URIError.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/builtins/globals.json
+++ b/javascript/builtins/globals.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -72,10 +72,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -123,10 +123,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -174,10 +174,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -225,10 +225,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -276,10 +276,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5.5"
@@ -327,10 +327,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -378,10 +378,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -429,10 +429,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -480,10 +480,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -531,10 +531,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -582,10 +582,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -633,10 +633,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -735,10 +735,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -786,10 +786,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -837,10 +837,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -20,10 +20,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": true
@@ -70,10 +70,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -120,10 +120,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "6"
@@ -223,10 +223,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -22,10 +22,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -126,10 +126,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -178,10 +178,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -230,10 +230,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -282,10 +282,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -334,10 +334,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -438,10 +438,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -490,10 +490,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -542,10 +542,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -800,10 +800,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -850,10 +850,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"

--- a/javascript/operators/arithmetic.json
+++ b/javascript/operators/arithmetic.json
@@ -23,10 +23,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -75,10 +75,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -127,10 +127,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -231,10 +231,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -283,10 +283,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -335,10 +335,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -387,10 +387,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -439,10 +439,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -491,10 +491,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/javascript/operators/assignment.json
+++ b/javascript/operators/assignment.json
@@ -23,10 +23,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -75,10 +75,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -127,10 +127,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -179,10 +179,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -231,10 +231,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -335,10 +335,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -387,10 +387,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -439,10 +439,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -491,10 +491,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -543,10 +543,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -595,10 +595,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -647,10 +647,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/javascript/operators/bitwise.json
+++ b/javascript/operators/bitwise.json
@@ -23,10 +23,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -75,10 +75,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -127,10 +127,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -179,10 +179,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -231,10 +231,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -283,10 +283,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -335,10 +335,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/javascript/operators/comma.json
+++ b/javascript/operators/comma.json
@@ -22,10 +22,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "3"

--- a/javascript/operators/comparison.json
+++ b/javascript/operators/comparison.json
@@ -23,10 +23,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -75,10 +75,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -127,10 +127,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -179,10 +179,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -231,10 +231,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -283,10 +283,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -335,10 +335,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -387,10 +387,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/javascript/operators/conditional.json
+++ b/javascript/operators/conditional.json
@@ -22,10 +22,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/operators/delete.json
+++ b/javascript/operators/delete.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/operators/function.json
+++ b/javascript/operators/function.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/operators/grouping.json
+++ b/javascript/operators/grouping.json
@@ -22,10 +22,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/operators/in.json
+++ b/javascript/operators/in.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/operators/instanceof.json
+++ b/javascript/operators/instanceof.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/operators/logical.json
+++ b/javascript/operators/logical.json
@@ -23,10 +23,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -75,10 +75,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -127,10 +127,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/javascript/operators/new.json
+++ b/javascript/operators/new.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/operators/property_accessors.json
+++ b/javascript/operators/property_accessors.json
@@ -22,10 +22,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/operators/this.json
+++ b/javascript/operators/this.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/operators/typeof.json
+++ b/javascript/operators/typeof.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/operators/void.json
+++ b/javascript/operators/void.json
@@ -21,10 +21,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -127,10 +127,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -178,10 +178,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -441,10 +441,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -492,10 +492,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -545,10 +545,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -673,10 +673,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "6"
@@ -725,10 +725,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -850,10 +850,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -956,10 +956,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "6"
@@ -1008,11 +1008,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "13",
+              "version_added": "14",
               "notes": "Prior to Firefox 51, using the <code>for...of</code> loop construct with the <code>const</code> keyword threw a <code>SyntaxError</code> (\"missing = in const declaration\")."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "ie": {
               "version_added": false
@@ -1111,10 +1111,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -1215,7 +1215,7 @@
                 "version_added": "52"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "52"
               },
               "ie": {
                 "version_added": null
@@ -1420,7 +1420,7 @@
                 "version_added": "52"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "52"
               },
               "ie": {
                 "version_added": null
@@ -1470,10 +1470,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -1601,10 +1601,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -1713,10 +1713,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -1764,10 +1764,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -1815,10 +1815,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -1867,10 +1867,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "6"
@@ -1917,10 +1917,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -1969,10 +1969,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -2020,10 +2020,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -2071,10 +2071,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1008,11 +1008,12 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "14",
+              "version_added": "13",
               "notes": "Prior to Firefox 51, using the <code>for...of</code> loop construct with the <code>const</code> keyword threw a <code>SyntaxError</code> (\"missing = in const declaration\")."
             },
             "firefox_android": {
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Prior to Firefox 51, using the <code>for...of</code> loop construct with the <code>const</code> keyword threw a <code>SyntaxError</code> (\"missing = in const declaration\")."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
I was bored in the train from Brussels to Bremen. All these JS features are pretty old and should be in Firefox 1 (and Fx Android 4). 