### PR TITLE
Add data for firstPartyDomain

### DIFF
--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -22,6 +22,27 @@
                 "version_added": true
               }
             }
+          },
+          "firstPartyDomain": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "59"
+                },
+                "firefox_android": {
+                  "version_added": "59"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "CookieStore": {
@@ -91,6 +112,27 @@
                 "version_added": true
               }
             }
+          },
+          "firstPartyDomain": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "59"
+                },
+                "firefox_android": {
+                  "version_added": "59"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "getAll": {
@@ -117,6 +159,27 @@
               },
               "opera": {
                 "version_added": true
+              }
+            }
+          },
+          "firstPartyDomain": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "59"
+                },
+                "firefox_android": {
+                  "version_added": "59"
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
           }
@@ -197,6 +260,27 @@
                 "version_added": true
               }
             }
+          },
+          "firstPartyDomain": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "59"
+                },
+                "firefox_android": {
+                  "version_added": "59"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "set": {
@@ -223,6 +307,27 @@
               },
               "opera": {
                 "version_added": true
+              }
+            }
+          },
+          "firstPartyDomain": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "59"
+                },
+                "firefox_android": {
+                  "version_added": "59"
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
           }


### PR DESCRIPTION
Bug 1381197 made the `cookies` API aware of first-party domains for cookies created when first-party isolation is on.

https://bugzilla.mozilla.org/show_bug.cgi?id=1381197
https://searchfox.org/mozilla-central/source/toolkit/components/extensions/schemas/cookies.json
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/cookies/Cookie
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/cookies/get
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/cookies/getAll
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/cookies/remove
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/cookies/set

