### PR TITLE
Added data for tabs.captureTab

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -712,6 +712,28 @@
             }
           }
         },
+        "captureTab": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/captureTab",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "59"
+              },
+              "firefox_android": {
+                "version_added": "59"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "captureVisibleTab": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/captureVisibleTab",
@@ -720,7 +742,7 @@
                 "notes": [
                   "The default file format is 'jpeg'."
                 ],
-                "version_added": true
+                "version_added": false
               },
               "edge": {
                 "version_added": "15"

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -742,7 +742,7 @@
                 "notes": [
                   "The default file format is 'jpeg'."
                 ],
-                "version_added": false
+                "version_added": true
               },
               "edge": {
                 "version_added": "15"


### PR DESCRIPTION
Bug 1427463 added a new API, `tabs.captureTab()`:

https://bugzilla.mozilla.org/show_bug.cgi?id=1427463
https://searchfox.org/mozilla-central/source/browser/components/extensions/schemas/tabs.json#1006-1025