### PR TITLE
Add BCD for :host/:host()/:host-content()

### DIFF
--- a/css/selectors/host-context.json
+++ b/css/selectors/host-context.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "hostfunction": {
+        "__compat": {
+          "description": "<code>:host-context()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:host-context()",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/host.json
+++ b/css/selectors/host.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "host": {
+        "__compat": {
+          "description": "<code>:host</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:host",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/hostfunction.json
+++ b/css/selectors/hostfunction.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "hostfunction": {
+        "__compat": {
+          "description": "<code>:host()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:host()",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
These have not been implemented in Firefox yet, but I thought I'd get them done quickly for completeness, while sorting out the web components documentation.