### PR TITLE
Add data for privacy.websites.cookieconfig

### DIFF
--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -91,6 +91,27 @@
           }
         },
         "websites": {
+          "cookieConfig": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "59"
+                },
+                "firefox_android": {
+                  "version_added": "59"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
           "firstPartyIsolate": {
             "__compat": {
               "support": {


### PR DESCRIPTION
Bug 1363860 added a new setting `cookieConfig` to the `privacy.websites` API:

https://bugzilla.mozilla.org/show_bug.cgi?id=1363860
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/privacy/websites