### PR TITLE
Added chrome and opera support of min-height:fill-available

### DIFF
--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -104,13 +104,13 @@
             "description": "<code>fill-available</code>",
             "support": {
               "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
                 "version_added": true
               },
+              "chrome": {
+                "version_added": "1"
+              },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": false
@@ -131,7 +131,7 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": "9"

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -107,7 +107,7 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": false
+                "version_added": true
               },
               "chrome_android": {
                 "version_added": null
@@ -128,7 +128,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null


### PR DESCRIPTION
Fixes #934 
I was unable to find the version they are supporting it since. Do you know of any resource to retrieve it?