### PR TITLE
String.prototype.includes is incorrectly marked as deprecated

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -959,7 +959,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },


### PR DESCRIPTION
The [compatibility table for `String.prototype.includes`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Browser_compatibility) shows that the “Basic support” is deprecated.

I assume the reason for this is that the data was originally converted from `String.prototype.contains` which indeed no longer exists. But of course [`includes` is actually propertly standardized](https://www.ecma-international.org/ecma-262/6.0/#sec-string.prototype.includes) and fine to use.