### PR TITLE
Update units: mozmm removed + capitalize Q

### DIFF
--- a/css/types/length.json
+++ b/css/types/length.json
@@ -313,7 +313,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": "4",
+                "version_removed": "59"
               },
               "firefox_android": {
                 "version_added": null

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -344,7 +344,7 @@
         },
         "Q": {
           "__compat": {
-            "description": "<code>q</code> unit",
+            "description": "<code>Q</code> unit",
             "support": {
               "webview_android": {
                 "version_added": false

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -342,7 +342,7 @@
             }
           }
         },
-        "q": {
+        "Q": {
           "__compat": {
             "description": "<code>q</code> unit",
             "support": {


### PR DESCRIPTION
The `mozmm` unit was removed in Firefox 59. Also, the `Q` unit should be capitalized.