### PR TITLE
Add Safari 11.1 beta as a valid version number

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -94,6 +94,10 @@
           "release_date": "2017-09-19",
           "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Safari_11_0/Safari_11_0.html",
           "status": "current"
+        },
+        "11.1": {
+          "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_11_1.html",
+          "status": "beta"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -79,6 +79,9 @@
         },
         "11": {
           "status": "current"
+        },
+        "11.1": {
+          "status": "beta"
         }
       }
     }


### PR DESCRIPTION
See https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_11_1.html