### PR TITLE
Add Array.prototype.flatten|flattenMap

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -459,6 +459,112 @@
             }
           }
         },
+        "flatten": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flatten",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "Available in Firefox Nightly only. See <a href='https://bugzil.la/1435813'>bug 1435813</a> for status on enabling this by default."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "Available in Firefox Nightly only. See <a href='https://bugzil.la/1435813'>bug 1435813</a> for status on enabling this by default."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "flattenMap": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flattenMap",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "Available in Firefox Nightly only. See <a href='https://bugzil.la/1435813'>bug 1435813</a> for status on enabling this by default."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "Available in Firefox Nightly only. See <a href='https://bugzil.la/1435813'>bug 1435813</a> for status on enabling this by default."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "forEach": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach",


### PR DESCRIPTION
Not yet in Chrome or elsewhere https://bugs.chromium.org/p/v8/issues/detail?id=7220
Firefox Nightly only for now: https://bugzilla.mozilla.org/show_bug.cgi?id=1421398

This is another candidate for https://github.com/mdn/browser-compat-data/issues/338