### PR TITLE
Adding compat data for Blob

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -1,0 +1,269 @@
+{
+  "api": {
+    "Blob": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob",
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": "5",
+            "notes": "A version of <code>slice()</code> taking the length as second argument was implemented in <a href='http://trac.webkit.org/changeset/55670'>WebKit</a> and <a href='http://www.opera.com/docs/specs/presto28/file/#blob'>Opera 11.10</a>. However, since that syntax differed from <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice'><code>Array.slice()</code></a> and <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice'><code>String.slice()</code></a>, WebKit removed support and added support for the new syntax as <a href='http://trac.webkit.org/changeset/83873'><code>Blob.webkitSlice()</code></a>."
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "4",
+            "notes": "A version of <code>slice()</code> taking the length as second argument was implemented in <a href='https://hg.mozilla.org/mozilla-central/rev/1b3947ed93c6'>Firefox 4</a>. However, since that syntax differed from <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice'><code>Array.slice()</code></a> and <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice'><code>String.slice()</code></a>, Gecko removed support and added support for the new syntax as <code>mozSlice()</code>."
+          },
+          "firefox_android": {
+            "version_added": "13"
+          },
+          "ie": {
+            "version_added": "10"
+          },
+          "opera": {
+            "version_added": "11",
+            "notes": "A version of <code>slice()</code> taking the length as second argument was implemented in <a href='http://trac.webkit.org/changeset/55670'>WebKit</a> and <a href='http://www.opera.com/docs/specs/presto28/file/#blob'>Opera 11.10</a>. However, since that syntax differed from <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice'><code>Array.slice()</code></a> and <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice'><code>String.slice()</code></a>, WebKit removed support and added support for the new syntax as <a href='http://trac.webkit.org/changeset/83873'><code>Blob.webkitSlice()</code></a>."
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": "5.1",
+            "notes": "A version of <code>slice()</code> taking the length as second argument was implemented in <a href='http://trac.webkit.org/changeset/55670'>WebKit</a> and <a href='http://www.opera.com/docs/specs/presto28/file/#blob'>Opera 11.10</a>. However, since that syntax differed from <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice'><code>Array.slice()</code></a> and <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice'><code>String.slice()</code></a>, WebKit removed support and added support for the new syntax as <a href='http://trac.webkit.org/changeset/83873'><code>Blob.webkitSlice()</code></a>."
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "Blob": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/Blob",
+          "description": "<code>Blob()</code> constructor",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "20"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "13",
+              "notes": "Before Firefox 16, the second parameter, when set to <code>null</code> or <code>undefined</code>, leads to an error instead of being handled as an empty dictionary."
+            },
+            "firefox_android": {
+              "version_added": "13",
+              "notes": "Before Firefox 16, the second parameter, when set to <code>null</code> or <code>undefined</code>, leads to an error instead of being handled as an empty dictionary."
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "size": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/size",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "5"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "type": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/type",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "5"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "slice": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/slice",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": [
+              {
+                "version_added": "21"
+              },
+              {
+                "version_added": "5",
+                "prefix": "webkit",
+                "notes": "The <code>slice()</code> method had initially taken <code>length</code> as the second argument to indicate the number of bytes to include in the new <code>Blob</code>. If you specified values such that <code>start + length</code> exceeded the size of the source <code>Blob</code>, the returned <code>Blob</code> contained data from the start index to the end of the source <code>Blob</code>.&nbsp;That version of the <code>slice()</code> was implemented in <a href='https://hg.mozilla.org/mozilla-central/rev/1b3947ed93c6'>Firefox 4</a>, <a href='http://trac.webkit.org/changeset/55670'>WebKit</a>, and <a href='http://www.opera.com/docs/specs/presto28/file/#blob'>Opera 11.10</a>. However, since that syntax is differed from <a href='/en-US/JavaScript/Reference/Global_Objects/Array/slice'><code>Array.slice()</code></a> and <a href='/en-US/JavaScript/Reference/Global_Objects/String/slice'><code>String.slice()</code></a>, Gecko and WebKit removed support and added support for the new syntax as <code>Blob.slice()</code>/<a href='http://trac.webkit.org/changeset/83873'><code>Blob.webkitSlice</code></a>."
+              }
+            ],
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "13",
+                "notes": "Prior to Gecko 12.0 (Firefox 12.0 / Thunderbird 12.0 / SeaMonkey 2.9), there was a bug that affected the behavior of <code>Blob.slice()</code>; it did not work for <code>start</code> and end positions outside the range of signed 64-bit values; it has now been fixed to support unsigned 64-bit values."
+              },
+              {
+                "version_added": "5",
+                "prefix": "moz",
+                "notes": "The <code>slice()</code> method had initially taken <code>length</code> as the second argument to indicate the number of bytes to include in the new <code>Blob</code>. If you specified values such that <code>start + length</code> exceeded the size of the source <code>Blob</code>, the returned <code>Blob</code> contained data from the start index to the end of the source <code>Blob</code>.&nbsp;That version of the <code>slice()</code> was implemented in <a href='https://hg.mozilla.org/mozilla-central/rev/1b3947ed93c6'>Firefox 4</a>, <a href='http://trac.webkit.org/changeset/55670'>WebKit</a>, and <a href='http://www.opera.com/docs/specs/presto28/file/#blob'>Opera 11.10</a>. However, since that syntax is differed from <a href='/en-US/JavaScript/Reference/Global_Objects/Array/slice'><code>Array.slice()</code></a> and <a href='/en-US/JavaScript/Reference/Global_Objects/String/slice'><code>String.slice()</code></a>, Gecko and WebKit removed support and added support for the new syntax as <code>Blob.slice()</code>/<a href='http://trac.webkit.org/changeset/83873'><code>Blob.webkitSlice</code></a>."
+              }
+            ],
+            "firefox_android": {
+              "version_added": "13"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "12",
+              "notes": "The <code>slice()</code> method had initially taken <code>length</code> as the second argument to indicate the number of bytes to include in the new <code>Blob</code>. If you specified values such that <code>start + length</code> exceeded the size of the source <code>Blob</code>, the returned <code>Blob</code> contained data from the start index to the end of the source <code>Blob</code>.&nbsp;That version of the <code>slice()</code> was implemented in <a href='https://hg.mozilla.org/mozilla-central/rev/1b3947ed93c6'>Firefox 4</a>, <a href='http://trac.webkit.org/changeset/55670'>WebKit</a>, and <a href='http://www.opera.com/docs/specs/presto28/file/#blob'>Opera 11.10</a>. However, since that syntax is differed from <a href='/en-US/JavaScript/Reference/Global_Objects/Array/slice'><code>Array.slice()</code></a> and <a href='/en-US/JavaScript/Reference/Global_Objects/String/slice'><code>String.slice()</code></a>, Gecko and WebKit removed support and added support for the new syntax as <code>Blob.slice()</code>/<a href='http://trac.webkit.org/changeset/83873'><code>Blob.webkitSlice</code></a>."
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "5.1",
+              "prefix": "webkit",
+              "notes": "This was implemented in <a href='http://trac.webkit.org/changeset/83873'>534.29</a>."
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -245,8 +245,7 @@
             },
             "safari": {
               "version_added": "5.1",
-              "prefix": "webkit",
-              "notes": "This was implemented in <a href='http://trac.webkit.org/changeset/83873'>534.29</a>."
+              "prefix": "webkit"
             },
             "safari_ios": {
               "version_added": null

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -25,7 +25,7 @@
             "notes": "A version of <code>slice()</code> taking the length as second argument was implemented in <a href='https://hg.mozilla.org/mozilla-central/rev/1b3947ed93c6'>Firefox 4</a>. However, since that syntax differed from <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice'><code>Array.slice()</code></a> and <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice'><code>String.slice()</code></a>, Gecko removed support and added support for the new syntax as <code>mozSlice()</code>."
           },
           "firefox_android": {
-            "version_added": "13"
+            "version_added": "14"
           },
           "ie": {
             "version_added": "10"
@@ -76,7 +76,7 @@
               "notes": "Before Firefox 16, the second parameter, when set to <code>null</code> or <code>undefined</code>, leads to an error instead of being handled as an empty dictionary."
             },
             "firefox_android": {
-              "version_added": "13",
+              "version_added": "14",
               "notes": "Before Firefox 16, the second parameter, when set to <code>null</code> or <code>undefined</code>, leads to an error instead of being handled as an empty dictionary."
             },
             "ie": {
@@ -211,6 +211,7 @@
               },
               {
                 "version_added": "5",
+                "version_removed": "21",
                 "prefix": "webkit",
                 "notes": "The <code>slice()</code> method had initially taken <code>length</code> as the second argument to indicate the number of bytes to include in the new <code>Blob</code>. If you specified values such that <code>start + length</code> exceeded the size of the source <code>Blob</code>, the returned <code>Blob</code> contained data from the start index to the end of the source <code>Blob</code>.&nbsp;That version of the <code>slice()</code> was implemented in <a href='https://hg.mozilla.org/mozilla-central/rev/1b3947ed93c6'>Firefox 4</a>, <a href='http://trac.webkit.org/changeset/55670'>WebKit</a>, and <a href='http://www.opera.com/docs/specs/presto28/file/#blob'>Opera 11.10</a>. However, since that syntax is differed from <a href='/en-US/JavaScript/Reference/Global_Objects/Array/slice'><code>Array.slice()</code></a> and <a href='/en-US/JavaScript/Reference/Global_Objects/String/slice'><code>String.slice()</code></a>, Gecko and WebKit removed support and added support for the new syntax as <code>Blob.slice()</code>/<a href='http://trac.webkit.org/changeset/83873'><code>Blob.webkitSlice</code></a>."
               }
@@ -231,12 +232,13 @@
               },
               {
                 "version_added": "5",
+                "version_removed": "13",
                 "prefix": "moz",
                 "notes": "The <code>slice()</code> method had initially taken <code>length</code> as the second argument to indicate the number of bytes to include in the new <code>Blob</code>. If you specified values such that <code>start + length</code> exceeded the size of the source <code>Blob</code>, the returned <code>Blob</code> contained data from the start index to the end of the source <code>Blob</code>.&nbsp;That version of the <code>slice()</code> was implemented in <a href='https://hg.mozilla.org/mozilla-central/rev/1b3947ed93c6'>Firefox 4</a>, <a href='http://trac.webkit.org/changeset/55670'>WebKit</a>, and <a href='http://www.opera.com/docs/specs/presto28/file/#blob'>Opera 11.10</a>. However, since that syntax is differed from <a href='/en-US/JavaScript/Reference/Global_Objects/Array/slice'><code>Array.slice()</code></a> and <a href='/en-US/JavaScript/Reference/Global_Objects/String/slice'><code>String.slice()</code></a>, Gecko and WebKit removed support and added support for the new syntax as <code>Blob.slice()</code>/<a href='http://trac.webkit.org/changeset/83873'><code>Blob.webkitSlice</code></a>."
               }
             ],
             "firefox_android": {
-              "version_added": "13"
+              "version_added": "14"
             },
             "ie": {
               "version_added": "10"

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -8,8 +8,7 @@
             "version_added": null
           },
           "chrome": {
-            "version_added": "5",
-            "notes": "A version of <code>slice()</code> taking the length as second argument was implemented in <a href='http://trac.webkit.org/changeset/55670'>WebKit</a> and <a href='http://www.opera.com/docs/specs/presto28/file/#blob'>Opera 11.10</a>. However, since that syntax differed from <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice'><code>Array.slice()</code></a> and <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice'><code>String.slice()</code></a>, WebKit removed support and added support for the new syntax as <a href='http://trac.webkit.org/changeset/83873'><code>Blob.webkitSlice()</code></a>."
+            "version_added": "5"
           },
           "chrome_android": {
             "version_added": null
@@ -21,8 +20,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "4",
-            "notes": "A version of <code>slice()</code> taking the length as second argument was implemented in <a href='https://hg.mozilla.org/mozilla-central/rev/1b3947ed93c6'>Firefox 4</a>. However, since that syntax differed from <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice'><code>Array.slice()</code></a> and <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice'><code>String.slice()</code></a>, Gecko removed support and added support for the new syntax as <code>mozSlice()</code>."
+            "version_added": "4"
           },
           "firefox_android": {
             "version_added": "14"
@@ -31,15 +29,13 @@
             "version_added": "10"
           },
           "opera": {
-            "version_added": "11",
-            "notes": "A version of <code>slice()</code> taking the length as second argument was implemented in <a href='http://trac.webkit.org/changeset/55670'>WebKit</a> and <a href='http://www.opera.com/docs/specs/presto28/file/#blob'>Opera 11.10</a>. However, since that syntax differed from <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice'><code>Array.slice()</code></a> and <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice'><code>String.slice()</code></a>, WebKit removed support and added support for the new syntax as <a href='http://trac.webkit.org/changeset/83873'><code>Blob.webkitSlice()</code></a>."
+            "version_added": "11"
           },
           "opera_android": {
             "version_added": null
           },
           "safari": {
-            "version_added": "5.1",
-            "notes": "A version of <code>slice()</code> taking the length as second argument was implemented in <a href='http://trac.webkit.org/changeset/55670'>WebKit</a> and <a href='http://www.opera.com/docs/specs/presto28/file/#blob'>Opera 11.10</a>. However, since that syntax differed from <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice'><code>Array.slice()</code></a> and <a href='/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice'><code>String.slice()</code></a>, WebKit removed support and added support for the new syntax as <a href='http://trac.webkit.org/changeset/83873'><code>Blob.webkitSlice()</code></a>."
+            "version_added": "5.1"
           },
           "safari_ios": {
             "version_added": null
@@ -212,8 +208,7 @@
               {
                 "version_added": "5",
                 "version_removed": "21",
-                "prefix": "webkit",
-                "notes": "The <code>slice()</code> method had initially taken <code>length</code> as the second argument to indicate the number of bytes to include in the new <code>Blob</code>. If you specified values such that <code>start + length</code> exceeded the size of the source <code>Blob</code>, the returned <code>Blob</code> contained data from the start index to the end of the source <code>Blob</code>.&nbsp;That version of the <code>slice()</code> was implemented in <a href='https://hg.mozilla.org/mozilla-central/rev/1b3947ed93c6'>Firefox 4</a>, <a href='http://trac.webkit.org/changeset/55670'>WebKit</a>, and <a href='http://www.opera.com/docs/specs/presto28/file/#blob'>Opera 11.10</a>. However, since that syntax is differed from <a href='/en-US/JavaScript/Reference/Global_Objects/Array/slice'><code>Array.slice()</code></a> and <a href='/en-US/JavaScript/Reference/Global_Objects/String/slice'><code>String.slice()</code></a>, Gecko and WebKit removed support and added support for the new syntax as <code>Blob.slice()</code>/<a href='http://trac.webkit.org/changeset/83873'><code>Blob.webkitSlice</code></a>."
+                "prefix": "webkit"
               }
             ],
             "chrome_android": {
@@ -233,8 +228,7 @@
               {
                 "version_added": "5",
                 "version_removed": "13",
-                "prefix": "moz",
-                "notes": "The <code>slice()</code> method had initially taken <code>length</code> as the second argument to indicate the number of bytes to include in the new <code>Blob</code>. If you specified values such that <code>start + length</code> exceeded the size of the source <code>Blob</code>, the returned <code>Blob</code> contained data from the start index to the end of the source <code>Blob</code>.&nbsp;That version of the <code>slice()</code> was implemented in <a href='https://hg.mozilla.org/mozilla-central/rev/1b3947ed93c6'>Firefox 4</a>, <a href='http://trac.webkit.org/changeset/55670'>WebKit</a>, and <a href='http://www.opera.com/docs/specs/presto28/file/#blob'>Opera 11.10</a>. However, since that syntax is differed from <a href='/en-US/JavaScript/Reference/Global_Objects/Array/slice'><code>Array.slice()</code></a> and <a href='/en-US/JavaScript/Reference/Global_Objects/String/slice'><code>String.slice()</code></a>, Gecko and WebKit removed support and added support for the new syntax as <code>Blob.slice()</code>/<a href='http://trac.webkit.org/changeset/83873'><code>Blob.webkitSlice</code></a>."
+                "prefix": "moz"
               }
             ],
             "firefox_android": {
@@ -244,8 +238,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "12",
-              "notes": "The <code>slice()</code> method had initially taken <code>length</code> as the second argument to indicate the number of bytes to include in the new <code>Blob</code>. If you specified values such that <code>start + length</code> exceeded the size of the source <code>Blob</code>, the returned <code>Blob</code> contained data from the start index to the end of the source <code>Blob</code>.&nbsp;That version of the <code>slice()</code> was implemented in <a href='https://hg.mozilla.org/mozilla-central/rev/1b3947ed93c6'>Firefox 4</a>, <a href='http://trac.webkit.org/changeset/55670'>WebKit</a>, and <a href='http://www.opera.com/docs/specs/presto28/file/#blob'>Opera 11.10</a>. However, since that syntax is differed from <a href='/en-US/JavaScript/Reference/Global_Objects/Array/slice'><code>Array.slice()</code></a> and <a href='/en-US/JavaScript/Reference/Global_Objects/String/slice'><code>String.slice()</code></a>, Gecko and WebKit removed support and added support for the new syntax as <code>Blob.slice()</code>/<a href='http://trac.webkit.org/changeset/83873'><code>Blob.webkitSlice</code></a>."
+              "version_added": "12"
             },
             "opera_android": {
               "version_added": null


### PR DESCRIPTION
Hey there all! Just dropping this here 😄 

Quick question about the notes in the first `Blob` entry though - should those be retained? That information is essentially wholesale duplicated in the actual compat data for `slice`, so it seems a little redundant to restate.

Fixes #969 