### PR TITLE
New browser settings for Firefox 59

### DIFF
--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -46,6 +46,28 @@
             }
           }
         },
+        "contextMenuShowEvent": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/contextMenuShowEvent",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "59"
+              },
+              "firefox_android": {
+                "version_added": "59"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "homepageOverride": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/homepageOverride",
@@ -105,6 +127,50 @@
               },
               "firefox_android": {
                 "version_added": "57"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "openBookmarksInNewTabs": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/openBookmarksInNewTabs",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "59"
+              },
+              "firefox_android": {
+                "version_added": "59"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "openSearchResultsInNewTabs": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/openSearchResultsInNewTabs",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "59"
+              },
+              "firefox_android": {
+                "version_added": "59"
               },
               "opera": {
                 "version_added": false


### PR DESCRIPTION
Yet more Firefox-only features:

* `browserSettings.contextMenuShowEvent`:  https://bugzilla.mozilla.org/show_bug.cgi?id=1419426
* `browserSettings.openBookmarksInNewTabs`: https://bugzilla.mozilla.org/show_bug.cgi?id=1420974
* `browserSettings.openSearchResultsInNewTabs`: https://bugzilla.mozilla.org/show_bug.cgi?id=1420969
