### PR TITLE
Correct method name: flattenMap -> flatMap

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -512,9 +512,9 @@
             }
           }
         },
-        "flattenMap": {
+        "flatMap": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flattenMap",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap",
             "support": {
               "webview_android": {
                 "version_added": false


### PR DESCRIPTION
I got this wrong. Sorry!
(see https://github.com/mdn/browser-compat-data/pull/985#issuecomment-364684656)