### PR TITLE
Array.prototype.values() shipped in FF and Chrome

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -2102,13 +2102,13 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/values",
             "support": {
               "webview_android": {
-                "version_added": false
+                "version_added": "66"
               },
               "chrome": {
-                "version_added": false
+                "version_added": "66"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "66"
               },
               "edge": {
                 "version_added": true
@@ -2117,11 +2117,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": false,
-                "notes": "Available in Firefox Nightly only due to compatibility issues."
+                "version_added": "60"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "60"
               },
               "ie": {
                 "version_added": false
@@ -2130,16 +2129,16 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "53"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "53"
               },
               "safari": {
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "9"
               }
             },
             "status": {


### PR DESCRIPTION
Firefox Site Compatibility: https://www.fxsitecompat.com/en-CA/docs/2018/array-prototype-values-is-now-enabled-again/
Chrome Platform Status: https://www.chromestatus.com/features/4755812090118144
