### PR TITLE
Add compat data for PaymentRequest

### DIFF
--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -1,0 +1,555 @@
+{
+  "api": {
+    "PaymentRequest": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest",
+        "support": {
+          "webview_android": {
+            "version_added": false
+          },
+          "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": {
+            "version_added": "53"
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "55",
+            "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+          },
+          "firefox_android": {
+            "version_added": "55",
+            "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "PaymentRequest": {
+        "__compat": {
+          "description": "<code>PaymentRequest</code>constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/PaymentRequest",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "firefox_android": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "requestId": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/requestId",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "firefox_android": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "shippingAddress": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/shippingAddress",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "firefox_android": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "shippingOption": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/shippingOption",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "firefox_android": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "shippingType": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/shippingType",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "56"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "firefox_android": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onshippingaddresschange": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/onshippingaddresschange",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "firefox_android": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onshippingoptionchange": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/onshippingoptionchange",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "firefox_android": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "canMakePayment": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/canMakePayment",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "56"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "firefox_android": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "show": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/show",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "firefox_android": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "abort": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/abort",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "firefox_android": {
+              "version_added": "55",
+              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -21,14 +21,26 @@
           },
           "firefox": {
             "version_added": "55",
-            "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.payments.request.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
             "version_added": "55",
-            "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.payments.request.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": false
@@ -71,14 +83,26 @@
             },
             "firefox": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -121,14 +145,26 @@
             },
             "firefox": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -171,14 +207,26 @@
             },
             "firefox": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -221,14 +269,26 @@
             },
             "firefox": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -271,14 +331,26 @@
             },
             "firefox": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -321,14 +393,26 @@
             },
             "firefox": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -371,14 +455,26 @@
             },
             "firefox": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -421,14 +517,26 @@
             },
             "firefox": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -471,14 +579,26 @@
             },
             "firefox": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -521,14 +641,26 @@
             },
             "firefox": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": "55",
-              "notes": "Feature is hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -63,7 +63,7 @@
       },
       "PaymentRequest": {
         "__compat": {
-          "description": "<code>PaymentRequest</code>constructor",
+          "description": "<code>PaymentRequest</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/PaymentRequest",
           "support": {
             "webview_android": {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest

Wasn't sure about secure context. Judging on previous discussion in this project, ~November, only API's that have changed should be flagged. As this is a new and experimental API, I've left this contect out.