### PR TITLE
Make line number not zero based for linter error reporting

### DIFF
--- a/test/test-style.js
+++ b/test/test-style.js
@@ -9,7 +9,7 @@ function jsonDiff(actual, expected) {
   for (var i = 0; i < actualLines.length; i++) {
     if (actualLines[i] !== expectedLines[i]) {
       return [
-        '#' + i + '\x1b[0m',
+        '#' + (i + 1) + '\x1b[0m',
         '    Actual:   ' + actualLines[i],
         '    Expected: ' + expectedLines[i]
       ].join('\n');


### PR DESCRIPTION
While I was debugging some styling issue with one of my compat JSON I realised that the `test-style.js` script would return the line number zero-based which left me a bit confused. 

To make the issue more clear to everyone. Let's imagine that we have trailing whitespaces on the first line. I would expect the linter to return something like the following: 

```
➜  $> npm run show-errors

> mdn-browser-compat-data@0.0.22 show-errors /Users/germain/dev/browser-compat-data
> npm test 1> /dev/null

  File : /Users/germain/dev/browser-compat-data/api/Body.json
  Style – Error on line #1
    Actual:   {
    Expected: {
``` 

However it currently returns the following

```
➜  $> npm run show-errors

> mdn-browser-compat-data@0.0.22 show-errors /Users/germain/dev/browser-compat-data
> npm test 1> /dev/null

  File : /Users/germain/dev/browser-compat-data/api/Body.json
  Style – Error on line #0
    Actual:   {
    Expected: {
``` 

Keen to hear your thoughts on this.
Thanks,