### PR TITLE
Add compat data for BlobBuilder

### DIFF
--- a/api/BlobBuilder.json
+++ b/api/BlobBuilder.json
@@ -1,0 +1,61 @@
+{
+  "api": {
+    "BlobBuilder": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/BlobBuilder",
+        "support": {
+          "webview_android": {
+            "version_added": "3",
+            "prefix": "Webkit"
+          },
+          "chrome": {
+            "version_added": "8",
+            "prefix": "Webkit"
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": null,
+            "version_removed": "18",
+            "prefix": "Moz",
+            "notes": "Starting in Firefox 14, using <code>MozBlobBuilder</code> will show a warning message in the web console that the use of <code>MozBlobBuilder</code> is deprecated and suggests to use <a href='/en-US/docs/Web/API/Blob'><code>Blob</code></a> constructor instead."
+          },
+          "firefox_android": {
+            "version_added": null,
+            "version_removed": "18",
+            "prefix": "Moz",
+            "notes": "Starting in Firefox 14, using <code>MozBlobBuilder</code> will show a warning message in the web console that the use of <code>MozBlobBuilder</code> is deprecated and suggests to use <a href='/en-US/docs/Web/API/Blob'><code>Blob</code></a> constructor instead."
+          },
+          "ie": {
+            "version_added": "10",
+            "prefix": "MS"
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hey all,
Quick question about this module - the only other compat data I can find on it is in relation to `getFile()`, which seems to have zero comparability _anywhere_. It doesn't have a seperate `mdn_url`, but I could technically use an anchored URL (i.e. `#getFile()`) to reference it. Would this be preferable, or will the bulk `BlobBuilder` block work alone?