### PR TITLE
Add compat data for PaymentRequestUpdateEvent

### DIFF
--- a/api/PaymentRequestUpdateEvent.json
+++ b/api/PaymentRequestUpdateEvent.json
@@ -1,0 +1,155 @@
+{
+  "api": {
+    "PaymentRequestUpdateEvent": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestUpdateEvent",
+        "support": {
+          "webview_android": {
+            "version_added": false
+          },
+          "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": {
+            "version_added": "52"
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "56",
+            "notes": "Hidden behind the <code>dom.payments.request.enabled</code> pref"
+          },
+          "firefox_android": {
+            "version_added": "56",
+            "notes": "Hidden behind the <code>dom.payments.request.enabled</code> pref"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "PaymentRequestUpdateEvent": {
+        "__compat": {
+          "description": "<code>PaymentRequestUpdateEvent()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestUpdateEvent/PaymentRequestUpdateEvent",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "52"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "56",
+              "notes": "Hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "firefox_android": {
+              "version_added": "56",
+              "notes": "Hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "updateWith": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestUpdateEvent/updateWith",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "52"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "56",
+              "notes": "Hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "firefox_android": {
+              "version_added": "56",
+              "notes": "Hidden behind the <code>dom.payments.request.enabled</code> pref"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/PaymentRequestUpdateEvent.json
+++ b/api/PaymentRequestUpdateEvent.json
@@ -21,14 +21,26 @@
           },
           "firefox": {
             "version_added": "56",
-            "notes": "Hidden behind the <code>dom.payments.request.enabled</code> pref"
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.payments.request.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
             "version_added": "56",
-            "notes": "Hidden behind the <code>dom.payments.request.enabled</code> pref"
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.payments.request.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": false
@@ -71,14 +83,26 @@
             },
             "firefox": {
               "version_added": "56",
-              "notes": "Hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": "56",
-              "notes": "Hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -121,14 +145,26 @@
             },
             "firefox": {
               "version_added": "56",
-              "notes": "Hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": "56",
-              "notes": "Hidden behind the <code>dom.payments.request.enabled</code> pref"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequestUpdateEvent

Been added but behind flag in Firefox: not sure if I've done this correctly, but it's a starting point.