### PR TITLE
Add compat data for FileError

### DIFF
--- a/api/FileError.json
+++ b/api/FileError.json
@@ -26,12 +26,12 @@
           "firefox": {
             "version_added": true,
             "version_removed": "13",
-            "notes": "The <code>FileError</code> interface has been removed starting with Gecko 13 (Firefox 13.0 / Thunderbird 13.0 / SeaMonkey 2.10). Instead the more general <a href='/en-US/docs/Web/API/DOMError'><code>DOMError</code></a> interface is used and returned by <a href='/en-US/docs/Web/API/FileReader'><code>FileReader.error</code></a>."
+            "notes": "The <code>FileError</code> interface has been removed starting with Firefox 13.0. Instead the more general <a href='/en-US/docs/Web/API/DOMError'><code>DOMError</code></a> interface is used and returned by <a href='/en-US/docs/Web/API/FileReader'><code>FileReader.error</code></a>."
           },
           "firefox_android": {
             "version_added": true,
             "version_removed": "14",
-            "notes": "The <code>FileError</code> interface has been removed starting with Gecko 13 (Firefox 13.0 / Thunderbird 13.0 / SeaMonkey 2.10). Instead the more general <a href='/en-US/docs/Web/API/DOMError'><code>DOMError</code></a> interface is used and returned by <a href='/en-US/docs/Web/API/FileReader'><code>FileReader.error</code></a>."
+            "notes": "The <code>FileError</code> interface has been removed starting with Firefox 13.0. Instead the more general <a href='/en-US/docs/Web/API/DOMError'><code>DOMError</code></a> interface is used and returned by <a href='/en-US/docs/Web/API/FileReader'><code>FileReader.error</code></a>."
           },
           "ie": {
             "version_added": false

--- a/api/FileError.json
+++ b/api/FileError.json
@@ -1,0 +1,60 @@
+{
+  "api": {
+    "FileError": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileError",
+        "support": {
+          "webview_android": {
+            "version_added": false
+          },
+          "chrome": {
+            "version_added": "13",
+            "version_removed": "53",
+            "prefix": "webkit"
+          },
+          "chrome_android": {
+            "version_added": "0.16",
+            "version_removed": "53",
+            "prefix": "webkit"
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": true,
+            "version_removed": "13",
+            "notes": "The <code>FileError</code> interface has been removed starting with Gecko 13 (Firefox 13.0 / Thunderbird 13.0 / SeaMonkey 2.10). Instead the more general <a href='/en-US/docs/Web/API/DOMError'><code>DOMError</code></a> interface is used and returned by <a href='/en-US/docs/Web/API/FileReader'><code>FileReader.error</code></a>."
+          },
+          "firefox_android": {
+            "version_added": true,
+            "version_removed": "14",
+            "notes": "The <code>FileError</code> interface has been removed starting with Gecko 13 (Firefox 13.0 / Thunderbird 13.0 / SeaMonkey 2.10). Instead the more general <a href='/en-US/docs/Web/API/DOMError'><code>DOMError</code></a> interface is used and returned by <a href='/en-US/docs/Web/API/FileReader'><code>FileReader.error</code></a>."
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hey All,

Adding the compat data for the [FileError](https://developer.mozilla.org/en-US/docs/Web/API/FileError) interface :smile: