### PR TITLE
add compat data for Cache

### DIFF
--- a/api/Cache.json
+++ b/api/Cache.json
@@ -1,0 +1,475 @@
+{
+  "api": {
+    "Cache": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Cache",
+        "support": {
+          "chrome": {
+            "version_added": "40",
+            "notes": [
+              "Available on global scope from version 43"
+            ]
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "39",
+            "notes": [
+              "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/firefox/organizations/'>Firefox 45 & 52 Extended Support Releases</a> (ESR.)"
+            ]
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "27",
+            "notes": [
+              "Available on global scope from version 30"
+            ]
+          },
+          "safari": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "40",
+            "notes": [
+              "Available on global scope from version 43"
+            ]
+          },
+          "chrome_android": {
+            "version_added": "40",
+            "notes": [
+              "Available on global scope from version 43"
+            ]
+          },
+          "firefox_android": {
+            "version_added": "39"
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": "27",
+            "notes": [
+              "Available on global scope from version 30"
+            ]
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "add": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Cache/add",
+          "support": {
+            "chrome": {
+              "version_added": "44",
+              "notes": [
+                "Require HTTPS from version 46"
+              ]
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "39",
+              "notes": [
+                "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/firefox/organizations/'>Firefox 45 & 52 Extended Support Releases</a> (ESR.)"
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "31",
+              "notes": [
+                "Require HTTPS from version 33"
+              ]
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "44",
+              "notes": [
+                "Require HTTPS from version 46"
+              ]
+            },
+            "chrome_android": {
+              "version_added": "44",
+              "notes": [
+                "Require HTTPS from version 46"
+              ]
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "31",
+              "notes": [
+                "Require HTTPS from version 33"
+              ]
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "addAll": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Cache/addAll",
+          "support": {
+            "chrome": {
+              "version_added": "46",
+              "notes": [
+                "Require HTTPS"
+              ]
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "39",
+              "notes": [
+                "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/firefox/organizations/'>Firefox 45 & 52 Extended Support Releases</a> (ESR.)"
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "33",
+              "notes": [
+                "Require HTTPS"
+              ]
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "46",
+              "notes": [
+                "Require HTTPS"
+              ]
+            },
+            "chrome_android": {
+              "version_added": "46",
+              "notes": [
+                "Require HTTPS"
+              ]
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "33",
+              "notes": [
+                "Require HTTPS"
+              ]
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "delete": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Cache/delete",
+          "support": {
+            "chrome": {
+              "version_added": "40"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "39",
+              "notes": [
+                "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/firefox/organizations/'>Firefox 45 & 52 Extended Support Releases</a> (ESR.)"
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "27"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "40"
+            },
+            "chrome_android": {
+              "version_added": "40"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "27"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keys": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Cache/keys",
+          "support": {
+            "chrome": {
+              "version_added": "40"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "39",
+              "notes": [
+                "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/firefox/organizations/'>Firefox 45 & 52 Extended Support Releases</a> (ESR.)"
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "27"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "40"
+            },
+            "chrome_android": {
+              "version_added": "40"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "27"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "match": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Cache/match",
+          "support": {
+            "chrome": {
+              "version_added": "40"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "39",
+              "notes": [
+                "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/firefox/organizations/'>Firefox 45 & 52 Extended Support Releases</a> (ESR.)"
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "27"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "40"
+            },
+            "chrome_android": {
+              "version_added": "40"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "27"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "matchAll": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Cache/matchAll",
+          "support": {
+            "chrome": {
+              "version_added": "47"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "39",
+              "notes": [
+                "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/firefox/organizations/'>Firefox 45 & 52 Extended Support Releases</a> (ESR.)"
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "34",
+              "notes": [
+                "Require HTTPS"
+              ]
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "47"
+            },
+            "chrome_android": {
+              "version_added": "47"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "34"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "put": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Cache/put",
+          "support": {
+            "chrome": {
+              "version_added": "40",
+              "notes": [
+                "Require HTTPS from version 46"
+              ]
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "39",
+              "notes": [
+                "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/firefox/organizations/'>Firefox 45 & 52 Extended Support Releases</a> (ESR.)"
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "27",
+              "notes": [
+                "Require HTTPS from version 33"
+              ]
+            },
+            "safari": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "40",
+              "notes": [
+                "Require HTTPS from version 46"
+              ]
+            },
+            "chrome_android": {
+              "version_added": "40",
+              "notes": [
+                "Require HTTPS from version 46"
+              ]
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "27",
+              "notes": [
+                "Require HTTPS from version 33"
+              ]
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Cache.json
+++ b/api/Cache.json
@@ -72,7 +72,7 @@
             "chrome": {
               "version_added": "44",
               "notes": [
-                "Require HTTPS from version 46"
+                "Requires HTTPS from version 46"
               ]
             },
             "edge": {
@@ -90,7 +90,7 @@
             "opera": {
               "version_added": "31",
               "notes": [
-                "Require HTTPS from version 33"
+                "Requires HTTPS from version 33"
               ]
             },
             "safari": {
@@ -99,13 +99,13 @@
             "webview_android": {
               "version_added": "44",
               "notes": [
-                "Require HTTPS from version 46"
+                "Requires HTTPS from version 46"
               ]
             },
             "chrome_android": {
               "version_added": "44",
               "notes": [
-                "Require HTTPS from version 46"
+                "Requires HTTPS from version 46"
               ]
             },
             "firefox_android": {
@@ -117,7 +117,7 @@
             "opera_android": {
               "version_added": "31",
               "notes": [
-                "Require HTTPS from version 33"
+                "Requires HTTPS from version 33"
               ]
             },
             "safari_ios": {
@@ -138,7 +138,7 @@
             "chrome": {
               "version_added": "46",
               "notes": [
-                "Require HTTPS"
+                "Requires HTTPS"
               ]
             },
             "edge": {
@@ -156,7 +156,7 @@
             "opera": {
               "version_added": "33",
               "notes": [
-                "Require HTTPS"
+                "Requires HTTPS"
               ]
             },
             "safari": {
@@ -165,13 +165,13 @@
             "webview_android": {
               "version_added": "46",
               "notes": [
-                "Require HTTPS"
+                "Requires HTTPS"
               ]
             },
             "chrome_android": {
               "version_added": "46",
               "notes": [
-                "Require HTTPS"
+                "Requires HTTPS"
               ]
             },
             "firefox_android": {
@@ -183,7 +183,7 @@
             "opera_android": {
               "version_added": "33",
               "notes": [
-                "Require HTTPS"
+                "Requires HTTPS"
               ]
             },
             "safari_ios": {
@@ -372,7 +372,7 @@
             "opera": {
               "version_added": "34",
               "notes": [
-                "Require HTTPS"
+                "Requires HTTPS"
               ]
             },
             "safari": {
@@ -411,7 +411,7 @@
             "chrome": {
               "version_added": "40",
               "notes": [
-                "Require HTTPS from version 46"
+                "Requires HTTPS from version 46"
               ]
             },
             "edge": {
@@ -429,7 +429,7 @@
             "opera": {
               "version_added": "27",
               "notes": [
-                "Require HTTPS from version 33"
+                "Requires HTTPS from version 33"
               ]
             },
             "safari": {
@@ -438,13 +438,13 @@
             "webview_android": {
               "version_added": "40",
               "notes": [
-                "Require HTTPS from version 46"
+                "Requires HTTPS from version 46"
               ]
             },
             "chrome_android": {
               "version_added": "40",
               "notes": [
-                "Require HTTPS from version 46"
+                "Requires HTTPS from version 46"
               ]
             },
             "firefox_android": {
@@ -456,7 +456,7 @@
             "opera_android": {
               "version_added": "27",
               "notes": [
-                "Require HTTPS from version 33"
+                "Requires HTTPS from version 33"
               ]
             },
             "safari_ios": {


### PR DESCRIPTION
Fixes #977

I've added the "global scope" or "HTTPS" data as notes for the browser that implemented those in different versions.

However, I was wondering whether, I should do a complex `support_statement` where I specify the fact that HTTPS is now required for a specific sub feature after version X? 
The schema does not really let me go to that much detail? Or maybe I haven't found what I needed in the documentation. What would you advise? 