### PR TITLE
updating pointer events BCD, as it is enabled in Fx59 desktop

### DIFF
--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -21,7 +21,7 @@
           },
           "firefox": [
             {
-              "version_added": false
+              "version_added": "59"
             },
             {
               "version_added": "41",
@@ -101,7 +101,7 @@
             },
             "firefox": [
               {
-                "version_added": false
+                "version_added": "59"
               },
               {
                 "version_added": "41",
@@ -181,7 +181,7 @@
             },
             "firefox": [
               {
-                "version_added": false
+                "version_added": "59"
               },
               {
                 "version_added": "41",
@@ -253,7 +253,7 @@
             },
             "firefox": [
               {
-                "version_added": false
+                "version_added": "59"
               },
               {
                 "version_added": "41",
@@ -332,7 +332,7 @@
             },
             "firefox": [
               {
-                "version_added": false
+                "version_added": "59"
               },
               {
                 "version_added": "41",
@@ -411,7 +411,7 @@
             },
             "firefox": [
               {
-                "version_added": false
+                "version_added": "59"
               },
               {
                 "version_added": "41",
@@ -490,7 +490,7 @@
             },
             "firefox": [
               {
-                "version_added": false
+                "version_added": "59"
               },
               {
                 "version_added": "54",
@@ -562,7 +562,7 @@
             },
             "firefox": [
               {
-                "version_added": false
+                "version_added": "59"
               },
               {
                 "version_added": "41",
@@ -634,7 +634,7 @@
             },
             "firefox": [
               {
-                "version_added": false
+                "version_added": "59"
               },
               {
                 "version_added": "41",
@@ -706,7 +706,7 @@
             },
             "firefox": [
               {
-                "version_added": false
+                "version_added": "59"
               },
               {
                 "version_added": "54",
@@ -778,7 +778,7 @@
             },
             "firefox": [
               {
-                "version_added": false
+                "version_added": "59"
               },
               {
                 "version_added": "41",
@@ -857,7 +857,7 @@
             },
             "firefox": [
               {
-                "version_added": false
+                "version_added": "59"
               },
               {
                 "version_added": "41",
@@ -928,7 +928,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "59"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1411467 for desktop enabling.

https://bugzilla.mozilla.org/show_bug.cgi?id=1426786 tracks enabling pointer events in Android.