### PR TITLE
Add compat data for PushManager

### DIFF
--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager",
         "support": {
           "webview_android": {
-            "version_added": "42"
+            "version_added": false
           },
           "chrome": {
             "version_added": "42"
@@ -70,7 +70,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/supportedContentEncodings",
           "support": {
             "webview_android": {
-              "version_added": "60"
+              "version_added": false
             },
             "chrome": {
               "version_added": "60"
@@ -136,7 +136,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/getSubscription",
           "support": {
             "webview_android": {
-              "version_added": "42"
+              "version_added": false
             },
             "chrome": {
               "version_added": "42"
@@ -202,7 +202,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/permissionState",
           "support": {
             "webview_android": {
-              "version_added": "42"
+              "version_added": false
             },
             "chrome": {
               "version_added": "42"
@@ -268,7 +268,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/subscribe",
           "support": {
             "webview_android": {
-              "version_added": "42"
+              "version_added": false
             },
             "chrome": {
               "version_added": "42"
@@ -334,7 +334,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/hasPermission",
           "support": {
             "webview_android": {
-              "version_added": "42"
+              "version_added": false
             },
             "chrome": {
               "version_added": "42"
@@ -400,7 +400,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/register",
           "support": {
             "webview_android": {
-              "version_added": "42"
+              "version_added": false
             },
             "chrome": {
               "version_added": "42"
@@ -466,7 +466,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/registrations",
           "support": {
             "webview_android": {
-              "version_added": "42"
+              "version_added": false
             },
             "chrome": {
               "version_added": "42"
@@ -532,7 +532,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/unregister",
           "support": {
             "webview_android": {
-              "version_added": "42"
+              "version_added": false
             },
             "chrome": {
               "version_added": "42"

--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -1,0 +1,598 @@
+{
+  "api": {
+    "PushManager": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager",
+        "support": {
+          "webview_android": {
+            "version_added": "42"
+          },
+          "chrome": {
+            "version_added": "42"
+          },
+          "chrome_android": {
+            "version_added": "42"
+          },
+          "edge": [
+            {
+              "version_added": "16",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable service workers"
+                }
+              ]
+            },
+            {
+              "version_added": "17"
+            }
+          ],
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "44",
+            "notes": [
+              "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45 and 52 Extended Support Releases</a> (ESR.)"
+            ]
+          },
+          "firefox_android": {
+            "version_added": "48",
+            "notes": "Push enabled by default."
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "29"
+          },
+          "opera_android": {
+            "version_added": "29"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "4.0"
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "supportedContentEncodings": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/supportedContentEncodings",
+          "support": {
+            "webview_android": {
+              "version_added": "60"
+            },
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": [
+              {
+                "version_added": "16",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable service workers"
+                  }
+                ]
+              },
+              {
+                "version_added": "17"
+              }
+            ],
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "44",
+              "notes": [
+                "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45 and 52 Extended Support Releases</a> (ESR.)"
+              ]
+            },
+            "firefox_android": {
+              "version_added": "48",
+              "notes": "Push enabled by default."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "47"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getSubscription": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/getSubscription",
+          "support": {
+            "webview_android": {
+              "version_added": "42"
+            },
+            "chrome": {
+              "version_added": "42"
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "edge": [
+              {
+                "version_added": "16",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable service workers"
+                  }
+                ]
+              },
+              {
+                "version_added": "17"
+              }
+            ],
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "44",
+              "notes": [
+                "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45 and 52 Extended Support Releases</a> (ESR.)"
+              ]
+            },
+            "firefox_android": {
+              "version_added": "48",
+              "notes": "Push enabled by default."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "permissionState": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/permissionState",
+          "support": {
+            "webview_android": {
+              "version_added": "42"
+            },
+            "chrome": {
+              "version_added": "42"
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "edge": [
+              {
+                "version_added": "16",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable service workers"
+                  }
+                ]
+              },
+              {
+                "version_added": "17"
+              }
+            ],
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "44",
+              "notes": [
+                "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45 and 52 Extended Support Releases</a> (ESR.)"
+              ]
+            },
+            "firefox_android": {
+              "version_added": "48",
+              "notes": "Push enabled by default."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "subscribe": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/subscribe",
+          "support": {
+            "webview_android": {
+              "version_added": "42"
+            },
+            "chrome": {
+              "version_added": "42"
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "edge": [
+              {
+                "version_added": "16",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable service workers"
+                  }
+                ]
+              },
+              {
+                "version_added": "17"
+              }
+            ],
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "44",
+              "notes": [
+                "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45 and 52 Extended Support Releases</a> (ESR.)"
+              ]
+            },
+            "firefox_android": {
+              "version_added": "48",
+              "notes": "Push enabled by default."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hasPermission": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/hasPermission",
+          "support": {
+            "webview_android": {
+              "version_added": "42"
+            },
+            "chrome": {
+              "version_added": "42"
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "edge": [
+              {
+                "version_added": "16",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable service workers"
+                  }
+                ]
+              },
+              {
+                "version_added": "17"
+              }
+            ],
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "44",
+              "notes": [
+                "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45 and 52 Extended Support Releases</a> (ESR.)"
+              ]
+            },
+            "firefox_android": {
+              "version_added": "48",
+              "notes": "Push enabled by default."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "register": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/register",
+          "support": {
+            "webview_android": {
+              "version_added": "42"
+            },
+            "chrome": {
+              "version_added": "42"
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "edge": [
+              {
+                "version_added": "16",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable service workers"
+                  }
+                ]
+              },
+              {
+                "version_added": "17"
+              }
+            ],
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "44",
+              "notes": [
+                "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45 and 52 Extended Support Releases</a> (ESR.)"
+              ]
+            },
+            "firefox_android": {
+              "version_added": "48",
+              "notes": "Push enabled by default."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "registrations": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/registrations",
+          "support": {
+            "webview_android": {
+              "version_added": "42"
+            },
+            "chrome": {
+              "version_added": "42"
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "edge": [
+              {
+                "version_added": "16",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable service workers"
+                  }
+                ]
+              },
+              {
+                "version_added": "17"
+              }
+            ],
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "44",
+              "notes": [
+                "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45 and 52 Extended Support Releases</a> (ESR.)"
+              ]
+            },
+            "firefox_android": {
+              "version_added": "48",
+              "notes": "Push enabled by default."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unregister": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/unregister",
+          "support": {
+            "webview_android": {
+              "version_added": "42"
+            },
+            "chrome": {
+              "version_added": "42"
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "edge": [
+              {
+                "version_added": "16",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable service workers"
+                  }
+                ]
+              },
+              {
+                "version_added": "17"
+              }
+            ],
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "44",
+              "notes": [
+                "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45 and 52 Extended Support Releases</a> (ESR.)"
+              ]
+            },
+            "firefox_android": {
+              "version_added": "48",
+              "notes": "Push enabled by default."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/PushManager

To reflect research earlier today: Edge 16 is behind flag, Edge 17 is enabled by default, and adding Samsung Internet 4.0.

ALL service worker and Push API will need editing to reflect this change. I'm proceeding immediately.