### PR TITLE
another attempt to get ShadowRoot added to BCD

### DIFF
--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -1,0 +1,355 @@
+{
+  "api": {
+    "ShadowRoot": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot",
+        "support": {
+          "webview_android": {
+            "version_added": "53"
+          },
+          "chrome": {
+            "version_added": "53"
+          },
+          "chrome_android": {
+            "version_added": "53"
+          },
+          "edge": {
+            "version_added": false,
+            "notes": "Under consideration"
+          },
+          "edge_mobile": {
+            "version_added": false,
+            "notes": "Under consideration"
+          },
+          "firefox": {
+            "version_added": "59",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webcomponents.enabled",
+                "value_to_set": "true"
+              },
+              {
+                "type": "preference",
+                "name": "dom.webcomponents.shadowdom.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
+          "firefox_android": {
+            "version_added": "59",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webcomponents.enabled",
+                "value_to_set": "true"
+              },
+              {
+                "type": "preference",
+                "name": "dom.webcomponents.shadowdom.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "40"
+          },
+          "opera_android": {
+            "version_added": "40"
+          },
+          "safari": {
+            "version_added": "10.1"
+          },
+          "safari_ios": {
+            "version_added": "10.1"
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "mode": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/mode",
+          "support": {
+            "webview_android": {
+              "version_added": "53"
+            },
+            "chrome": {
+              "version_added": "53"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": false,
+              "notes": "Under consideration"
+            },
+            "edge_mobile": {
+              "version_added": false,
+              "notes": "Under consideration"
+            },
+            "firefox": {
+              "version_added": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "40"
+            },
+            "opera_android": {
+              "version_added": "40"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.1"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "host": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/host",
+          "support": {
+            "webview_android": {
+              "version_added": "53"
+            },
+            "chrome": {
+              "version_added": "53"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": false,
+              "notes": "Under consideration"
+            },
+            "edge_mobile": {
+              "version_added": false,
+              "notes": "Under consideration"
+            },
+            "firefox": {
+              "version_added": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "40"
+            },
+            "opera_android": {
+              "version_added": "40"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.1"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "innerHTML": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/innerHTML",
+          "support": {
+            "webview_android": {
+              "version_added": "53"
+            },
+            "chrome": {
+              "version_added": "53"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": false,
+              "notes": "Under consideration"
+            },
+            "edge_mobile": {
+              "version_added": false,
+              "notes": "Under consideration"
+            },
+            "firefox": {
+              "version_added": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "40"
+            },
+            "opera_android": {
+              "version_added": "40"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.1"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "documentorshadowroot": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/mode",
+          "description": "Features included from the <a href='https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot'>DocumentOrShadowRoot</a> mixin",
+          "support": {
+            "webview_android": {
+              "version_added": "53"
+            },
+            "chrome": {
+              "version_added": "53"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": false,
+              "notes": "Features still implemented on the <a href='https://developer.mozilla.org/docs/Web/API/Document'>Document</a> interface"
+            },
+            "edge_mobile": {
+              "version_added": false,
+              "notes": "Features still implemented on the <a href='https://developer.mozilla.org/docs/Web/API/Document'>Document</a> interface"
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Features still implemented on the <a href='https://developer.mozilla.org/docs/Web/API/Document'>Document</a> interface"
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Features still implemented on the <a href='https://developer.mozilla.org/docs/Web/API/Document'>Document</a> interface"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "40"
+            },
+            "opera_android": {
+              "version_added": "40"
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Features still implemented on the <a href='https://developer.mozilla.org/docs/Web/API/Document'>Document</a> interface"
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Features still implemented on the <a href='https://developer.mozilla.org/docs/Web/API/Document'>Document</a> interface"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds ShadowRoot.json to the repo, as previous done in https://github.com/mdn/browser-compat-data/pull/1045, and fixes the comments made over there.

The reason I did this is that I accidentally deleted the fork the other PR was made on, so now it has become detached - note it now says "chrisdavidmills wants to merge 1 commit into mdn:master from unknown repository".

So carry on work in this repo, and don't merge the other one!

