### PR TITLE
Add QQ browser identifier (qq_android)

### DIFF
--- a/browsers/qq_android.json
+++ b/browsers/qq_android.json
@@ -1,0 +1,44 @@
+{
+  "browsers": {
+    "qq_android": {
+      "releases": {
+        "7.2.1": {
+          "relase_date": "2017-01-18",
+          "status": "retired"
+        },
+        "7.3.1": {
+          "relase_date": "2017-03-08",
+          "status": "retired"
+        },
+        "7.5": {
+          "relase_date": "2017-05-08",
+          "status": "retired"
+        },
+        "7.5.1": {
+          "relase_date": "2017-05-18",
+          "status": "retired"
+        },
+        "7.6.1": {
+          "relase_date": "2017-06-16",
+          "status": "retired"
+        },
+        "7.8": {
+          "relase_date": "2017-08-21",
+          "status": "retired"
+        },
+        "8.0": {
+          "relase_date": "2017-11-22",
+          "status": "retired"
+        },
+        "8.1.3": {
+          "relase_date": "2018-01-11",
+          "status": "retired"
+        },
+        "8.2": {
+          "relase_date": "2018-02-01",
+          "status": "current"
+        }
+      }
+    }
+  }
+}

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -17,6 +17,7 @@
         "nodejs": { "$ref": "#/definitions/browser_statement" },
         "opera": { "$ref": "#/definitions/browser_statement" },
         "opera_android": { "$ref": "#/definitions/browser_statement" },
+        "qq_android": { "$ref": "#/definitions/browser_statement" },
         "safari": { "$ref": "#/definitions/browser_statement" },
         "safari_ios": { "$ref": "#/definitions/browser_statement" },
         "samsunginternet_android": { "$ref": "#/definitions/browser_statement" }

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -106,6 +106,7 @@ The currently accepted browser identifiers should be declared in the following o
 * `nodejs` Node.js JavaScript runtime built on Chrome's V8 JavaScript engine,
 * `opera`, the Opera browser (desktop), based on Blink since Opera 15,
 * `opera_android`, the Opera browser (Android version),
+* `qq_android`, the QQ browser (Android version),
 * `safari`, Apple Safari, on Mac OS,
 * `safari_ios`, Apple Safari, on iOS,
 * `samsunginternet_android`, the Samsung Internet browser (Android version).

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -83,6 +83,7 @@
         "nodejs": { "$ref": "#/definitions/support_statement" },
         "opera": { "$ref": "#/definitions/support_statement" },
         "opera_android": { "$ref": "#/definitions/support_statement" },
+        "qq_android": { "$ref": "#/definitions/support_statement" },
         "safari": { "$ref": "#/definitions/support_statement" },
         "safari_ios": { "$ref": "#/definitions/support_statement" },
         "samsunginternet_android": { "$ref": "#/definitions/support_statement" }


### PR DESCRIPTION
The versions are from
https://github.com/GoogleChromeLabs/confluence/pull/248 with the
addition of 8.2 which was just released:
https://web.archive.org/web/20180203145110/http://mb.qq.com/

This is QQ浏览器, the Chinese-language version.

Fixes https://github.com/mdn/browser-compat-data/issues/1073.