### PR TITLE
Add compat data for SubtleCrypto

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -26,8 +26,7 @@
             "version_added": "34"
           },
           "ie": {
-            "version_added": "11",
-            "prefix": "msCrypto"
+            "version_added": "11"
           },
           "opera": {
             "version_added": "24"
@@ -36,12 +35,10 @@
             "version_added": "37"
           },
           "safari": {
-            "version_added": "8",
-            "prefix": "webkitCrypto"
+            "version_added": "8"
           },
           "safari_ios": {
-            "version_added": null,
-            "prefix": "webkitCrypto.subtle"
+            "version_added": null
           }
         },
         "status": {
@@ -76,8 +73,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "11",
-              "prefix": "msCrypto"
+              "version_added": "11"
             },
             "opera": {
               "version_added": "24"
@@ -86,12 +82,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "8",
-              "prefix": "webkitCrypto"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null,
-              "prefix": "webkitCrypto.subtle"
+              "version_added": null
             }
           },
           "status": {
@@ -127,8 +121,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "11",
-              "prefix": "msCrypto"
+              "version_added": "11"
             },
             "opera": {
               "version_added": "24"
@@ -137,12 +130,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "8",
-              "prefix": "webkitCrypto"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null,
-              "prefix": "webkitCrypto.subtle"
+              "version_added": null
             }
           },
           "status": {
@@ -178,8 +169,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "11",
-              "prefix": "msCrypto"
+              "version_added": "11"
             },
             "opera": {
               "version_added": "24"
@@ -188,12 +178,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "8",
-              "prefix": "webkitCrypto"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null,
-              "prefix": "webkitCrypto.subtle"
+              "version_added": null
             }
           },
           "status": {
@@ -229,8 +217,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "11",
-              "prefix": "msCrypto"
+              "version_added": "11"
             },
             "opera": {
               "version_added": "24"
@@ -239,12 +226,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "8",
-              "prefix": "webkitCrypto"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null,
-              "prefix": "webkitCrypto.subtle"
+              "version_added": null
             }
           },
           "status": {
@@ -280,8 +265,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "11",
-              "prefix": "msCrypto"
+              "version_added": "11"
             },
             "opera": {
               "version_added": "24"
@@ -290,12 +274,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "8",
-              "prefix": "webkitCrypto"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null,
-              "prefix": "webkitCrypto.subtle"
+              "version_added": null
             }
           },
           "status": {
@@ -331,8 +313,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "11",
-              "prefix": "msCrypto"
+              "version_added": "11"
             },
             "opera": {
               "version_added": "24"
@@ -341,12 +322,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "8",
-              "prefix": "webkitCrypto"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null,
-              "prefix": "webkitCrypto.subtle"
+              "version_added": null
             }
           },
           "status": {
@@ -382,8 +361,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "11",
-              "prefix": "msCrypto"
+              "version_added": "11"
             },
             "opera": {
               "version_added": "24"
@@ -392,12 +370,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "8",
-              "prefix": "webkitCrypto"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null,
-              "prefix": "webkitCrypto.subtle"
+              "version_added": null
             }
           },
           "status": {
@@ -433,8 +409,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "11",
-              "prefix": "msCrypto"
+              "version_added": "11"
             },
             "opera": {
               "version_added": "24"
@@ -443,12 +418,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "8",
-              "prefix": "webkitCrypto"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null,
-              "prefix": "webkitCrypto.subtle"
+              "version_added": null
             }
           },
           "status": {
@@ -484,8 +457,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "11",
-              "prefix": "msCrypto"
+              "version_added": "11"
             },
             "opera": {
               "version_added": "24"
@@ -494,12 +466,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "8",
-              "prefix": "webkitCrypto"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null,
-              "prefix": "webkitCrypto.subtle"
+              "version_added": null
             }
           },
           "status": {
@@ -535,8 +505,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "11",
-              "prefix": "msCrypto"
+              "version_added": "11"
             },
             "opera": {
               "version_added": "24"
@@ -545,12 +514,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "8",
-              "prefix": "webkitCrypto"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null,
-              "prefix": "webkitCrypto.subtle"
+              "version_added": null
             }
           },
           "status": {
@@ -586,8 +553,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "11",
-              "prefix": "msCrypto"
+              "version_added": "11"
             },
             "opera": {
               "version_added": "24"
@@ -596,12 +562,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "8",
-              "prefix": "webkitCrypto"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null,
-              "prefix": "webkitCrypto.subtle"
+              "version_added": null
             }
           },
           "status": {
@@ -637,8 +601,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "11",
-              "prefix": "msCrypto"
+              "version_added": "11"
             },
             "opera": {
               "version_added": "24"
@@ -647,12 +610,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "8",
-              "prefix": "webkitCrypto"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null,
-              "prefix": "webkitCrypto.subtle"
+              "version_added": null
             }
           },
           "status": {

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -1,0 +1,667 @@
+{
+  "api": {
+    "SubtleCrypto": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto",
+        "support": {
+          "webview_android": {
+            "version_added": "53"
+          },
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "34"
+          },
+          "firefox_android": {
+            "version_added": "34"
+          },
+          "ie": {
+            "version_added": "11",
+            "prefix": "msCrypto"
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "37"
+          },
+          "safari": {
+            "version_added": "8",
+            "prefix": "webkitCrypto"
+          },
+          "safari_ios": {
+            "version_added": null,
+            "prefix": "webkitCrypto.subtle"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "encrypt": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/encrypt",
+          "support": {
+            "webview_android": {
+              "version_added": "53"
+            },
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
+            "ie": {
+              "version_added": "11",
+              "prefix": "msCrypto"
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "37"
+            },
+            "safari": {
+              "version_added": "8",
+              "prefix": "webkitCrypto"
+            },
+            "safari_ios": {
+              "version_added": null,
+              "prefix": "webkitCrypto.subtle"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "decrypt": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/decrypt",
+          "support": {
+            "webview_android": {
+              "version_added": "53"
+            },
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
+            "ie": {
+              "version_added": "11",
+              "prefix": "msCrypto"
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "37"
+            },
+            "safari": {
+              "version_added": "8",
+              "prefix": "webkitCrypto"
+            },
+            "safari_ios": {
+              "version_added": null,
+              "prefix": "webkitCrypto.subtle"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sign": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign",
+          "support": {
+            "webview_android": {
+              "version_added": "53"
+            },
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
+            "ie": {
+              "version_added": "11",
+              "prefix": "msCrypto"
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "37"
+            },
+            "safari": {
+              "version_added": "8",
+              "prefix": "webkitCrypto"
+            },
+            "safari_ios": {
+              "version_added": null,
+              "prefix": "webkitCrypto.subtle"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "verify": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/verify",
+          "support": {
+            "webview_android": {
+              "version_added": "53"
+            },
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
+            "ie": {
+              "version_added": "11",
+              "prefix": "msCrypto"
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "37"
+            },
+            "safari": {
+              "version_added": "8",
+              "prefix": "webkitCrypto"
+            },
+            "safari_ios": {
+              "version_added": null,
+              "prefix": "webkitCrypto.subtle"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "digest": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/digest",
+          "support": {
+            "webview_android": {
+              "version_added": "53"
+            },
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
+            "ie": {
+              "version_added": "11",
+              "prefix": "msCrypto"
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "37"
+            },
+            "safari": {
+              "version_added": "8",
+              "prefix": "webkitCrypto"
+            },
+            "safari_ios": {
+              "version_added": null,
+              "prefix": "webkitCrypto.subtle"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "generateKey": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/generateKey",
+          "support": {
+            "webview_android": {
+              "version_added": "53"
+            },
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
+            "ie": {
+              "version_added": "11",
+              "prefix": "msCrypto"
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "37"
+            },
+            "safari": {
+              "version_added": "8",
+              "prefix": "webkitCrypto"
+            },
+            "safari_ios": {
+              "version_added": null,
+              "prefix": "webkitCrypto.subtle"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deriveKey": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveKey",
+          "support": {
+            "webview_android": {
+              "version_added": "53"
+            },
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
+            "ie": {
+              "version_added": "11",
+              "prefix": "msCrypto"
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "37"
+            },
+            "safari": {
+              "version_added": "8",
+              "prefix": "webkitCrypto"
+            },
+            "safari_ios": {
+              "version_added": null,
+              "prefix": "webkitCrypto.subtle"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deriveBits": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveBits",
+          "support": {
+            "webview_android": {
+              "version_added": "53"
+            },
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
+            "ie": {
+              "version_added": "11",
+              "prefix": "msCrypto"
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "37"
+            },
+            "safari": {
+              "version_added": "8",
+              "prefix": "webkitCrypto"
+            },
+            "safari_ios": {
+              "version_added": null,
+              "prefix": "webkitCrypto.subtle"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "importKey": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/importKey",
+          "support": {
+            "webview_android": {
+              "version_added": "53"
+            },
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
+            "ie": {
+              "version_added": "11",
+              "prefix": "msCrypto"
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "37"
+            },
+            "safari": {
+              "version_added": "8",
+              "prefix": "webkitCrypto"
+            },
+            "safari_ios": {
+              "version_added": null,
+              "prefix": "webkitCrypto.subtle"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "exportKey": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/exportKey",
+          "support": {
+            "webview_android": {
+              "version_added": "53"
+            },
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
+            "ie": {
+              "version_added": "11",
+              "prefix": "msCrypto"
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "37"
+            },
+            "safari": {
+              "version_added": "8",
+              "prefix": "webkitCrypto"
+            },
+            "safari_ios": {
+              "version_added": null,
+              "prefix": "webkitCrypto.subtle"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "wrapKey": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/wrapKey",
+          "support": {
+            "webview_android": {
+              "version_added": "53"
+            },
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
+            "ie": {
+              "version_added": "11",
+              "prefix": "msCrypto"
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "37"
+            },
+            "safari": {
+              "version_added": "8",
+              "prefix": "webkitCrypto"
+            },
+            "safari_ios": {
+              "version_added": null,
+              "prefix": "webkitCrypto.subtle"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unwrapKey": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/unwrapKey",
+          "support": {
+            "webview_android": {
+              "version_added": "53"
+            },
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
+            "ie": {
+              "version_added": "11",
+              "prefix": "msCrypto"
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "8",
+              "prefix": "webkitCrypto"
+            },
+            "safari_ios": {
+              "version_added": null,
+              "prefix": "webkitCrypto.subtle"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -11,7 +11,7 @@
             "version_added": "37"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "53"
           },
           "edge": {
             "version_added": "12"
@@ -61,7 +61,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "edge": {
               "version_added": "12"
@@ -112,7 +112,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "edge": {
               "version_added": "12"
@@ -163,7 +163,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "edge": {
               "version_added": "12"
@@ -214,7 +214,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "edge": {
               "version_added": "12"
@@ -265,7 +265,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "edge": {
               "version_added": "12"
@@ -316,7 +316,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "edge": {
               "version_added": "12"
@@ -367,7 +367,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "edge": {
               "version_added": "12"
@@ -418,7 +418,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "edge": {
               "version_added": "12"
@@ -469,7 +469,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "edge": {
               "version_added": "12"
@@ -520,7 +520,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "edge": {
               "version_added": "12"
@@ -571,7 +571,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "edge": {
               "version_added": "12"
@@ -622,7 +622,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "edge": {
               "version_added": "12"


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto

Previously Edge Mobile marked as 37 where that is not a valid version number. Switched to 12, the earliest noted use of the API in Edge (11 was of course IE). https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/dn904640(v=vs.85)