### PR TITLE
Add compat data for HTMLAudioElement

### DIFF
--- a/api/HTMLAudioElement.json
+++ b/api/HTMLAudioElement.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "HTMLAudioElement": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAudioElement",
+        "support": {
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3"
+          },
+          "firefox_android": {
+            "version_added": "4"
+          },
+          "ie": {
+            "version_added": true
+          },
+          "opera": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Unsure of how to (or even if I should) represent the constructor and methods, currently omitted as they are not linked by url and non-standard. Need a second opinion.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLAudioElement