### PR TITLE
Add MediaSource compat data

### DIFF
--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -1,0 +1,974 @@
+{
+  "api": {
+    "MediaSource": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource",
+        "support": {
+          "chrome": [
+            {
+              "version_added": "31"
+            },
+            {
+              "version_added": "23",
+              "version_removed": "31",
+              "prefix": "-webkit-"
+            }
+          ],
+          "edge": {
+            "version_added": true
+          },
+          "firefox": [
+            {
+              "version_added": "42"
+            },
+            {
+              "version_added": "25",
+              "version_removed": "42",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.mediasource.enabled"
+                }
+              ],
+              "notes": [
+                "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": "11",
+            "notes": [
+              "Only works on Windows 8+."
+            ]
+          },
+          "opera": {
+            "version_added": "15"
+          },
+          "safari": {
+            "version_added": "8"
+          },
+          "webview_android": {
+            "version_added": "33"
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": "41"
+          },
+          "opera_android": {
+            "version_added": "30"
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "MediaSource": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/MediaSource",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "31"
+              },
+              {
+                "version_added": "23",
+                "version_removed": "31",
+                "prefix": "-webkit-"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.mediasource.enabled"
+                  }
+                ],
+                "notes": [
+                  "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": "11",
+              "notes": [
+                "Only works on Windows 8+."
+              ]
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "webview_android": {
+              "version_added": "33"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sourceBuffers": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/sourceBuffers",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "31"
+              },
+              {
+                "version_added": "23",
+                "version_removed": "31",
+                "prefix": "-webkit-"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.mediasource.enabled"
+                  }
+                ],
+                "notes": [
+                  "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": "11",
+              "notes": [
+                "Only works on Windows 8+."
+              ]
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "webview_android": {
+              "version_added": "33"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "activeSourceBuffers": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/activeSourceBuffers",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "31"
+              },
+              {
+                "version_added": "23",
+                "version_removed": "31",
+                "prefix": "-webkit-"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.mediasource.enabled"
+                  }
+                ],
+                "notes": [
+                  "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": "11",
+              "notes": [
+                "Only works on Windows 8+."
+              ]
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "webview_android": {
+              "version_added": "33"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "readyState": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/readyState",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "31"
+              },
+              {
+                "version_added": "23",
+                "version_removed": "31",
+                "prefix": "-webkit-"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.mediasource.enabled"
+                  }
+                ],
+                "notes": [
+                  "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": "11",
+              "notes": [
+                "Only works on Windows 8+."
+              ]
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "webview_android": {
+              "version_added": "33"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "duration": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/duration",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "31"
+              },
+              {
+                "version_added": "23",
+                "version_removed": "31",
+                "prefix": "-webkit-"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.mediasource.enabled"
+                  }
+                ],
+                "notes": [
+                  "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": "11",
+              "notes": [
+                "Only works on Windows 8+."
+              ]
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "webview_android": {
+              "version_added": "33"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onsourceclose": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/onsourceclose",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "31"
+              },
+              {
+                "version_added": "23",
+                "version_removed": "31",
+                "prefix": "-webkit-"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.mediasource.enabled"
+                  }
+                ],
+                "notes": [
+                  "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": "11",
+              "notes": [
+                "Only works on Windows 8+."
+              ]
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "webview_android": {
+              "version_added": "33"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onsourceended": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/onsourceended",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "31"
+              },
+              {
+                "version_added": "23",
+                "version_removed": "31",
+                "prefix": "-webkit-"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.mediasource.enabled"
+                  }
+                ],
+                "notes": [
+                  "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": "11",
+              "notes": [
+                "Only works on Windows 8+."
+              ]
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "webview_android": {
+              "version_added": "33"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onsourceopen": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/onsourceopen",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "31"
+              },
+              {
+                "version_added": "23",
+                "version_removed": "31",
+                "prefix": "-webkit-"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.mediasource.enabled"
+                  }
+                ],
+                "notes": [
+                  "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": "11",
+              "notes": [
+                "Only works on Windows 8+."
+              ]
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "webview_android": {
+              "version_added": "33"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "addSourceBuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/addSourceBuffer",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "31"
+              },
+              {
+                "version_added": "23",
+                "version_removed": "31",
+                "prefix": "-webkit-"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.mediasource.enabled"
+                  }
+                ],
+                "notes": [
+                  "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": "11",
+              "notes": [
+                "Only works on Windows 8+."
+              ]
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "webview_android": {
+              "version_added": "33"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "removeSourceBuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/removeSourceBuffer",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "31"
+              },
+              {
+                "version_added": "23",
+                "version_removed": "31",
+                "prefix": "-webkit-"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.mediasource.enabled"
+                  }
+                ],
+                "notes": [
+                  "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": "11",
+              "notes": [
+                "Only works on Windows 8+."
+              ]
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "webview_android": {
+              "version_added": "33"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "endOfStream": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/endOfStream",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "31"
+              },
+              {
+                "version_added": "23",
+                "version_removed": "31",
+                "prefix": "-webkit-"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.mediasource.enabled"
+                  }
+                ],
+                "notes": [
+                  "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": "11",
+              "notes": [
+                "Only works on Windows 8+."
+              ]
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "webview_android": {
+              "version_added": "33"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setLiveSeekableRange": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/setLiveSeekableRange",
+          "support": {
+            "chrome": {
+              "version_added": "62"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "clearLiveSeekableRange": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/clearLiveSeekableRange",
+          "support": {
+            "chrome": {
+              "version_added": "62"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isTypeSupported": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/isTypeSupported",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "31"
+              },
+              {
+                "version_added": "23",
+                "version_removed": "31",
+                "prefix": "-webkit-"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.mediasource.enabled"
+                  }
+                ],
+                "notes": [
+                  "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": "11",
+              "notes": [
+                "Only works on Windows 8+."
+              ]
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "webview_android": {
+              "version_added": "33"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -50,6 +50,9 @@
           "webview_android": {
             "version_added": "33"
           },
+          "chrome_android": {
+            "version_added": "33"
+          },
           "edge_mobile": {
             "version_added": true
           },
@@ -117,6 +120,9 @@
               "version_added": "8"
             },
             "webview_android": {
+              "version_added": "33"
+            },
+            "chrome_android": {
               "version_added": "33"
             },
             "edge_mobile": {
@@ -189,6 +195,9 @@
             "webview_android": {
               "version_added": "33"
             },
+            "chrome_android": {
+              "version_added": "33"
+            },
             "edge_mobile": {
               "version_added": true
             },
@@ -257,6 +266,9 @@
               "version_added": "8"
             },
             "webview_android": {
+              "version_added": "33"
+            },
+            "chrome_android": {
               "version_added": "33"
             },
             "edge_mobile": {
@@ -329,6 +341,9 @@
             "webview_android": {
               "version_added": "33"
             },
+            "chrome_android": {
+              "version_added": "33"
+            },
             "edge_mobile": {
               "version_added": true
             },
@@ -397,6 +412,9 @@
               "version_added": "8"
             },
             "webview_android": {
+              "version_added": "33"
+            },
+            "chrome_android": {
               "version_added": "33"
             },
             "edge_mobile": {
@@ -469,6 +487,9 @@
             "webview_android": {
               "version_added": "33"
             },
+            "chrome_android": {
+              "version_added": "33"
+            },
             "edge_mobile": {
               "version_added": true
             },
@@ -537,6 +558,9 @@
               "version_added": "8"
             },
             "webview_android": {
+              "version_added": "33"
+            },
+            "chrome_android": {
               "version_added": "33"
             },
             "edge_mobile": {
@@ -609,6 +633,9 @@
             "webview_android": {
               "version_added": "33"
             },
+            "chrome_android": {
+              "version_added": "33"
+            },
             "edge_mobile": {
               "version_added": true
             },
@@ -677,6 +704,9 @@
               "version_added": "8"
             },
             "webview_android": {
+              "version_added": "33"
+            },
+            "chrome_android": {
               "version_added": "33"
             },
             "edge_mobile": {
@@ -749,6 +779,9 @@
             "webview_android": {
               "version_added": "33"
             },
+            "chrome_android": {
+              "version_added": "33"
+            },
             "edge_mobile": {
               "version_added": true
             },
@@ -819,6 +852,9 @@
             "webview_android": {
               "version_added": "33"
             },
+            "chrome_android": {
+              "version_added": "33"
+            },
             "edge_mobile": {
               "version_added": true
             },
@@ -856,10 +892,19 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "62"
+            },
+            "chrome_android": {
+              "version_added": "62"
+            },
+            "opera_android": {
+              "version_added": "49"
             }
           },
           "status": {
@@ -886,10 +931,19 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "62"
+            },
+            "chrome_android": {
+              "version_added": "62"
+            },
+            "opera_android": {
+              "version_added": "49"
             }
           },
           "status": {
@@ -947,6 +1001,9 @@
               "version_added": "8"
             },
             "webview_android": {
+              "version_added": "33"
+            },
+            "chrome_android": {
               "version_added": "33"
             },
             "edge_mobile": {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/MediaSource

It looks like there's a few missing pages on the actual `MediaSource` documentation, i'll see whether I get a chance to update the doc to add them.

There's something a bit unclear to me in the JSON schema. In this case Chrome added `MediaSource` with a prefix on version 25 and added full support on version 32. What should I put as version removed for the prefixed property? 31 or 32?

Thanks!