### PR TITLE
Update npm dependencies install command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ or maybe you found your own.
 Let us know if these look good to you.
 
 ## Validating the data
-You can use `npm test` to validate data against the schema. You might need to install the devDependencies using `npm install --dev`.
+You can use `npm test` to validate data against the schema. You might need to install the devDependencies using `npm install --only=dev`.
 The JSON data is validated against the schema using [`ajv`](http://epoberezkin.github.io/ajv/).
 
 ## Test rendering

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
       "dev": true
     },
     "extend": {
-      "version": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "fast-deep-equal": {


### PR DESCRIPTION
Previous versions used --dev flag to install only devDependencies. That has now been deprecated in favour of [--only={prod[uction]|dev[elopment]}](https://docs.npmjs.com/cli/install).