### PR TITLE
Expression closures have been removed from Fx60

### DIFF
--- a/javascript/operators/expression_closures.json
+++ b/javascript/operators/expression_closures.json
@@ -22,10 +22,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3",
+              "version_removed": "60"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4",
+              "version_removed": "60"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Added in Firefox 3: https://bugzilla.mozilla.org/show_bug.cgi?id=381113
Removed in Firefox 60: https://bugzilla.mozilla.org/show_bug.cgi?id=1426519