### PR TITLE
Added Edge version that supports exponentiation

### DIFF
--- a/javascript/operators/arithmetic.json
+++ b/javascript/operators/arithmetic.json
@@ -173,10 +173,10 @@
                 "version_added": "52"
               },
               "edge": {
-                "version_added": "13"
+                "version_added": "14"
               },
               "edge_mobile": {
-                "version_added": "13"
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "52"

--- a/javascript/operators/arithmetic.json
+++ b/javascript/operators/arithmetic.json
@@ -173,10 +173,10 @@
                 "version_added": "52"
               },
               "edge": {
-                "version_added": null
+                "version_added": "13"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "52"


### PR DESCRIPTION
I've added the **version of edge that supports the exponentiation operation** which is **EDGE 13.** I've added this based on this [source ](http://news.thewindowsclub.com/microsoft-introduces-edgehtml-13-80893/). It was previously missing in this file.