### PR TITLE
Added theme data for Firefox 59/60

### DIFF
--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -98,6 +98,72 @@
               }
             }
           },
+          "button_background": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "notes": [
+                    "The CSS color form is not supported for this property."
+                  ]
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "button_background_active": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "button_background_hover": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
           "frame": {
             "__compat": {
               "support": {
@@ -335,6 +401,27 @@
               }
             }
           },
+          "tab_loading": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
           "tab_text": {
             "__compat": {
               "support": {
@@ -554,7 +641,7 @@
               }
             }
           },
-          "toolbar_vertical_separator": {
+          "toolbar_field_separator": {
             "__compat": {
               "support": {
                 "chrome": {
@@ -563,12 +650,19 @@
                 "edge": {
                   "version_added": false
                 },
-                "firefox": {
-                  "version_added": "58",
-                  "notes": [
-                    "Before version 59, the RGB array form was not supported for this property."
-                  ]
-                },
+                "firefox": [
+                  {
+                    "version_added": "59"
+                  },
+                  {
+                    "alternative_name": "toolbar_vertical_separator",
+                    "version_added": "58",
+                    "version_removed": "59",
+                    "notes": [
+                      "Before version 59, the RGB array form was not supported for this property."
+                    ]
+                  }
+                ],
                 "firefox_android": {
                   "version_added": false
                 },

--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -98,30 +98,6 @@
               }
             }
           },
-          "button_background": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true,
-                  "notes": [
-                    "The CSS color form is not supported for this property."
-                  ]
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "60"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            }
-          },
           "button_background_active": {
             "__compat": {
               "support": {


### PR DESCRIPTION
This PR covers theme updates for Firefox 60:

* `colors.toolbar_vertical_separator` renamed to `colors.toolbar_field_separator`. Landed in Firefox 60 and and uplifted to Firefox 59 (https://bugzilla.mozilla.org/show_bug.cgi?id=1423762).

* `colors.tab_loading`. Firefox-only and new in Firefox 60 (https://bugzilla.mozilla.org/show_bug.cgi?id=1426686).

* `colors.button_background`, `colors.button_background_hover`, `colors.button_background_active`. New in Firefox 60. `colors.button_background` is also supported in Chrome, the others are Firefox-only. (https://bugzilla.mozilla.org/show_bug.cgi?id=1431189).
