### PR TITLE
Added data for new menus APIs in Firefox 60

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -484,6 +484,90 @@
             }
           }
         },
+        "onHidden": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/onHidden",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "60"
+                },
+                {
+                  "alternative_name": "contextMenus.onHidden",
+                  "version_added": "60"
+                }
+              ],
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "onShown": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/onShown",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "60"
+                },
+                {
+                  "alternative_name": "contextMenus.onShown",
+                  "version_added": "60"
+                }
+              ],
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "refresh": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/refresh",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "60"
+                },
+                {
+                  "alternative_name": "contextMenus.refresh",
+                  "version_added": "60"
+                }
+              ],
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "remove": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/remove",


### PR DESCRIPTION
New APIs in the menus namespace. New in Firefox 60, Firefox-only, for a change.

* onHidden
* onShown
* refresh()

I haven't written the docs pages yet.

https://bugzilla.mozilla.org/show_bug.cgi?id=1215376