### PR TITLE
Added data for devtools.network.getHAR

### DIFF
--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -134,6 +134,28 @@
           }
         },
         "network": {
+          "getHAR": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.network/getHAR",
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
           "onNavigated": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.network/onNavigated",


### PR DESCRIPTION
Bug 1311177 adds support in Firefox 60 for the devtools.network.getHAR() method, also supported by Chrome and I think Opera: https://developer.chrome.com/extensions/devtools_network#method-getHAR.

https://bugzilla.mozilla.org/show_bug.cgi?id=1311177