### PR TITLE
Added commands.reset and commands.update

### DIFF
--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -67,6 +67,50 @@
               }
             }
           }
+        },
+        "reset": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/reset",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "update": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/update",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Bug 1421811 added 2 new functions to the [`commands`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/commands) namespace: `reset()` and `update()`:

https://hg.mozilla.org/mozilla-central/diff/c8f509a24089/browser/components/extensions/schemas/commands.json
https://hg.mozilla.org/mozilla-central/diff/4f515f0fb671/browser/components/extensions/schemas/commands.json
 
https://bugzilla.mozilla.org/show_bug.cgi?id=1421811