### PR TITLE
Added data for devtools.network.onRequestFinished

### DIFF
--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -155,6 +155,28 @@
                 }
               }
             }
+          },
+          "onRequestFinished": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.network/onRequestFinished",
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
           }
         },
         "panels": {


### PR DESCRIPTION
Bug 1311171 added support in Firefox 60 for the `devtools.network.onRequestFinished` event. This is also supported in Chrome and Opera:
https://dev.opera.com/extensions/apis/
https://developer.chrome.com/extensions/devtools_network#event-onRequestFinished.

https://bugzilla.mozilla.org/show_bug.cgi?id=1311171