### PR TITLE
Add compat data for HTMLContentElement

### DIFF
--- a/api/HTMLContentElement.json
+++ b/api/HTMLContentElement.json
@@ -20,10 +20,26 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": "28"
+            "version_added": "28",
+            "version_removed": "59",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webcomponents.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
-            "version_added": "28"
+            "version_added": "28",
+            "version_removed": "59",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webcomponents.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "ie": {
             "version_added": false
@@ -67,10 +83,26 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "28"
+              "version_added": "28",
+              "version_removed": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": "28"
+              "version_added": "28",
+              "version_removed": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false
@@ -115,10 +147,26 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "28"
+              "version_added": "28",
+              "version_removed": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": "28"
+              "version_added": "28",
+              "version_removed": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false

--- a/api/HTMLContentElement.json
+++ b/api/HTMLContentElement.json
@@ -1,0 +1,148 @@
+{
+  "api": {
+    "HTMLContentElement": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLContentElement",
+        "support": {
+          "webview_android": {
+            "version_added": "37"
+          },
+          "chrome": {
+            "version_added": "35"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "28"
+          },
+          "firefox_android": {
+            "version_added": "28"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "26"
+          },
+          "opera_android": {
+            "version_added": "26"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": true
+        }
+      },
+      "select": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLContentElement/select",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.6"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "9"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getDistributedNodes": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLContentElement/getDistributedNodes",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/HTMLContentElement.json
+++ b/api/HTMLContentElement.json
@@ -52,46 +52,46 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLContentElement/select",
           "support": {
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             },
             "chrome": {
-              "version_added": "4"
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "37"
             },
             "edge": {
-              "version_added": true
+              "version_added": null
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": null
             },
             "firefox": {
-              "version_added": "3.6"
+              "version_added": "28"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "28"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": false
             },
             "opera": {
-              "version_added": "9"
+              "version_added": "26"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": null
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -100,46 +100,46 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLContentElement/getDistributedNodes",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": "37"
             },
             "chrome": {
-              "version_added": false
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "37"
             },
             "edge": {
-              "version_added": false
+              "version_added": null
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "28"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "28"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "26"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "26"
             },
             "safari": {
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": false
+            "standard_track": true,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
Not sure about the note on Fx as it ONLY appears relevant to Release channel. Added comment to enquire with Chris in spreadsheet.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLContentElement