### PR TITLE
add compat data for HTMLMediaElement

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -7,14 +7,20 @@
           "chrome": {
             "version_added": true
           },
+          "chrome_android": {
+            "version_added": true
+          },
           "edge": {
             "version_added": true
           },
+          "edge_mobile": {
+            "version_added": true
+          },
           "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
+            "version_added": "3.5"
+          },
+          "firefox_android": {
+            "version_added": true
           },
           "ie": {
             "version_added": "9"
@@ -22,163 +28,17 @@
           "opera": {
             "version_added": true
           },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
           "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "audioTracks": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/audioTracks",
-        "support": {
-          "edge": {
-            "version_added": false
-          },
-          "firefox": {
-            "version_added": "33",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "media.track.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": "33",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "media.track.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "autoplay": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/autoplay",
-        "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
             "version_added": true
           },
           "safari": {
             "version_added": true
           },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
           "safari_ios": {
             "version_added": true
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "buffered": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/buffered",
-        "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "4"
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
           },
           "webview_android": {
             "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
           }
         },
         "status": {
@@ -186,1994 +46,2148 @@
           "standard_track": true,
           "deprecated": false
         }
-      }
-    },
-    "controller": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/controller",
-        "support": {
-          "edge": {
-            "version_added": false
-          },
-          "firefox": {
-            "version_added": false,
-            "notes": [
-              "Gecko doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>847377</a>."
-            ]
-          },
-          "edge_mobile": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": false,
-            "notes": [
-              "Gecko doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>847377</a>."
-            ]
+      },
+      "addTextTrack": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/addTextTrack",
+          "support": {},
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "controlsList": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/controlsList",
-        "support": {
-          "chrome": {
-            "version_added": "58"
-          },
-          "opera": {
-            "version_added": "45"
-          },
-          "webview_android": {
-            "version_added": "58"
-          },
-          "chrome_android": {
-            "version_added": "58"
-          },
-          "opera_android": {
-            "version_added": "42"
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "crossOrigin": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/crossOrigin",
-        "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": [
-            {
-              "version_added": "12",
-              "version_removed": "22",
-              "notes": [
-                "Firefox implements this in lowercase <code>crossorigin</code>"
+      },
+      "audioTracks": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/audioTracks",
+          "support": {
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
               ]
             },
-            {
-              "version_added": "22"
+            "firefox_android": {
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             }
-          ],
-          "ie": {
-            "version_added": "9"
           },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "currentSrc": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/currentSrc",
-        "support": {
-          "chrome": {
-            "version_added": true
+      },
+      "autoplay": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/autoplay",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "currentTime": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/currentTime",
-        "support": {
-          "chrome": {
-            "version_added": true
+      },
+      "buffered": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/buffered",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "defaultMuted": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/defaultMuted",
-        "support": {
-          "chrome": {
-            "version_added": true
+      },
+      "canPlayType": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/canPlayType",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "11"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": "14"
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "defaultPlaybackRate": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/defaultPlaybackRate",
-        "support": {
-          "chrome": {
-            "version_added": true
+      },
+      "captureStream": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/captureStream",
+          "support": {
+            "chrome": {
+              "version_added": "53"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "15",
+              "prefix": "moz"
+            },
+            "firefox_android": {
+              "version_added": "15",
+              "prefix": "moz"
+            },
+            "webview_android": {
+              "version_added": "53"
+            }
           },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "20"
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": "20"
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "disableRemotePlayback": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/disableRemotePlayback",
-        "support": {
-          "chrome": {
-            "version_added": true
+      },
+      "controller": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/controller",
+          "support": {
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": [
+                "Firefox doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>847377</a>."
+              ]
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": [
+                "Firefox doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>847377</a>."
+              ]
+            }
           },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "duration": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/duration",
-        "support": {
-          "chrome": {
-            "version_added": true
+      },
+      "controls": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/controls",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "ended": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/ended",
-        "support": {
-          "chrome": {
-            "version_added": true
+      },
+      "controlsList": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/controlsList",
+          "support": {
+            "chrome": {
+              "version_added": "58"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "opera": {
+              "version_added": "45"
+            },
+            "opera_android": {
+              "version_added": "42"
+            },
+            "webview_android": {
+              "version_added": "58"
+            }
           },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "error": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/error",
-        "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "loop": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/loop",
-        "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "11"
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "mediaGroup": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mediaGroup",
-        "support": {
-          "edge": {
-            "version_added": false
-          },
-          "firefox": {
-            "version_added": false,
-            "notes": [
-              "Gecko doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>847377</a>."
-            ]
-          },
-          "edge_mobile": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": false,
-            "notes": [
-              "Gecko doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>847377</a>."
-            ]
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "mediaKeys": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mediaKeys",
-        "support": {},
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "mozAudioCaptured": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozAudioCaptured",
-        "support": {},
-        "status": {
-          "experimental": false,
-          "standard_track": false,
-          "deprecated": true
-        }
-      }
-    },
-    "mozFragmentEnd": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozFragmentEnd",
-        "support": {},
-        "status": {
-          "experimental": false,
-          "standard_track": false,
-          "deprecated": true
-        }
-      }
-    },
-    "mozFrameBufferLength": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozFrameBufferLength",
-        "support": {
-          "chrome": {
-            "version_added": false
-          },
-          "edge": {
-            "version_added": false
-          },
-          "firefox": {
-            "version_added": "4"
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "webview_android": {
-            "version_added": false
-          },
-          "chrome_android": {
-            "version_added": false
-          },
-          "edge_mobile": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": "4"
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": false,
-          "deprecated": true
-        }
-      }
-    },
-    "mozSampleRate": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozSampleRate",
-        "support": {
-          "chrome": {
-            "version_added": false
-          },
-          "edge": {
-            "version_added": false
-          },
-          "firefox": {
-            "version_added": "4"
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "webview_android": {
-            "version_added": false
-          },
-          "chrome_android": {
-            "version_added": false
-          },
-          "edge_mobile": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": "4"
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": false,
-          "deprecated": true
-        }
-      }
-    },
-    "muted": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/muted",
-        "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "networkState": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/networkState",
-        "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "paused": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/paused",
-        "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "playbackRate": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/playbackRate",
-        "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "20"
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": "20"
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "played": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/played",
-        "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "15"
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": "15"
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "preload": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/preload",
-        "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "4"
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": "4"
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "preservesPitch": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/preservesPitch",
-        "support": {
-          "chrome": {
-            "prefix": "-webkit-",
-            "version_added": true
-          },
-          "edge": {
-            "version_added": false
-          },
-          "firefox": {
-            "prefix": "-moz-",
-            "version_added": "20"
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": true
-        }
-      }
-    },
-    "readyState": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/readyState",
-        "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "seekable": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/seekable",
-        "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "8"
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": "8"
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "seeking": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/seeking",
-        "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "sinkId": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/sinkId",
-        "support": {
-          "chrome": {
-            "version_added": "49"
-          },
-          "edge": {
-            "version_added": false
-          },
-          "webview_android": {
-            "version_added": "49"
-          },
-          "chrome_android": {
-            "version_added": "49"
-          },
-          "edge_mobile": {
-            "version_added": false
-          }
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "src": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/src",
-        "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "srcObject": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/srcObject",
-        "support": {
-          "chrome": {
-            "version_added": "52"
-          },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": true
-          },
-          "opera": {
-            "version_added": "39"
-          },
-          "webview_android": {
-            "version_added": "52"
-          },
-          "chrome_android": {
-            "version_added": "52"
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": "39"
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "textTracks": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/textTracks",
-        "support": {
-          "edge": {
-            "version_added": false
-          },
-          "edge_mobile": {
-            "version_added": false
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "videoTracks": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/videoTracks",
-        "support": {
-          "edge": {
-            "version_added": false
-          },
-          "firefox": {
-            "version_added": "33",
-            "flags": [
+      },
+      "crossOrigin": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/crossOrigin",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
               {
-                "type": "preference",
-                "name": "media.track.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": "33",
-            "flags": [
+                "version_added": "22"
+              },
               {
-                "type": "preference",
-                "name": "media.track.enabled",
-                "value_to_set": "true"
+                "version_added": "12",
+                "version_removed": "22",
+                "alternative_name": "crossorigin"
               }
-            ]
+            ],
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "volume": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/volume",
-        "support": {
-          "chrome": {
-            "version_added": true
+      },
+      "currentSrc": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/currentSrc",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "onencrypted": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/onencrypted",
-        "support": {},
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "onwaitingforkey": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/onwaitingforkey",
-        "support": {
-          "chrome": {
-            "version_added": "55"
+      },
+      "currentTime": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/currentTime",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
-          "edge": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": "42"
-          },
-          "webview_android": {
-            "version_added": "55"
-          },
-          "chrome_android": {
-            "version_added": "55"
-          },
-          "edge_mobile": {
-            "version_added": false
-          },
-          "opera_android": {
-            "version_added": "42"
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "initialTime": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/initialTime",
-        "support": {
-          "edge": {
-            "version_added": false
+      },
+      "defaultMuted": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/defaultMuted",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "11"
+            },
+            "firefox_android": {
+              "version_added": "14"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
-          "firefox": {
-            "version_added": "9",
-            "version_removed": "23"
-          },
-          "edge_mobile": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": "9",
-            "version_removed": "23"
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": false,
-          "deprecated": true
         }
-      }
-    },
-    "mozChannels": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozChannels",
-        "support": {
-          "chrome": {
-            "version_added": false
+      },
+      "defaultPlaybackRate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/defaultPlaybackRate",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "20"
+            },
+            "firefox_android": {
+              "version_added": "20"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
-          "edge": {
-            "version_added": false
-          },
-          "firefox": {
-            "version_added": "4"
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "webview_android": {
-            "version_added": false
-          },
-          "chrome_android": {
-            "version_added": false
-          },
-          "edge_mobile": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": "4"
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": false,
-          "deprecated": true
         }
-      }
-    },
-    "onmozinterruptbegin": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/onmozinterruptbegin",
-        "support": {
-          "firefox": {
-            "version_added": true,
-            "version_removed": "55"
+      },
+      "disableRemotePlayback": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/disableRemotePlayback",
+          "support": {
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": "49"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "20"
+            },
+            "firefox_android": {
+              "version_added": "15"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "49"
+            }
           },
-          "firefox_android": {
-            "version_added": true,
-            "version_removed": "55"
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": false,
-          "deprecated": true
         }
-      }
-    },
-    "onmozinterruptend": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/onmozinterruptend",
-        "support": {
-          "firefox": {
-            "version_added": true,
-            "version_removed": "55"
+      },
+      "duration": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/duration",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
-          "firefox_android": {
-            "version_added": true,
-            "version_removed": "55"
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "addTextTrack": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/addTextTrack",
-        "support": {},
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "captureStream": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/captureStream",
-        "support": {
-          "chrome": {
-            "version_added": "53"
+      },
+      "ended": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/ended",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
-          "edge": {
-            "version_added": false
-          },
-          "webview_android": {
-            "version_added": "53"
-          },
-          "chrome_android": {
-            "version_added": "53"
-          },
-          "edge_mobile": {
-            "version_added": false
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "canPlayType": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/canPlayType",
-        "support": {
-          "chrome": {
-            "version_added": true
+      },
+      "error": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/error",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "fastSeek": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/fastSeek",
-        "support": {
-          "edge": {
-            "version_added": false
+      },
+      "fastSeek": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/fastSeek",
+          "support": {
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            }
           },
-          "firefox": {
-            "version_added": "31"
-          },
-          "edge_mobile": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": "31"
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "load": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/load",
-        "support": {
-          "chrome": {
-            "version_added": true
+      },
+      "initialTime": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/initialTime",
+          "support": {
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "9",
+              "version_removed": "23"
+            },
+            "firefox_android": {
+              "version_added": "9",
+              "version_removed": "23"
+            }
           },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "mozCaptureStream": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozCaptureStream",
-        "support": {},
-        "status": {
-          "experimental": false,
-          "standard_track": false,
-          "deprecated": true
-        }
-      }
-    },
-    "mozCaptureStreamUntilEnded": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozCaptureStreamUntilEnded",
-        "support": {},
-        "status": {
-          "experimental": false,
-          "standard_track": false,
-          "deprecated": true
-        }
-      }
-    },
-    "mozGetMetadata": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozGetMetadata",
-        "support": {
-          "chrome": {
-            "version_added": false
-          },
-          "edge": {
-            "version_added": false
-          },
-          "firefox": {
-            "version_added": "17"
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "webview_android": {
-            "version_added": false
-          },
-          "chrome_android": {
-            "version_added": false
-          },
-          "edge_mobile": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": "17"
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
+      },
+      "load": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/load",
+          "support": {},
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "pause": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/pause",
-        "support": {
-          "chrome": {
-            "version_added": true
+      },
+      "loop": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/loop",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "11"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "play": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/play",
-        "support": {
-          "chrome": {
-            "version_added": true
+      },
+      "mediaGroup": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mediaGroup",
+          "support": {
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": [
+                "Firefox doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>847377</a>."
+              ]
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": [
+                "Firefox doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>847377</a>."
+              ]
+            }
           },
-          "edge": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": [
-              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
-            ]
-          },
-          "ie": {
-            "version_added": "9"
-          },
-          "opera": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "seekToNextFrame": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/seekToNextFrame",
-        "support": {
-          "edge": {
-            "version_added": false
+      },
+      "mediaKeys": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mediaKeys",
+          "support": {},
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozAudioCaptured": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozAudioCaptured",
+          "support": {},
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "mozCaptureStreamUntilEnded": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozCaptureStreamUntilEnded",
+          "support": {},
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "mozChannels": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozChannels",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
-          "firefox": {
-            "version_added": "49",
-            "flags": [
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "mozFragmentEnd": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozFragmentEnd",
+          "support": {},
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "mozFrameBufferLength": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozFrameBufferLength",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "mozGetMetadata": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozGetMetadata",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "17"
+            },
+            "firefox_android": {
+              "version_added": "17"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozLoadFrom": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozLoadFrom",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "3.6",
+              "version_removed": "24"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "24"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "mozSampleRate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozSampleRate",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "muted": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/muted",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "networkState": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/networkState",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5",
+              "notes": [
+                "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+              ]
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onerror": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/onerror",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onencrypted": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/onencrypted",
+          "support": {},
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onmozinterruptbegin": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/onmozinterruptbegin",
+          "support": {
+            "firefox": {
+              "version_added": true,
+              "version_removed": "55"
+            },
+            "firefox_android": {
+              "version_added": true,
+              "version_removed": "55"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "onmozinterruptend": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/onmozinterruptend",
+          "support": {
+            "firefox": {
+              "version_added": true,
+              "version_removed": "55"
+            },
+            "firefox_android": {
+              "version_added": true,
+              "version_removed": "55"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onwaitingforkey": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/onwaitingforkey",
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "55"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42"
+            },
+            "opera_android": {
+              "version_added": "42"
+            },
+            "webview_android": {
+              "version_added": "55"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pause": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/pause",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "paused": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/paused",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "play": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/play",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "playbackRate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/playbackRate",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "20"
+            },
+            "firefox_android": {
+              "version_added": "20"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "played": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/played",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "15"
+            },
+            "firefox_android": {
+              "version_added": "15"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "preload": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/preload",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "preservesPitch": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/preservesPitch",
+          "support": {
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "prefix": "-moz-",
+              "version_added": "20"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "readyState": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/readyState",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "seekToNextFrame": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/seekToNextFrame",
+          "support": {
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "49",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.seekToNextFrame",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "49",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.seekToNextFrame",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "seekable": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/seekable",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "8"
+            },
+            "firefox_android": {
+              "version_added": "8"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "seeking": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/seeking",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setMediaKeys": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/setMediaKeys",
+          "support": {},
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setSinkId": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/setSinkId",
+          "support": {
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": "49"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "49"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sinkId": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/sinkId",
+          "support": {
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": "49"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "49"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "src": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/src",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "srcObject": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/srcObject",
+          "support": {
+            "chrome": {
+              "version_added": "52"
+            },
+            "chrome_android": {
+              "version_added": "52"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
               {
-                "type": "preference",
-                "name": "media.seekToNextFrame",
-                "value_to_set": "true"
-              }
-            ]
-          },
-          "edge_mobile": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": "49",
-            "flags": [
+                "version_added": true
+              },
               {
-                "type": "preference",
-                "name": "media.seekToNextFrame",
-                "value_to_set": "true"
+                "version_added": "18",
+                "version_removed": "58",
+                "prefix": "moz"
               }
-            ]
+            ],
+            "firefox_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": "18",
+                "version_removed": "58",
+                "prefix": "moz"
+              }
+            ],
+            "opera": {
+              "version_added": "39"
+            },
+            "opera_android": {
+              "version_added": "39"
+            },
+            "webview_android": {
+              "version_added": "52"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": true
         }
-      }
-    },
-    "setMediaKeys": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/setMediaKeys",
-        "support": {},
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
-    },
-    "setSinkId": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/setSinkId",
-        "support": {
-          "chrome": {
-            "version_added": "49"
+      },
+      "textTracks": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/textTracks",
+          "support": {
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            }
           },
-          "edge": {
-            "version_added": false
-          },
-          "webview_android": {
-            "version_added": "49"
-          },
-          "chrome_android": {
-            "version_added": "49"
-          },
-          "edge_mobile": {
-            "version_added": false
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "mozLoadFrom": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozLoadFrom",
-        "support": {
-          "chrome": {
-            "version_added": false
+      },
+      "videoTracks": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/videoTracks",
+          "support": {
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
           },
-          "edge": {
-            "version_added": false
-          },
-          "firefox": {
-            "version_added": "3.6",
-            "version_removed": "24"
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "webview_android": {
-            "version_added": false
-          },
-          "chrome_android": {
-            "version_added": false
-          },
-          "edge_mobile": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": "4",
-            "version_removed": "24"
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": false,
-          "deprecated": true
+        }
+      },
+      "volume": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/volume",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       }
     }

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1,0 +1,2181 @@
+{
+  "api": {
+    "HTMLMediaElement": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "audioTracks": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/audioTracks",
+        "support": {
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "33",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "media.track.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": "33",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "media.track.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "autoplay": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/autoplay",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "buffered": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/buffered",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "4"
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "controller": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/controller",
+        "support": {
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false,
+            "notes": [
+              "Gecko doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>847377</a>."
+            ]
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false,
+            "notes": [
+              "Gecko doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>847377</a>."
+            ]
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "controlsList": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/controlsList",
+        "support": {
+          "chrome": {
+            "version_added": "58"
+          },
+          "opera": {
+            "version_added": "45"
+          },
+          "webview_android": {
+            "version_added": "58"
+          },
+          "chrome_android": {
+            "version_added": "58"
+          },
+          "opera_android": {
+            "version_added": "42"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "crossOrigin": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/crossOrigin",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": [
+            {
+              "version_added": "12",
+              "version_removed": "22",
+              "notes": [
+                "Firefox implements this in lowercase <code>crossorigin</code>"
+              ]
+            },
+            {
+              "version_added": "22"
+            }
+          ],
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "currentSrc": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/currentSrc",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "currentTime": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/currentTime",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "defaultMuted": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/defaultMuted",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "11"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": "14"
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "defaultPlaybackRate": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/defaultPlaybackRate",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "20"
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": "20"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "disableRemotePlayback": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/disableRemotePlayback",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "duration": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/duration",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "ended": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/ended",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "error": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/error",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "loop": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/loop",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "11"
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "mediaGroup": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mediaGroup",
+        "support": {
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false,
+            "notes": [
+              "Gecko doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>847377</a>."
+            ]
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false,
+            "notes": [
+              "Gecko doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>847377</a>."
+            ]
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "mediaKeys": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mediaKeys",
+        "support": {},
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "mozAudioCaptured": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozAudioCaptured",
+        "support": {},
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      }
+    },
+    "mozFragmentEnd": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozFragmentEnd",
+        "support": {},
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      }
+    },
+    "mozFrameBufferLength": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozFrameBufferLength",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "4"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": "4"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      }
+    },
+    "mozSampleRate": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozSampleRate",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "4"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": "4"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      }
+    },
+    "muted": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/muted",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "networkState": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/networkState",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "paused": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/paused",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "playbackRate": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/playbackRate",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "20"
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": "20"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "played": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/played",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "15"
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": "15"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "preload": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/preload",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "4"
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": "4"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "preservesPitch": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/preservesPitch",
+        "support": {
+          "chrome": {
+            "prefix": "-webkit-",
+            "version_added": true
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "prefix": "-moz-",
+            "version_added": "20"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": true
+        }
+      }
+    },
+    "readyState": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/readyState",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "seekable": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/seekable",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "8"
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": "8"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "seeking": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/seeking",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "sinkId": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/sinkId",
+        "support": {
+          "chrome": {
+            "version_added": "49"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "49"
+          },
+          "chrome_android": {
+            "version_added": "49"
+          },
+          "edge_mobile": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "src": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/src",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "srcObject": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/srcObject",
+        "support": {
+          "chrome": {
+            "version_added": "52"
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": true
+          },
+          "opera": {
+            "version_added": "39"
+          },
+          "webview_android": {
+            "version_added": "52"
+          },
+          "chrome_android": {
+            "version_added": "52"
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": "39"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "textTracks": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/textTracks",
+        "support": {
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "videoTracks": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/videoTracks",
+        "support": {
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "33",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "media.track.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": "33",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "media.track.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "volume": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/volume",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "onencrypted": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/onencrypted",
+        "support": {},
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "onwaitingforkey": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/onwaitingforkey",
+        "support": {
+          "chrome": {
+            "version_added": "55"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "42"
+          },
+          "webview_android": {
+            "version_added": "55"
+          },
+          "chrome_android": {
+            "version_added": "55"
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": "42"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "initialTime": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/initialTime",
+        "support": {
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "9",
+            "version_removed": "23"
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": "9",
+            "version_removed": "23"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      }
+    },
+    "mozChannels": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozChannels",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "4"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": "4"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      }
+    },
+    "onmozinterruptbegin": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/onmozinterruptbegin",
+        "support": {
+          "firefox": {
+            "version_added": true,
+            "version_removed": "55"
+          },
+          "firefox_android": {
+            "version_added": true,
+            "version_removed": "55"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      }
+    },
+    "onmozinterruptend": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/onmozinterruptend",
+        "support": {
+          "firefox": {
+            "version_added": true,
+            "version_removed": "55"
+          },
+          "firefox_android": {
+            "version_added": true,
+            "version_removed": "55"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "addTextTrack": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/addTextTrack",
+        "support": {},
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "captureStream": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/captureStream",
+        "support": {
+          "chrome": {
+            "version_added": "53"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "53"
+          },
+          "chrome_android": {
+            "version_added": "53"
+          },
+          "edge_mobile": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "canPlayType": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/canPlayType",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "fastSeek": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/fastSeek",
+        "support": {
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "31"
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": "31"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "load": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/load",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "mozCaptureStream": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozCaptureStream",
+        "support": {},
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      }
+    },
+    "mozCaptureStreamUntilEnded": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozCaptureStreamUntilEnded",
+        "support": {},
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      }
+    },
+    "mozGetMetadata": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozGetMetadata",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "17"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": "17"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "pause": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/pause",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "play": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/play",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "3.5",
+            "notes": [
+              "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
+            ]
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "seekToNextFrame": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/seekToNextFrame",
+        "support": {
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "49",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "media.seekToNextFrame",
+                "value_to_set": "true"
+              }
+            ]
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": "49",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "media.seekToNextFrame",
+                "value_to_set": "true"
+              }
+            ]
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": true
+        }
+      }
+    },
+    "setMediaKeys": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/setMediaKeys",
+        "support": {},
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "setSinkId": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/setSinkId",
+        "support": {
+          "chrome": {
+            "version_added": "49"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "49"
+          },
+          "chrome_android": {
+            "version_added": "49"
+          },
+          "edge_mobile": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    },
+    "mozLoadFrom": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozLoadFrom",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "3.6",
+            "version_removed": "24"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": "4",
+            "version_removed": "24"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement

Sorry this PR is quite massive, but so is the `HTMLMediaElement` object.
It looks like a bit of data is not filled in or incorrectly filled in. 

I also had a questions regarding properties like: `mozChannels`. Should I add it in the compat data as `channels` with a prefix of `-moz-`, or add it as `mozChannels` ? 
Between those two options I chose the latter. Happy to change if needed.

Thanks