### PR TITLE
Bug 1433576 - RTCRtpContributingSource timestamp fixed

### DIFF
--- a/api/RTCRtpContributingSource.json
+++ b/api/RTCRtpContributingSource.json
@@ -80,38 +80,32 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": [
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.peerconnection.rtpsourcesapi.enable",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "60",
-                "notes": "Starting in Firefox 60, the <code>timestamp</code> is correctly computed based on the window's <code>Performance</code> time, rather than <code>Date.getTime()</code>."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.peerconnection.rtpsourcesapi.enable",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "60",
-                "notes": "Starting in Firefox 60, the <code>timestamp</code> is correctly computed based on the window's <code>Performance</code> time, rather than <code>Date.getTime()</code>."
-              }
-            ],
+            "firefox": {
+              "version_added": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.peerconnection.rtpsourcesapi.enable",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": [
+                "Starting in version 60, the <code>timestamp</code> is correctly computed based on the window's <code>Performance</code> time, rather than <code>Date.getTime()</code>."
+              ]
+            },
+            "firefox_android": {
+              "version_added": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.peerconnection.rtpsourcesapi.enable",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": [
+                "Starting in version 60, the <code>timestamp</code> is correctly computed based on the window's <code>Performance</code> time, rather than <code>Date.getTime()</code>."
+              ]
+            },
             "ie": {
               "version_added": false
             },

--- a/api/RTCRtpContributingSource.json
+++ b/api/RTCRtpContributingSource.json
@@ -80,26 +80,38 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.peerconnection.rtpsourcesapi.enable",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.peerconnection.rtpsourcesapi.enable",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.peerconnection.rtpsourcesapi.enable",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "60",
+                "notes": "Starting in Firefox 60, the <code>timestamp</code> is correctly computed based on the window's <code>Performance</code> time, rather than <code>Date.getTime()</code>."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.peerconnection.rtpsourcesapi.enable",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "60",
+                "notes": "Starting in Firefox 60, the <code>timestamp</code> is correctly computed based on the window's <code>Performance</code> time, rather than <code>Date.getTime()</code>."
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
Previously, the timestamp was computed using Date.getTime();
now the Preformance Timing API is being used. Updated the
compat table to note this..