### PR TITLE
Add compat data for attr() functionality added in CSS Values 3

### DIFF
--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -1,18 +1,19 @@
 {
   "css": {
-    "properties": {
-      "content": {
+    "types": {
+      "attr": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/content",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/attr",
+          "description": "<code>attr()</code>",
           "support": {
             "webview_android": {
-              "version_added": "1"
+              "version_added": "2.1"
             },
             "chrome": {
-              "version_added": "1"
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": null
             },
             "edge": {
               "version_added": true
@@ -30,16 +31,16 @@
               "version_added": "8"
             },
             "opera": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9.5"
+              "version_added": "10"
             },
             "safari": {
-              "version_added": "1"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": "3.1"
             }
           },
           "status": {
@@ -48,50 +49,51 @@
             "deprecated": false
           }
         },
-        "url": {
+        "css-values-3": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url",
-            "description": "<code>url()</code>",
+            "description": "Usage in other properties than <code>content</code> and with non-string values",
             "support": {
               "webview_android": {
                 "version_added": null
               },
               "chrome": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "See Chromium <a href='https://code.google.com/p/chromium/issues/detail?id=246571'>bug 246571</a>."
               },
               "chrome_android": {
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
-                "version_added": "8"
+                "version_added": false
               },
               "opera": {
-                "version_added": "7"
+                "version_added": false
               },
               "opera_android": {
                 "version_added": null
               },
               "safari": {
-                "version_added": "1"
+                "version_added": null
               },
               "safari_ios": {
                 "version_added": null
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -7,13 +7,13 @@
           "description": "<code>attr()</code>",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": true
             },
             "chrome": {
               "version_added": "2"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -54,14 +54,16 @@
             "description": "Usage in other properties than <code>content</code> and with non-string values",
             "support": {
               "webview_android": {
-                "version_added": null
+                "version_added": false,
+                "notes": "See Chromium <a href='https://code.google.com/p/chromium/issues/detail?id=246571'>bug 246571</a>."
               },
               "chrome": {
                 "version_added": false,
                 "notes": "See Chromium <a href='https://code.google.com/p/chromium/issues/detail?id=246571'>bug 246571</a>."
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false,
+                "notes": "See Chromium <a href='https://code.google.com/p/chromium/issues/detail?id=246571'>bug 246571</a>."
               },
               "edge": {
                 "version_added": false
@@ -74,7 +76,8 @@
                 "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
               },
               "ie": {
                 "version_added": false
@@ -83,7 +86,7 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": null


### PR DESCRIPTION
The `attr()` compat data is currently included in the `content` property, but CSS Values allows this notation in all properties. So, just like `calc()`, I moved it to a file in css/types, and added extra compat data from https://developer.mozilla.org/en-US/docs/Web/CSS/attr$revision/1323990#Browser_compatibility