### PR TITLE
Updated versions for node async/await

### DIFF
--- a/javascript/operators/async_function_expression.json
+++ b/javascript/operators/async_function_expression.json
@@ -31,7 +31,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": "7.6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": "42"

--- a/javascript/operators/async_function_expression.json
+++ b/javascript/operators/async_function_expression.json
@@ -31,7 +31,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.6"
             },
             "opera": {
               "version_added": "42"

--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -30,7 +30,7 @@
               "version_added": null
             },
             "nodejs": {
-              "version_added": null
+              "version_added": "7.6"
             },
             "opera": {
               "version_added": "42"

--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -30,7 +30,7 @@
               "version_added": null
             },
             "nodejs": {
-              "version_added": "7.6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": "42"


### PR DESCRIPTION
Async/await have been available to Node since version 7.6.  Async simply had "true" while await was null.  Updated these two.