### PR TITLE
Add compat data for VRFieldOfViewReadOnly

### DIFF
--- a/api/VRFieldOfViewReadOnly.json
+++ b/api/VRFieldOfViewReadOnly.json
@@ -1,0 +1,73 @@
+{
+  "api": {
+    "VRFieldOfViewReadOnly": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/VRFieldOfViewReadOnly",
+        "support": {
+          "webview_android": {
+            "version_added": false
+          },
+          "chrome": {
+            "version_added": true,
+            "notes": "The support in Chrome is currently experimental. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "39",
+            "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>.",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.vr*"
+              }
+            ]
+          },
+          "firefox_android": [
+            {
+              "version_added": "39",
+              "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.vr*"
+                }
+              ]
+            },
+            {
+              "version_added": "44",
+              "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
+            }
+          ],
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": false,
+          "deprecated": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hello again,

I have a few questions to help me understand this better.

1/ How do we differentiate between Firefox Mobile (Gecko) and Firefox OS? The way I understand it so far is we have `firefox_android` for the former, but no tag for the latter?

2/ Related, Is Firefox Mobile (Gecko) the same as Fennec (mentioned [here](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#the-support_statement-object)), i.e. I can mean either of them when referring to `firefox_android`?

I decided to keep the [original Firefox Mobile (Gecko)](https://developer.mozilla.org/en-US/docs/Web/API/VRFieldOfViewReadOnly) notes under `firefox_android`, but I'll remove them if my understanding isn't correct. Thank you.