### PR TITLE
Add NavigationPreloadManager

### DIFF
--- a/api/NavigationPreloadManager.json
+++ b/api/NavigationPreloadManager.json
@@ -1,0 +1,254 @@
+{
+  "api": {
+    "NavigationPreloadManager": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager",
+        "support": {
+          "webview_android": {
+            "version_added": "62"
+          },
+          "chrome": {
+            "version_added": "62"
+          },
+          "chrome_android": {
+            "version_added": "62"
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": false,
+            "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>"
+          },
+          "firefox_android": {
+            "version_added": false,
+            "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "49"
+          },
+          "opera_android": {
+            "version_added": "49"
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "enable": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager/enable",
+          "support": {
+            "webview_android": {
+              "version_added": "62"
+            },
+            "chrome": {
+              "version_added": "62"
+            },
+            "chrome_android": {
+              "version_added": "62"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>"
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "49"
+            },
+            "opera_android": {
+              "version_added": "49"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "disable": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager/disable",
+          "support": {
+            "webview_android": {
+              "version_added": "62"
+            },
+            "chrome": {
+              "version_added": "62"
+            },
+            "chrome_android": {
+              "version_added": "62"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>"
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "49"
+            },
+            "opera_android": {
+              "version_added": "49"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setHeaderValue": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager/setHeaderValue",
+          "support": {
+            "webview_android": {
+              "version_added": "62"
+            },
+            "chrome": {
+              "version_added": "62"
+            },
+            "chrome_android": {
+              "version_added": "62"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>"
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "49"
+            },
+            "opera_android": {
+              "version_added": "49"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getState": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager/getState",
+          "support": {
+            "webview_android": {
+              "version_added": "62"
+            },
+            "chrome": {
+              "version_added": "62"
+            },
+            "chrome_android": {
+              "version_added": "62"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>"
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "49"
+            },
+            "opera_android": {
+              "version_added": "49"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds the browser compatibility table data for the [`NavigationPreloadManager` API](https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager).