### PR TITLE
Add HTMLShadowElement

### DIFF
--- a/api/HTMLShadowElement.json
+++ b/api/HTMLShadowElement.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLShadowElement",
         "support": {
           "webview_android": {
-            "version_added": "37"
+            "version_added": "35"
           },
           "chrome": {
             "version_added": "35"
           },
           "chrome_android": {
-            "version_added": "37"
+            "version_added": "35"
           },
           "edge": {
             "version_added": false
@@ -66,13 +66,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/getDistributedNodes",
           "support": {
             "webview_android": {
-              "version_added": "37"
+              "version_added": "35"
             },
             "chrome": {
               "version_added": "35"
             },
             "chrome_android": {
-              "version_added": "37"
+              "version_added": "35"
             },
             "edge": {
               "version_added": false

--- a/api/HTMLShadowElement.json
+++ b/api/HTMLShadowElement.json
@@ -1,0 +1,114 @@
+{
+  "api": {
+    "HTMLShadowElement": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLShadowElement",
+        "support": {
+          "webview_android": {
+            "version_added": "37"
+          },
+          "chrome": {
+            "version_added": "35"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "28",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webcomponents.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
+          "firefox_android": {
+            "version_added": "28",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webcomponents.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "26"
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": true
+        }
+      },
+      "getDistributedNodes": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/getDistributedNodes",
+          "support": {
+            "webview_android": {
+              "version_added": "37"
+            },
+            "chrome": {
+              "version_added": "35"
+            },
+            "chrome_android": {
+              "version_added": "37"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "26"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds the browser compatibility table data for the [`HTMLShadowElement` API](https://developer.mozilla.org/docs/Web/API/HTMLShadowElement).