### PR TITLE
Update BCD for -moz-border-*-colors as they have been completely removed from Fx

### DIFF
--- a/css/properties/-moz-border-bottom-colors.json
+++ b/css/properties/-moz-border-bottom-colors.json
@@ -20,30 +20,16 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": [
-              {
-                "version_added": "59",
-                "version_removed": "60",
-                "notes": "The property was removed completely in Firefox 60."
-              },
-              {
-                "version_added": "1",
-                "version_removed": "59",
-                "notes": "From Firefox 59, the property is limited to usage in chrome code only."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "59",
-                "version_removed": "60",
-                "notes": "The property was removed completely in Firefox 60."
-              },
-              {
-                "version_added": "4",
-                "version_removed": "59",
-                "notes": "From Firefox 59, the property is limited to usage in chrome code only."
-              }
-            ],
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "59",
+              "notes": "In Firefox 59, the property was limited to usage in chrome code only. In Firefox 60 it was removed completely."
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "59",
+              "notes": "In Firefox 59, the property was limited to usage in chrome code only. In Firefox 60 it was removed completely."
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/-moz-border-bottom-colors.json
+++ b/css/properties/-moz-border-bottom-colors.json
@@ -20,16 +20,30 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "1",
-              "version_removed": "59",
-              "notes": "From Firefox 59, the property is limited to usage in chrome code only."
-            },
-            "firefox_android": {
-              "version_added": "4",
-              "version_removed": "59",
-              "notes": "From Firefox 59, the property is limited to usage in chrome code only."
-            },
+            "firefox": [
+              {
+                "version_added": "60",
+                "version_removed": "60",
+                "notes": "The property was removed completely in Firefox 60."
+              },
+              {
+                "version_added": "1",
+                "version_removed": "59",
+                "notes": "From Firefox 59, the property is limited to usage in chrome code only."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "60",
+                "version_removed": "60",
+                "notes": "The property was removed completely in Firefox 60."
+              },
+              {
+                "version_added": "4",
+                "version_removed": "59",
+                "notes": "From Firefox 59, the property is limited to usage in chrome code only."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/-moz-border-bottom-colors.json
+++ b/css/properties/-moz-border-bottom-colors.json
@@ -22,7 +22,7 @@
             },
             "firefox": [
               {
-                "version_added": "60",
+                "version_added": "59",
                 "version_removed": "60",
                 "notes": "The property was removed completely in Firefox 60."
               },
@@ -34,7 +34,7 @@
             ],
             "firefox_android": [
               {
-                "version_added": "60",
+                "version_added": "59",
                 "version_removed": "60",
                 "notes": "The property was removed completely in Firefox 60."
               },

--- a/css/properties/-moz-border-left-colors.json
+++ b/css/properties/-moz-border-left-colors.json
@@ -20,30 +20,16 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": [
-              {
-                "version_added": "59",
-                "version_removed": "60",
-                "notes": "The property was removed completely in Firefox 60."
-              },
-              {
-                "version_added": "1",
-                "version_removed": "59",
-                "notes": "From Firefox 59, the property is limited to usage in chrome code only."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "59",
-                "version_removed": "60",
-                "notes": "The property was removed completely in Firefox 60."
-              },
-              {
-                "version_added": "4",
-                "version_removed": "59",
-                "notes": "From Firefox 59, the property is limited to usage in chrome code only."
-              }
-            ],
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "59",
+              "notes": "In Firefox 59, the property was limited to usage in chrome code only. In Firefox 60 it was removed completely."
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "59",
+              "notes": "In Firefox 59, the property was limited to usage in chrome code only. In Firefox 60 it was removed completely."
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/-moz-border-left-colors.json
+++ b/css/properties/-moz-border-left-colors.json
@@ -20,16 +20,30 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "1",
-              "version_removed": "59",
-              "notes": "From Firefox 59, the property is limited to usage in chrome code only."
-            },
-            "firefox_android": {
-              "version_added": "4",
-              "version_removed": "59",
-              "notes": "From Firefox 59, the property is limited to usage in chrome code only."
-            },
+            "firefox": [
+              {
+                "version_added": "60",
+                "version_removed": "60",
+                "notes": "The property was removed completely in Firefox 60."
+              },
+              {
+                "version_added": "1",
+                "version_removed": "59",
+                "notes": "From Firefox 59, the property is limited to usage in chrome code only."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "60",
+                "version_removed": "60",
+                "notes": "The property was removed completely in Firefox 60."
+              },
+              {
+                "version_added": "4",
+                "version_removed": "59",
+                "notes": "From Firefox 59, the property is limited to usage in chrome code only."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/-moz-border-left-colors.json
+++ b/css/properties/-moz-border-left-colors.json
@@ -22,7 +22,7 @@
             },
             "firefox": [
               {
-                "version_added": "60",
+                "version_added": "59",
                 "version_removed": "60",
                 "notes": "The property was removed completely in Firefox 60."
               },
@@ -34,7 +34,7 @@
             ],
             "firefox_android": [
               {
-                "version_added": "60",
+                "version_added": "59",
                 "version_removed": "60",
                 "notes": "The property was removed completely in Firefox 60."
               },

--- a/css/properties/-moz-border-right-colors.json
+++ b/css/properties/-moz-border-right-colors.json
@@ -20,30 +20,16 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": [
-              {
-                "version_added": "59",
-                "version_removed": "60",
-                "notes": "The property was removed completely in Firefox 60."
-              },
-              {
-                "version_added": "1",
-                "version_removed": "59",
-                "notes": "From Firefox 59, the property is limited to usage in chrome code only."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "59",
-                "version_removed": "60",
-                "notes": "The property was removed completely in Firefox 60."
-              },
-              {
-                "version_added": "4",
-                "version_removed": "59",
-                "notes": "From Firefox 59, the property is limited to usage in chrome code only."
-              }
-            ],
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "59",
+              "notes": "In Firefox 59, the property was limited to usage in chrome code only. In Firefox 60 it was removed completely."
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "59",
+              "notes": "In Firefox 59, the property was limited to usage in chrome code only. In Firefox 60 it was removed completely."
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/-moz-border-right-colors.json
+++ b/css/properties/-moz-border-right-colors.json
@@ -20,16 +20,30 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "1",
-              "version_removed": "59",
-              "notes": "From Firefox 59, the property is limited to usage in chrome code only."
-            },
-            "firefox_android": {
-              "version_added": "4",
-              "version_removed": "59",
-              "notes": "From Firefox 59, the property is limited to usage in chrome code only."
-            },
+            "firefox": [
+              {
+                "version_added": "60",
+                "version_removed": "60",
+                "notes": "The property was removed completely in Firefox 60."
+              },
+              {
+                "version_added": "1",
+                "version_removed": "59",
+                "notes": "From Firefox 59, the property is limited to usage in chrome code only."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "60",
+                "version_removed": "60",
+                "notes": "The property was removed completely in Firefox 60."
+              },
+              {
+                "version_added": "4",
+                "version_removed": "59",
+                "notes": "From Firefox 59, the property is limited to usage in chrome code only."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/-moz-border-right-colors.json
+++ b/css/properties/-moz-border-right-colors.json
@@ -22,7 +22,7 @@
             },
             "firefox": [
               {
-                "version_added": "60",
+                "version_added": "59",
                 "version_removed": "60",
                 "notes": "The property was removed completely in Firefox 60."
               },
@@ -34,7 +34,7 @@
             ],
             "firefox_android": [
               {
-                "version_added": "60",
+                "version_added": "59",
                 "version_removed": "60",
                 "notes": "The property was removed completely in Firefox 60."
               },

--- a/css/properties/-moz-border-top-colors.json
+++ b/css/properties/-moz-border-top-colors.json
@@ -20,30 +20,16 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": [
-              {
-                "version_added": "59",
-                "version_removed": "60",
-                "notes": "The property was removed completely in Firefox 60."
-              },
-              {
-                "version_added": "1",
-                "version_removed": "59",
-                "notes": "From Firefox 59, the property is limited to usage in chrome code only."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "59",
-                "version_removed": "60",
-                "notes": "The property was removed completely in Firefox 60."
-              },
-              {
-                "version_added": "4",
-                "version_removed": "59",
-                "notes": "From Firefox 59, the property is limited to usage in chrome code only."
-              }
-            ],
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "59",
+              "notes": "In Firefox 59, the property was limited to usage in chrome code only. In Firefox 60 it was removed completely."
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "59",
+              "notes": "In Firefox 59, the property was limited to usage in chrome code only. In Firefox 60 it was removed completely."
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/-moz-border-top-colors.json
+++ b/css/properties/-moz-border-top-colors.json
@@ -20,16 +20,30 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "1",
-              "version_removed": "59",
-              "notes": "From Firefox 59, the property is limited to usage in chrome code only."
-            },
-            "firefox_android": {
-              "version_added": "4",
-              "version_removed": "59",
-              "notes": "From Firefox 59, the property is limited to usage in chrome code only."
-            },
+            "firefox": [
+              {
+                "version_added": "60",
+                "version_removed": "60",
+                "notes": "The property was removed completely in Firefox 60."
+              },
+              {
+                "version_added": "1",
+                "version_removed": "59",
+                "notes": "From Firefox 59, the property is limited to usage in chrome code only."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "60",
+                "version_removed": "60",
+                "notes": "The property was removed completely in Firefox 60."
+              },
+              {
+                "version_added": "4",
+                "version_removed": "59",
+                "notes": "From Firefox 59, the property is limited to usage in chrome code only."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/-moz-border-top-colors.json
+++ b/css/properties/-moz-border-top-colors.json
@@ -22,7 +22,7 @@
             },
             "firefox": [
               {
-                "version_added": "60",
+                "version_added": "59",
                 "version_removed": "60",
                 "notes": "The property was removed completely in Firefox 60."
               },
@@ -34,7 +34,7 @@
             ],
             "firefox_android": [
               {
-                "version_added": "60",
+                "version_added": "59",
                 "version_removed": "60",
                 "notes": "The property was removed completely in Firefox 60."
               },


### PR DESCRIPTION
…ved from Fx altogether

As per https://bugzilla.mozilla.org/show_bug.cgi?id=1429723

I wasn't sure if I've done this right - it felt weird to have to include the version_added property when it is being removed...