### PR TITLE
Mark shape-margin as not deprecated

### DIFF
--- a/css/properties/shape-margin.json
+++ b/css/properties/shape-margin.json
@@ -46,7 +46,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
The CSS `shape-margin` property is [marked as deprecated in the data](https://developer.mozilla.org/en-US/docs/Web/CSS/shape-margin#Browser_compatibility). I can't find any evidence for this.