### PR TITLE
Add Microsoft Edge compat data for the `applications` manifest key

### DIFF
--- a/webextensions/manifest/applications.json
+++ b/webextensions/manifest/applications.json
@@ -9,7 +9,8 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "alternative_name": "browser_specific_settings",
+              "version_added": "15"
             },
             "firefox": {
               "version_added": "48"


### PR DESCRIPTION
This adds the Microsoft Edge compatibility data for the [`applications` manifest key](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/applications).

The version number was extrapolated from the date of [commit `64c3ce1`](https://github.com/MicrosoftDocs/edge-developer/commit/64c3ce142dc09f3bab5f278a61428ff9265ac9ff) in the Microsoft Docs repository.