### PR TITLE
Reinstate toolbar_vertical_separator

### DIFF
--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -647,6 +647,30 @@
                 }
               }
             }
+          },
+          "toolbar_vertical_separator": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "58",
+                  "notes": [
+                    "Before version 59, this had the same meaning as <code>toolbar_field_separator</code>."
+                  ]
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Fix for: https://github.com/mdn/browser-compat-data/issues/1211

As far as I can tell, in Firefox 59:

* the meaning of `toolbar_vertical_separator` changed
* a new property `toolbar_field_separator` was introduced, which means the same thing that `toolbar_vertical_separator` used to mean

https://bugzilla.mozilla.org/show_bug.cgi?id=1423762

@nt1m , please confirm that I've understood.

