### PR TITLE
Add compat data for SVGAnimateElement

### DIFF
--- a/api/SVGAnimateElement.json
+++ b/api/SVGAnimateElement.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "SVGAnimateElement": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimateElement",
+        "support": {
+          "webview_android": {
+            "version_added": false
+          },
+          "chrome": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add compat data for https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimateElement


**Note**: set Edge support as `version_added: null`, however https://developer.microsoft.com/en-us/microsoft-edge/platform/status/svgsmilanimation/ hints the XML-based feature isn't planned on Edge. It might not be enough to conclude the SVG DOM API is not implemented, hence `version_added: null` instead of `version_added: false`. 

<br>

![screen shot 2018-02-28 at 11 48 55 pm](https://user-images.githubusercontent.com/223121/36828034-38e79f18-1ce5-11e8-9a0c-b65555c83316.png)
