### PR TITLE
Add compat data for NavigatorLanguage

### DIFF
--- a/api/NavigatorLanguage.json
+++ b/api/NavigatorLanguage.json
@@ -1,0 +1,291 @@
+{
+  "api": {
+    "NavigatorLanguage": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorLanguage",
+        "support": {
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "ie": {
+            "version_added": true
+          },
+          "opera": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "on_workernavigator": {
+        "__compat": {
+          "description": "on WorkerNavigator",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "35"
+            },
+            "firefox_android": {
+              "version_added": "35"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          }
+        },
+        "language": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorLanguage/language",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true,
+                "notes": "Returns the browser UI language, not the value of the <code>Accept-Language HTTP</code> header."
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": [
+                {
+                  "version_added": "1",
+                  "notes": "Prior to Firefox 4 this property's value was also part of the user agent string, as reported by <code>navigator.userAgent</code>."
+                },
+                {
+                  "version_added": "5",
+                  "notes": "Starting in Firefox 5.0 this property's value is based on the value of the <code>Accept-Language</code> HTTP header."
+                }
+              ],
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "11",
+                "notes": "Closest available (non-standard) properties are <code>userLanguage</code> and <code>browserLanguage</code>."
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "on_workernavigator": {
+            "__compat": {
+              "description": "on WorkerNavigator",
+              "support": {
+                "webview_android": {
+                  "version_added": null
+                },
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "35"
+                },
+                "firefox_android": {
+                  "version_added": "35"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
+        "languages": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorLanguage/languages",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "32",
+                "notes": "In Chrome, <code>navigator.language</code> is the language of the browser UI, and is not guaranteed to be equal to <code>navigator.languages[0]</code>."
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null,
+                "notes": "Will ship in Windows 10 Fall Creators Update"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "32",
+                "notes": "In Firefox, the <code>navigator.languages</code> property's value is taken from the <code>intl.accept_languages</code> preference."
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "11",
+                "notes": "Closest available (non-standard) properties are <code>userLanguage</code> and <code>browserLanguage</code>."
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "11",
+                "notes": "implemented in Safari Technology Preview 16 (10.2)"
+              },
+              "safari_ios": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "on_workernavigator": {
+            "__compat": {
+              "description": "on WorkerNavigator",
+              "support": {
+                "webview_android": {
+                  "version_added": null
+                },
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "35"
+                },
+                "firefox_android": {
+                  "version_added": "35"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage

Can we add `<a href=...` to `notes` ?