### PR TITLE
Sync Firefox compat data for HTMLDialogElement and <dialog>

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -27,7 +27,8 @@
                 "name": "dom.dialog_element.enabled",
                 "value_to_set": "true"
               }
-            ]
+            ],
+            "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
           },
           "firefox_android": {
             "version_added": "53",
@@ -37,7 +38,8 @@
                 "name": "dom.dialog_element.enabled",
                 "value_to_set": "true"
               }
-            ]
+            ],
+            "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
           },
           "ie": {
             "version_added": false
@@ -88,7 +90,8 @@
                   "name": "dom.dialog_element.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
             },
             "firefox_android": {
               "version_added": "53",
@@ -98,7 +101,8 @@
                   "name": "dom.dialog_element.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
             },
             "ie": {
               "version_added": false
@@ -150,7 +154,8 @@
                   "name": "dom.dialog_element.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
             },
             "firefox_android": {
               "version_added": "53",
@@ -160,7 +165,8 @@
                   "name": "dom.dialog_element.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
             },
             "ie": {
               "version_added": false
@@ -212,7 +218,8 @@
                   "name": "dom.dialog_element.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
             },
             "firefox_android": {
               "version_added": "53",
@@ -222,7 +229,8 @@
                   "name": "dom.dialog_element.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
             },
             "ie": {
               "version_added": false
@@ -274,7 +282,8 @@
                   "name": "dom.dialog_element.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
             },
             "firefox_android": {
               "version_added": "53",
@@ -284,7 +293,8 @@
                   "name": "dom.dialog_element.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
             },
             "ie": {
               "version_added": false
@@ -336,7 +346,8 @@
                   "name": "dom.dialog_element.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
             },
             "firefox_android": {
               "version_added": "53",
@@ -346,7 +357,8 @@
                   "name": "dom.dialog_element.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
             },
             "ie": {
               "version_added": false

--- a/html/elements/dialog.json
+++ b/html/elements/dialog.json
@@ -21,11 +21,25 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false,
+              "version_added": "53",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.dialog_element.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
             },
             "firefox_android": {
-              "version_added": false,
+              "version_added": "53",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.dialog_element.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
             },
             "ie": {
@@ -69,11 +83,25 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false,
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
               },
               "firefox_android": {
-                "version_added": false,
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
               },
               "ie": {


### PR DESCRIPTION
This synchronises the Firefox compatibility table data for the [`HTMLDialogElement` API](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement) and the [HTML `<dialog>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog).