### PR TITLE
Prevent tag auto-closing and correctly syntax highlight

### DIFF
--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -92,7 +92,7 @@
         },
         "contain_and_cover": {
           "__compat": {
-            "description": "<contain> and <cover>",
+            "description": "<code>contain</code> and <code>cover</code>",
             "support": {
               "webview_android": {
                 "version_added": null


### PR DESCRIPTION
Original was treated as a tag and auto-closed by something in the docs build. This avoids that and correctly marks up the keywords to appear as monospace/code.