### PR TITLE
Correct XMLHttpRequest

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -2,7 +2,7 @@
   "api": {
     "XMLHttpRequest": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/web/api/XMLHttpRequest",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest",
         "support": {
           "webview_android": {
             "version_added": true

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -773,6 +773,60 @@
           }
         }
       },
+      "timeout": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/timeout",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "29"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "12"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "8"
+            },
+            "opera": [
+              {
+                "version_added": "17"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "16"
+              }
+            ],
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "upload": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/upload",
@@ -1547,54 +1601,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        }
-      },
-      "timeout": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/timeout",
-          "support": {
-            "webview_android": {
-              "version_added": true
-            },
-            "chrome": {
-              "version_added": "29"
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": "12"
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": "8"
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
           }
         }
       }

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1443,6 +1443,59 @@
           }
         }
       },
+      "sendAsBinary": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/sendAsBinary",
+          "support": {
+            "webview_android": {
+              "notes": "There is a <a href='https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/sendAsBinary#sendAsBinary%28%29_polyfill'>polyfill available</a> to support <code>sendAsBinary()</code>.",
+              "version_added": false
+            },
+            "chrome": {
+              "notes": "There is a <a href='https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/sendAsBinary#sendAsBinary%28%29_polyfill'>polyfill available</a> to support <code>sendAsBinary()</code>.",
+              "version_added": false
+            },
+            "chrome_android": {
+              "notes": "There is a <a href='https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/sendAsBinary#sendAsBinary%28%29_polyfill'>polyfill available</a> to support <code>sendAsBinary()</code>.",
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "2",
+              "version_removed": "31"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "31"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
       "setRequestHeader": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/setRequestHeader",
@@ -1494,58 +1547,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        }
-      },
-      "sendAsBinary": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/sendAsBinary",
-          "support": {
-            "webview_android": {
-              "notes": "There is a <a href='https://developer.mozilla.org/docs/Web/API/XMLHttpRequest#sendAsBinary%28%29_polyfill'>polyfill available</a> to support <code>sendAsBinary()</code>.",
-              "version_added": false
-            },
-            "chrome": {
-              "notes": "There is a <a href='https://developer.mozilla.org/docs/Web/API/XMLHttpRequest#sendAsBinary%28%29_polyfill'>polyfill available</a> to support <code>sendAsBinary()</code>.",
-              "version_added": false
-            },
-            "chrome_android": {
-              "notes": "There is a <a href='https://developer.mozilla.org/docs/Web/API/XMLHttpRequest#sendAsBinary%28%29_polyfill'>polyfill available</a> to support <code>sendAsBinary()</code>.",
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "edge_mobile": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "2",
-              "version_removed": "31"
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
           }
         }
       },

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -70,7 +70,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "notes": "Internet Explorer version 5 and 6 supported ajax calls using <code>ActiveXObject()</code>",
@@ -119,7 +119,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "7"
@@ -165,7 +165,7 @@
                 "version_added": "9"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "9"
               },
               "ie": {
                 "version_added": "9"
@@ -206,10 +206,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -254,10 +254,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "notes": "Before IE 10, the value of XMLHttpRequest.responseText could be read only once the request was complete.",
@@ -303,7 +303,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "12"
+              "version_added": "6"
             },
             "firefox_android": {
               "version_added": "50"
@@ -353,7 +353,7 @@
                 "version_added": "6"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "50"
               },
               "ie": {
                 "version_added": "10"
@@ -401,7 +401,7 @@
                 "version_added": "6"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "50"
               },
               "ie": {
                 "version_added": "10"
@@ -449,7 +449,7 @@
                 "version_added": "11"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "50"
               },
               "ie": {
                 "version_added": "10"
@@ -497,7 +497,7 @@
                 "version_added": "10"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "50"
               },
               "ie": {
                 "version_added": false
@@ -601,7 +601,7 @@
               "version_added": "32"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "32"
             },
             "ie": {
               "version_added": false
@@ -650,7 +650,8 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Prior to Firefox 51, an error parsing the received data added a <code>&lt;parsererror&gt;</code> node to the top of the <code>Document</code> and then returned the <code>Document</code> in whatever state it happens to be in. This was inconsistent with the specification. Starting with Firefox 51, this scenario now correctly returns <code>null</code> as per the spec."
             },
             "ie": {
               "version_added": true
@@ -698,7 +699,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "notes": "Internet Explorer version 5 and 6 supported ajax calls using <code>ActiveXObject()</code>",
@@ -747,7 +748,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "notes": "Internet Explorer version 5 and 6 supported ajax calls using <code>ActiveXObject()</code>",
@@ -946,7 +947,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": true
@@ -1004,7 +1005,8 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "Starting from Firefox 49, empty headers are returned as empty strings in case the preference <code>network.http.keep_empty_response_headers_as_empty_string</code> is set to <code>true</code>, defaulting to <code>false</code>. Before Firefox 49 empty headers had been ignored. Since Firefox 50 the preference defaults to <code>true</code>."
             },
             "ie": [
               {
@@ -1056,10 +1058,11 @@
             },
             "firefox": {
               "notes": "Starting from Firefox 49, empty headers are returned as empty strings in case the preference <code>network.http.keep_empty_response_headers_as_empty_string</code> is set to <code>true</code>, defaulting to <code>false</code>. Before Firefox 49 empty headers had been ignored. Since Firefox 50 the preference defaults to <code>true</code>.",
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Starting from Firefox 49, empty headers are returned as empty strings in case the preference <code>network.http.keep_empty_response_headers_as_empty_string</code> is set to <code>true</code>, defaulting to <code>false</code>. Before Firefox 49 empty headers had been ignored. Since Firefox 50 the preference defaults to <code>true</code>."
             },
             "ie": [
               {
@@ -1164,7 +1167,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": true
@@ -1221,7 +1224,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": [
               {
@@ -1275,7 +1278,7 @@
                 "version_added": "9"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "9"
               },
               "ie": {
                 "version_added": "10"
@@ -1324,7 +1327,7 @@
                 "version_added": "20"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "20"
               },
               "ie": {
                 "version_added": null
@@ -1373,7 +1376,7 @@
                 "version_added": "2"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
@@ -1422,7 +1425,7 @@
                 "version_added": "2"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
@@ -1570,7 +1573,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": true


### PR DESCRIPTION
This makes some corrections to the browser compatibility table data for the [`XMLHttpRequest` API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest).