### PR TITLE
Correct ShadowRoot

### DIFF
--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -15,41 +15,33 @@
           },
           "edge": {
             "version_added": false,
-            "notes": "Under consideration"
+            "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
           },
           "edge_mobile": {
             "version_added": false,
-            "notes": "Under consideration"
+            "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
           },
           "firefox": {
             "version_added": "59",
             "flags": [
               {
                 "type": "preference",
-                "name": "dom.webcomponents.enabled",
-                "value_to_set": "true"
-              },
-              {
-                "type": "preference",
                 "name": "dom.webcomponents.shadowdom.enabled",
                 "value_to_set": "true"
               }
-            ]
+            ],
+            "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
           },
           "firefox_android": {
             "version_added": "59",
             "flags": [
               {
                 "type": "preference",
-                "name": "dom.webcomponents.enabled",
-                "value_to_set": "true"
-              },
-              {
-                "type": "preference",
                 "name": "dom.webcomponents.shadowdom.enabled",
                 "value_to_set": "true"
               }
-            ]
+            ],
+            "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
           },
           "ie": {
             "version_added": false
@@ -88,41 +80,33 @@
             },
             "edge": {
               "version_added": false,
-              "notes": "Under consideration"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
             "edge_mobile": {
               "version_added": false,
-              "notes": "Under consideration"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
             "firefox": {
               "version_added": "59",
               "flags": [
                 {
                   "type": "preference",
-                  "name": "dom.webcomponents.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "type": "preference",
                   "name": "dom.webcomponents.shadowdom.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
             },
             "firefox_android": {
               "version_added": "59",
               "flags": [
                 {
                   "type": "preference",
-                  "name": "dom.webcomponents.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "type": "preference",
                   "name": "dom.webcomponents.shadowdom.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
             },
             "ie": {
               "version_added": false
@@ -162,41 +146,33 @@
             },
             "edge": {
               "version_added": false,
-              "notes": "Under consideration"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
             "edge_mobile": {
               "version_added": false,
-              "notes": "Under consideration"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
             "firefox": {
               "version_added": "59",
               "flags": [
                 {
                   "type": "preference",
-                  "name": "dom.webcomponents.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "type": "preference",
                   "name": "dom.webcomponents.shadowdom.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
             },
             "firefox_android": {
               "version_added": "59",
               "flags": [
                 {
                   "type": "preference",
-                  "name": "dom.webcomponents.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "type": "preference",
                   "name": "dom.webcomponents.shadowdom.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
             },
             "ie": {
               "version_added": false
@@ -236,41 +212,33 @@
             },
             "edge": {
               "version_added": false,
-              "notes": "Under consideration"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
             "edge_mobile": {
               "version_added": false,
-              "notes": "Under consideration"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
             "firefox": {
               "version_added": "59",
               "flags": [
                 {
                   "type": "preference",
-                  "name": "dom.webcomponents.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "type": "preference",
                   "name": "dom.webcomponents.shadowdom.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
             },
             "firefox_android": {
               "version_added": "59",
               "flags": [
                 {
                   "type": "preference",
-                  "name": "dom.webcomponents.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "type": "preference",
                   "name": "dom.webcomponents.shadowdom.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
             },
             "ie": {
               "version_added": false
@@ -297,8 +265,7 @@
       },
       "documentorshadowroot": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/mode",
-          "description": "Features included from the <a href='https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot'>DocumentOrShadowRoot</a> mixin",
+          "description": "Features included from the <a href='https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot'><code>DocumentOrShadowRoot</code></a> mixin",
           "support": {
             "webview_android": {
               "version_added": "53"
@@ -319,11 +286,17 @@
             },
             "firefox": {
               "version_added": false,
-              "notes": "Features still implemented on the <a href='https://developer.mozilla.org/docs/Web/API/Document'>Document</a> interface"
+              "notes": [
+                "Features still implemented on the <a href='https://developer.mozilla.org/docs/Web/API/Document'>Document</a> interface",
+                "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+              ]
             },
             "firefox_android": {
               "version_added": false,
-              "notes": "Features still implemented on the <a href='https://developer.mozilla.org/docs/Web/API/Document'>Document</a> interface"
+              "notes": [
+                "Features still implemented on the <a href='https://developer.mozilla.org/docs/Web/API/Document'>Document</a> interface",
+                "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+              ]
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This makes some corrections to the browser compatibility table data for the [`ShadowRoot` API](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot).