### PR TITLE
Correct WorkerGlobalScope

### DIFF
--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -450,26 +450,14 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": [
-              {
-                "version_added": "30"
-              },
-              {
-                "version_added": "29",
-                "version_removed": "30",
-                "alternative_name": "WorkerConsole"
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "30"
-              },
-              {
-                "version_added": "29",
-                "version_removed": "30",
-                "alternative_name": "WorkerConsole"
-              }
-            ],
+            "firefox": {
+              "version_added": "29",
+              "notes": "Before Firefox 30, the console would be of type <code>WorkerConsole</code> instead of <code>Console</code>."
+            },
+            "firefox_android": {
+              "version_added": "29",
+              "notes": "Before Firefox 30, the console would be of type <code>WorkerConsole</code> instead of <code>Console</code>."
+            },
             "ie": {
               "version_added": true
             },

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -452,20 +452,22 @@
             },
             "firefox": [
               {
-                "version_added": "29",
-                "alternative_name": "WorkerConsole"
+                "version_added": "30"
               },
               {
-                "version_added": "30"
+                "version_added": "29",
+                "version_removed": "30",
+                "alternative_name": "WorkerConsole"
               }
             ],
             "firefox_android": [
               {
-                "version_added": "29",
-                "alternative_name": "WorkerConsole"
+                "version_added": "30"
               },
               {
-                "version_added": "30"
+                "version_added": "29",
+                "version_removed": "30",
+                "alternative_name": "WorkerConsole"
               }
             ],
             "ie": {


### PR DESCRIPTION
This corrects the Firefox version support for the [`WorkerGlobalScope.console`](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/console) sub-feature support.