### PR TITLE
Update CSS caret-support support for Safari

### DIFF
--- a/css/properties/caret-color.json
+++ b/css/properties/caret-color.json
@@ -36,10 +36,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             }
           },
           "status": {

--- a/css/properties/caret-color.json
+++ b/css/properties/caret-color.json
@@ -39,7 +39,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": "11.1"
             }
           },
           "status": {


### PR DESCRIPTION
Webkit support has been [implemented in Safari Tech Preview 38](https://webkit.org/blog/7877/release-notes-for-safari-technology-preview-38/)
According to https://caniuse.com/#feat=css-caret-color this property will be supported by Safari 11.1 and iOS Safari 11.3