### PR TITLE
Add Safari and Node WebAssembly results

### DIFF
--- a/javascript/builtins/WebAssembly.json
+++ b/javascript/builtins/WebAssembly.json
@@ -38,7 +38,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": null
+              "version_added": "8"
             },
             "opera": {
               "version_added": "44"
@@ -96,7 +96,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "8"
               },
               "opera": {
                 "version_added": "44"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "8"
               },
               "opera": {
                 "version_added": "44"
@@ -213,7 +213,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "8"
                 },
                 "opera": {
                   "version_added": "44"
@@ -272,7 +272,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "8"
                 },
                 "opera": {
                   "version_added": "44"
@@ -332,7 +332,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "8"
               },
               "opera": {
                 "version_added": "44"
@@ -391,7 +391,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "8"
               },
               "opera": {
                 "version_added": "44"
@@ -449,7 +449,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "8"
                 },
                 "opera": {
                   "version_added": "44"
@@ -508,7 +508,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "8"
                 },
                 "opera": {
                   "version_added": "44"
@@ -567,7 +567,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "8"
                 },
                 "opera": {
                   "version_added": "44"
@@ -627,7 +627,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "8"
               },
               "opera": {
                 "version_added": "44"
@@ -685,7 +685,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "8"
                 },
                 "opera": {
                   "version_added": "44"
@@ -744,7 +744,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "8"
                 },
                 "opera": {
                   "version_added": "44"
@@ -803,7 +803,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "8"
                 },
                 "opera": {
                   "version_added": "44"
@@ -862,7 +862,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "8"
                 },
                 "opera": {
                   "version_added": "44"
@@ -922,7 +922,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "8"
               },
               "opera": {
                 "version_added": "44"
@@ -981,7 +981,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "8"
               },
               "opera": {
                 "version_added": "44"
@@ -1039,7 +1039,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "8"
                 },
                 "opera": {
                   "version_added": "44"
@@ -1098,7 +1098,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "8"
                 },
                 "opera": {
                   "version_added": "44"
@@ -1157,7 +1157,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "8"
                 },
                 "opera": {
                   "version_added": "44"
@@ -1216,7 +1216,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "8"
                 },
                 "opera": {
                   "version_added": "44"
@@ -1275,7 +1275,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "8"
                 },
                 "opera": {
                   "version_added": "44"
@@ -1335,7 +1335,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "8"
               },
               "opera": {
                 "version_added": "44"
@@ -1445,7 +1445,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "8"
               },
               "opera": {
                 "version_added": "44"
@@ -1555,7 +1555,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "8"
               },
               "opera": {
                 "version_added": "44"

--- a/javascript/builtins/WebAssembly.json
+++ b/javascript/builtins/WebAssembly.json
@@ -1386,7 +1386,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "47"
@@ -1395,10 +1395,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {
@@ -1496,7 +1496,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "47"
@@ -1505,10 +1505,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
Streaming compilation and instantiation of wasm checked in latest Safari 11.1 (13605.1.27.2.1) Beta and Node 9.7.1

Node has all basic wasm features starting from version 8.0.0 (v8 5.7)