### PR TITLE
Added mandatory applicationServerKey for chrome

### DIFF
--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -273,7 +273,7 @@
             "chrome": {
               "version_added": "42",
               "notes": [
-                "options parameter with applicationServerKey value is required"
+                "The <code>options</code> parameter with a <code>applicationServerKey</code> value is required."
               ]
             },
             "chrome_android": {

--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -271,7 +271,10 @@
               "version_added": false
             },
             "chrome": {
-              "version_added": "42"
+              "version_added": "42",
+              "notes": [
+                "options parameter with applicationServerKey value is required"
+              ]
             },
             "chrome_android": {
               "version_added": "42"


### PR DESCRIPTION
In chrome, `applicationServerKey` is required and not optional. I dont know about chrome mobile or android! I can assure that its optional in Firefox.