### PR TITLE
Add missing HTML global attributes

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -49,6 +49,66 @@
           }
         }
       },
+      "autocapitalize": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/autocapitalize",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "qq_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "uc_android": {
+              "version_added": null
+            },
+            "uc_chinese_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "class": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/class",
@@ -99,15 +159,50 @@
       },
       "contextmenu": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/class",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/contextmenu",
           "support": {
-            "chrome": {
+            "webview_android": {
               "version_added": true,
-              "version_removed": "52"
+              "version_removed": "52",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              ]
             },
+            "chrome": [
+              {
+                "version_added": "52",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--enable-blink-features",
+                    "value_to_set": "ContextMenu"
+                  }
+                ],
+                "notes": "This was removed from the <i>Enable Experimental Web Platform Features</i> due to a <a href='https://crbug.com/412945'>Web compatibility issue</a>. In June 2017, it was removed entirely from the browsers. This is documented in <a href='https://crbug.com/87553'>Chromium bug 87553</a>."
+              },
+              {
+                "version_added": true,
+                "version_removed": "52",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
+              }
+            ],
             "chrome_android": {
               "version_added": true,
-              "version_removed": "52"
+              "version_removed": "52",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              ]
             },
             "edge": {
               "version_added": false
@@ -120,15 +215,35 @@
             },
             "firefox_android": {
               "version_added": "32",
-              "version_removed": "56"
+              "version_removed": "56",
+              "notes": "Support for the <code>contextmenu</code> attribute has been removed from Firefox for Android (See <a href='https://bugzil.la/1424252'>bug 1424252</a>)."
             },
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true,
-              "version_removed": "39"
-            },
+            "opera": [
+              {
+                "version_added": "39",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--enable-blink-features",
+                    "value_to_set": "ContextMenu"
+                  }
+                ],
+                "notes": "This was removed from the <i>Enable Experimental Web Platform Features</i> due to a <a href='https://crbug.com/412945'>Web compatibility issue</a>. In June 2017, it was removed entirely from the browsers. This is documented in <a href='https://crbug.com/87553'>Chromium bug 87553</a>."
+              },
+              {
+                "version_added": true,
+                "version_removed": "39",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": false
             },
@@ -136,11 +251,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": true,
-              "version_removed": "52"
+              "version_added": false
             }
           },
           "status": {
@@ -349,10 +460,175 @@
           }
         }
       },
+      "id": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/id",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": true,
+                "version_removed": "32",
+                "partial_implementation": true,
+                "notes": "<code>id</code> is a true global attribute only since Firefox 32."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": true,
+                "version_removed": "32",
+                "partial_implementation": true,
+                "notes": "<code>id</code> is a true global attribute only since Firefox 32."
+              }
+            ],
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "is": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/is",
+          "support": {
+            "webview_android": {
+              "version_added": "66"
+            },
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.customelements.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.customelements.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.customelements.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.customelements.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "53"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "itemid": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/itemid",
           "support": {
+            "webview_android": {
+              "version_added": true
+            },
             "chrome": {
               "version_added": true
             },
@@ -385,8 +661,53 @@
             },
             "safari_ios": {
               "version_added": true
-            },
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "itemprop": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/itemprop",
+          "support": {
             "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
               "version_added": true
             }
           },
@@ -401,6 +722,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/itemref",
           "support": {
+            "webview_android": {
+              "version_added": true
+            },
             "chrome": {
               "version_added": true
             },
@@ -432,9 +756,6 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": true
-            },
-            "webview_android": {
               "version_added": true
             }
           },
@@ -449,6 +770,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/itemscope",
           "support": {
+            "webview_android": {
+              "version_added": true
+            },
             "chrome": {
               "version_added": true
             },
@@ -481,8 +805,53 @@
             },
             "safari_ios": {
               "version_added": true
-            },
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "itemtype": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/itemtype",
+          "support": {
             "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
               "version_added": true
             }
           },


### PR DESCRIPTION
This adds the missing [`autocapitalize`](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/autocapitalize), [`id`](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/id), [`is`](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/is), [`itemprop`](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/itemprop) and [`itemtype`](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/itemtype) [HTML global attributes](https://developer.mozilla.org/docs/Web/HTML/Global_attributes) and corrects the [`contextmenu` HTML global attribute](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/contextmenu)

---

Fixes #914