### PR TITLE
Update XHR open() to note Firefox doesn't allow sync

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1112,17 +1112,13 @@
             "edge_mobile": {
               "version_added": true
             },
-            "firefox": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": "30",
-                "notes": "Starting in Firefox 30, synchronous requests on the main thread have been deprecated due to their negative impact on performance and the user experience. Therefore, the <code>async</code> parameter may not be <code>false</code> except in a <code>Worker</code>."
-              }
-            ],
+            "firefox": {
+              "version_added": true,
+              "notes": "Starting in Firefox 30, synchronous requests on the main thread have been deprecated due to their negative impact on performance and the user experience. Therefore, the <code>async</code> parameter may not be <code>false</code> except in a <code>Worker</code>."
+            },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Starting in Firefox 30, synchronous requests on the main thread have been deprecated due to their negative impact on performance and the user experience. Therefore, the <code>async</code> parameter may not be <code>false</code> except in a <code>Worker</code>."
             },
             "ie": [
               {

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1112,9 +1112,15 @@
             "edge_mobile": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": true
-            },
+            "firefox": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": "30",
+                "notes": "Starting in Firefox 30, synchronous requests on the main thread have been deprecated due to their negative impact on performance and the user experience. Therefore, the <code>async</code> parameter may not be <code>false</code> except in a <code>Worker</code>."
+              }
+            ],
             "firefox_android": {
               "version_added": true
             },


### PR DESCRIPTION
Add a note to XMLHttpRequest.open() to explain that Firefox
30 no longer permits the async parameter to be set to
false and why.