### PR TITLE
Improve -moz-border-*-colors notes formatting

### DIFF
--- a/css/properties/-moz-border-bottom-colors.json
+++ b/css/properties/-moz-border-bottom-colors.json
@@ -23,12 +23,18 @@
             "firefox": {
               "version_added": "1",
               "version_removed": "59",
-              "notes": "In Firefox 59, the property was limited to usage in chrome code only. In Firefox 60 it was removed completely."
+              "notes": [
+                "In Firefox 59, the property was limited to usage in chrome code only (See <a href='https://bugzil.la/1417200'>bug 1417200</a>).",
+                "In Firefox 60, the property was removed completely (See <a href='https://bugzil.la/1429723'>bug 1429723</a>)."
+              ]
             },
             "firefox_android": {
               "version_added": "4",
               "version_removed": "59",
-              "notes": "In Firefox 59, the property was limited to usage in chrome code only. In Firefox 60 it was removed completely."
+              "notes": [
+                "In Firefox 59, the property was limited to usage in chrome code only (See <a href='https://bugzil.la/1417200'>bug 1417200</a>).",
+                "In Firefox 60, the property was removed completely (See <a href='https://bugzil.la/1429723'>bug 1429723</a>)."
+              ]
             },
             "ie": {
               "version_added": false

--- a/css/properties/-moz-border-left-colors.json
+++ b/css/properties/-moz-border-left-colors.json
@@ -23,12 +23,18 @@
             "firefox": {
               "version_added": "1",
               "version_removed": "59",
-              "notes": "In Firefox 59, the property was limited to usage in chrome code only. In Firefox 60 it was removed completely."
+              "notes": [
+                "In Firefox 59, the property was limited to usage in chrome code only (See <a href='https://bugzil.la/1417200'>bug 1417200</a>).",
+                "In Firefox 60, the property was removed completely (See <a href='https://bugzil.la/1429723'>bug 1429723</a>)."
+              ]
             },
             "firefox_android": {
               "version_added": "4",
               "version_removed": "59",
-              "notes": "In Firefox 59, the property was limited to usage in chrome code only. In Firefox 60 it was removed completely."
+              "notes": [
+                "In Firefox 59, the property was limited to usage in chrome code only (See <a href='https://bugzil.la/1417200'>bug 1417200</a>).",
+                "In Firefox 60, the property was removed completely (See <a href='https://bugzil.la/1429723'>bug 1429723</a>)."
+              ]
             },
             "ie": {
               "version_added": false

--- a/css/properties/-moz-border-right-colors.json
+++ b/css/properties/-moz-border-right-colors.json
@@ -23,12 +23,18 @@
             "firefox": {
               "version_added": "1",
               "version_removed": "59",
-              "notes": "In Firefox 59, the property was limited to usage in chrome code only. In Firefox 60 it was removed completely."
+              "notes": [
+                "In Firefox 59, the property was limited to usage in chrome code only (See <a href='https://bugzil.la/1417200'>bug 1417200</a>).",
+                "In Firefox 60, the property was removed completely (See <a href='https://bugzil.la/1429723'>bug 1429723</a>)."
+              ]
             },
             "firefox_android": {
               "version_added": "4",
               "version_removed": "59",
-              "notes": "In Firefox 59, the property was limited to usage in chrome code only. In Firefox 60 it was removed completely."
+              "notes": [
+                "In Firefox 59, the property was limited to usage in chrome code only (See <a href='https://bugzil.la/1417200'>bug 1417200</a>).",
+                "In Firefox 60, the property was removed completely (See <a href='https://bugzil.la/1429723'>bug 1429723</a>)."
+              ]
             },
             "ie": {
               "version_added": false

--- a/css/properties/-moz-border-top-colors.json
+++ b/css/properties/-moz-border-top-colors.json
@@ -23,12 +23,18 @@
             "firefox": {
               "version_added": "1",
               "version_removed": "59",
-              "notes": "In Firefox 59, the property was limited to usage in chrome code only. In Firefox 60 it was removed completely."
+              "notes": [
+                "In Firefox 59, the property was limited to usage in chrome code only (See <a href='https://bugzil.la/1417200'>bug 1417200</a>).",
+                "In Firefox 60, the property was removed completely (See <a href='https://bugzil.la/1429723'>bug 1429723</a>)."
+              ]
             },
             "firefox_android": {
               "version_added": "4",
               "version_removed": "59",
-              "notes": "In Firefox 59, the property was limited to usage in chrome code only. In Firefox 60 it was removed completely."
+              "notes": [
+                "In Firefox 59, the property was limited to usage in chrome code only (See <a href='https://bugzil.la/1417200'>bug 1417200</a>).",
+                "In Firefox 60, the property was removed completely (See <a href='https://bugzil.la/1429723'>bug 1429723</a>)."
+              ]
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This improves the formatting of the [`-moz-border-bottom-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-border-bottom-colors#Browser_compatibility), [`-moz-border-left-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-border-left-colors#Browser_compatibility), [`-moz-border-right-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-border-right-colors#Browser_compatibility) and [`-moz-border-top-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-border-top-colors#Browser_compatibility) browser compatibility notes.