### PR TITLE
Add -moz-image-rect(…)

### DIFF
--- a/css/types/-moz-image-rect.json
+++ b/css/types/-moz-image-rect.json
@@ -22,7 +22,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "2"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
@@ -58,7 +58,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": false,
             "deprecated": false
           }

--- a/css/types/-moz-image-rect.json
+++ b/css/types/-moz-image-rect.json
@@ -1,0 +1,69 @@
+{
+  "css": {
+    "types": {
+      "-moz-image-rect": {
+        "__compat": {
+          "description": "<code>-moz-image-rect()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-image-rect",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "2"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "qq_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=32177'>WebKit bug 32177</a>"
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=32177'>WebKit bug 32177</a>"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "uc_android": {
+              "version_added": false
+            },
+            "uc_chinese_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds the browser compatibility table data for the [`-moz-image-rect(…)` CSS type](https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-image-rect).

See [bug 113577](https://bugzil.la/113577) for the version when this was implemented (1.9.3a1).