### PR TITLE
Add compat data for CSSStyleSheet

### DIFF
--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -195,119 +195,95 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/insertRule",
           "support": {
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": "60",
-                "notes": "<code>index</code> is optional"
-              }
-            ],
-            "chrome": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": "60",
-                "notes": "<code>index</code> is optional"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": "60",
-                "notes": "<code>index</code> is optional"
-              }
-            ],
-            "edge": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": null,
-                "notes": "<code>index</code> is optional"
-              }
-            ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": null,
-                "notes": "<code>index</code> is optional"
-              }
-            ],
-            "firefox": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": null,
-                "notes": "<code>index</code> is optional"
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": null,
-                "notes": "<code>index</code> is optional"
-              }
-            ],
-            "ie": [
-              {
-                "version_added": "9"
-              },
-              {
-                "version_added": null,
-                "notes": "<code>index</code> is optional"
-              }
-            ],
-            "opera": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": "47",
-                "notes": "<code>index</code> is optional"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": "47",
-                "notes": "<code>index</code> is optional"
-              }
-            ],
-            "safari": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": null,
-                "notes": "<code>index</code> is optional"
-              }
-            ],
-            "safari_ios": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": null,
-                "notes": "<code>index</code> is optional"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "optional_index": {
+          "__compat": {
+            "description": "<code>index</code> is optional",
+            "support": {
+              "webview_android": {
+                "version_added": "60"
+              },
+              "chrome": {
+                "version_added": "60"
+              },
+              "chrome_android": {
+                "version_added": "60"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "47"
+              },
+              "opera_android": {
+                "version_added": "47"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -1,0 +1,316 @@
+{
+  "api": {
+    "CSSStyleSheet": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet",
+        "support": {
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "cssRules": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/cssRules",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ownerRule": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/ownerRule",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteRule": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/deleteRule",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "insertRule": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/insertRule",
+          "support": {
+            "webview_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": "60",
+                "notes": "<code>index</code> is optional"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": "60",
+                "notes": "<code>index</code> is optional"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": "60",
+                "notes": "<code>index</code> is optional"
+              }
+            ],
+            "edge": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": null,
+                "notes": "<code>index</code> is optional"
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": null,
+                "notes": "<code>index</code> is optional"
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": null,
+                "notes": "<code>index</code> is optional"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": null,
+                "notes": "<code>index</code> is optional"
+              }
+            ],
+            "ie": [
+              {
+                "version_added": "9"
+              },
+              {
+                "version_added": null,
+                "notes": "<code>index</code> is optional"
+              }
+            ],
+            "opera": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": "47",
+                "notes": "<code>index</code> is optional"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": "47",
+                "notes": "<code>index</code> is optional"
+              }
+            ],
+            "safari": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": null,
+                "notes": "<code>index</code> is optional"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": null,
+                "notes": "<code>index</code> is optional"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The previous spec is obsolete and new spec is an editor's draft. Is the compat data out-of-date?