### PR TITLE
Update chrome browser releases data

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -256,12 +256,16 @@
         },
         "64": {
           "release_date": "2018-01-23",
-          "status": "current"
+          "status": "retired"
         },
         "65": {
-          "status": "beta"
+          "release_date": "2018-03-06",
+          "status": "current"
         },
         "66": {
+          "status": "beta"
+        },
+        "67": {
           "status": "nightly"
         }
       }


### PR DESCRIPTION
Updated according to https://chromereleases.googleblog.com/2018/03/stable-channel-update-for-desktop.html