### PR TITLE
Add helper script for sorting browser versions

### DIFF
--- a/helper-scripts/sort-versions.js
+++ b/helper-scripts/sort-versions.js
@@ -1,0 +1,45 @@
+/* eslint-env node */
+
+const fs = require('fs');
+
+const fileName = process.argv.slice(2)[0];
+
+console.log(`Sorting version arrays in ${fileName}`);
+
+const data = fs.readFileSync(fileName);
+const compatData = JSON.parse(data.toString());
+
+const apiName = Object.keys(compatData.api);
+const methods = Object.keys(compatData.api[apiName]);
+
+const api = compatData.api[apiName];
+
+methods.forEach(method => {
+  const support = api[method].support || api[method].__compat.support;
+  const browsers = Object.keys(support);
+
+  browsers.forEach(browser => {
+    let supportData = support[browser];
+
+    if (!Array.isArray(supportData)) {
+      return;
+    }
+
+    supportData = supportData.sort((a, b) => {
+      if (a.version_added && b.version_added) {
+        const av = parseFloat(a.version_added);
+        const bv = parseFloat(b.version_added);
+
+        return bv - av;
+      }
+    });
+  });
+});
+
+fs.writeFile(fileName, JSON.stringify(compatData, null, 2), err => {
+  if (err) {
+    return console.log(err);
+  }
+
+  console.log(`Versions have been sorted ${fileName}.`);
+});

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint": "node test/lint",
     "render": "node test/render",
     "show-errors": "npm test 1> /dev/null",
-    "test": "npm run lint"
+    "test": "npm run lint",
+    "sort-versions": "node ./helper-scripts/sort-versions.js"
   }
 }


### PR DESCRIPTION
Making own PR for the helper script after this comment: https://github.com/mdn/browser-compat-data/pull/1122#issuecomment-371462746

This add a script that sorts browser versions in reverse chronological for you, since it's a little bit annoying to keep that in mind yourself when making the JSON, and more so when having to change it later! :)

To be run like this; `npm run sort-versions api/URL.json`