### PR TITLE
Add missing note to :-moz-system-metric(windows-default-theme)

### DIFF
--- a/css/selectors/-moz-system-metric.json
+++ b/css/selectors/-moz-system-metric.json
@@ -477,12 +477,18 @@
               "firefox": {
                 "version_added": "3",
                 "version_removed": "58",
-                "notes": "Internal only since Firefox 58 (See <a href='https://bugzil.la/1396066'>bug 1396066</a>)."
+                "notes": [
+                  "Internal only since Firefox 58 (See <a href='https://bugzil.la/1396066'>bug 1396066</a>).",
+                  "Implemented in <a href='https://bugzil.la/426660'>bug 426660</a>. Changed the behavior of Royale and Zone to work the same as Luna in <a href='https://bugzil.la/429176'>bug 429176</a>."
+                ]
               },
               "firefox_android": {
                 "version_added": "4",
                 "version_removed": "58",
-                "notes": "Internal only since Firefox 58 (See <a href='https://bugzil.la/1396066'>bug 1396066</a>)."
+                "notes": [
+                  "Internal only since Firefox 58 (See <a href='https://bugzil.la/1396066'>bug 1396066</a>).",
+                  "Implemented in <a href='https://bugzil.la/426660'>bug 426660</a>. Changed the behavior of Royale and Zone to work the same as Luna in <a href='https://bugzil.la/429176'>bug 429176</a>."
+                ]
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This adds the missing note from [`:-moz-system-metric(windows-default-theme)`](https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-system-metric(windows-default-theme)#Browser_compatibility).