### PR TITLE
Add flags information to AnimationTimeline

### DIFF
--- a/api/AnimationTimeline.json
+++ b/api/AnimationTimeline.json
@@ -19,12 +19,38 @@
           "edge_mobile": {
             "version_added": null
           },
-          "firefox": {
-            "version_added": "48"
-          },
-          "firefox_android": {
-            "version_added": "48"
-          },
+          "firefox": [
+            {
+              "version_added": "48"
+            },
+            {
+              "version_added": "45",
+              "version_removed": "48",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.core.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "48"
+            },
+            {
+              "version_added": "45",
+              "version_removed": "48",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.core.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "ie": {
             "version_added": false
           },


### PR DESCRIPTION
This adds the [`flags`](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#flags) information to the [`AnimationTimeline` API](https://developer.mozilla.org/en-US/docs/Web/API/AnimationTimeline) ([old version](https://developer.mozilla.org/en-US/docs/Web/API/AnimationTimeline$revision/1137307#Browser_compatibility)).