### PR TITLE
Add compat data for SVGAnimateMotionElement

### DIFF
--- a/api/SVGAnimateMotionElement.json
+++ b/api/SVGAnimateMotionElement.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "SVGAnimateMotionElement": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimateMotionElement",
+        "support": {
+          "webview_android": {
+            "version_added": false
+          },
+          "chrome": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": "10"
+          },
+          "safari_ios": {
+            "version_added": "9"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimateMotionElement

Set Safari and Safari IOS versions based on https://developer.apple.com/documentation/webkitjs/svganimatemotionelement