### PR TITLE
Add compat data for SVGAnimatedAngle

### DIFF
--- a/api/SVGAnimatedAngle.json
+++ b/api/SVGAnimatedAngle.json
@@ -38,7 +38,7 @@
             "version_added": "10"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "3"
           }
         },
         "status": {

--- a/api/SVGAnimatedAngle.json
+++ b/api/SVGAnimatedAngle.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "SVGAnimatedAngle": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedAngle",
+        "support": {
+          "webview_android": {
+            "version_added": false
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": null
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": "10"
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimatedAngle

Per https://developer.apple.com/documentation/webkitjs/svganimatedangle the support on Safari is as follow:
Safari Desktop 10.0+
Safari Mobile 2.1+

Set Safari desktop version to "10", but for Safari IOS had to set to "true" as linter wouldn't allow me to set "2.1" (not a valid browser version error).
