### PR TITLE
Add compat data for :scope selector: Not supported in Edge

### DIFF
--- a/css/selectors/scope.json
+++ b/css/selectors/scope.json
@@ -16,7 +16,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -87,7 +87,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null


### PR DESCRIPTION
neither basic nor querySelector support

Tested using codepen: https://codepen.io/bertyhell/pen/zWYPaR?editors=1010

Result for chrome 64 (64.0.3282.186): 
![image](https://user-images.githubusercontent.com/1710840/37183526-cb9f4f34-2336-11e8-8707-54bb43db9710.png)

Result for edge 16 (41.16299.248.0):
![image](https://user-images.githubusercontent.com/1710840/37183545-db9cfb66-2336-11e8-9ae7-4869d5e5001e.png)
