### PR TITLE
Update nodejs compat for Array.includes()

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -696,7 +696,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "6"
               },
               "opera": {
                 "version_added": "34"


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes

Check compatibility on [node.green](http://node.green/#ES2016-features-Array-prototype-includes-Array-prototype-includes)