### PR TITLE
Update versioning info for some animation APIs

### DIFF
--- a/api/AnimationEffectReadOnly.json
+++ b/api/AnimationEffectReadOnly.json
@@ -67,10 +67,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "48"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "ie": {
               "version_added": false
@@ -115,10 +115,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "48"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "ie": {
               "version_added": false

--- a/api/AnimationEffectReadOnly.json
+++ b/api/AnimationEffectReadOnly.json
@@ -67,7 +67,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "53"
             },
             "firefox_android": {
               "version_added": false
@@ -115,7 +115,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "53"
             },
             "firefox_android": {
               "version_added": false

--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -275,7 +275,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
               "version_removed": "16"
             },
             "edge_mobile": {

--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -200,7 +200,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "9"
             },
             "safari_ios": {
               "version_added": null
@@ -221,7 +221,7 @@
               "version_added": true
             },
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
               "version_added": "43"
@@ -248,7 +248,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "9"
             },
             "safari_ios": {
               "version_added": true
@@ -275,7 +275,8 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": null
+              "version_added": true,
+              "version_removed": "16"
             },
             "edge_mobile": {
               "version_added": null


### PR DESCRIPTION
Updates are based on the first few rows after clicking "Expand All" on the
Web API Confluence Dashboard:

[Firefox support for AnimationEffectReadOnly](https://web-confluence.appspot.com/#!/catalog?releaseKeys=%5B%22Firefox_52.0_Windows_10.0%22,%22Firefox_53.0_Windows_10.0%22,%22Firefox_54.0_Windows_10.0%22,%22Firefox_55.0_Windows_10.0%22,%22Firefox_56.0_Windows_10.0%22%5D&releaseOptions=null&numAvailable=null&currentPage=0&gap=5&itemPerPage=15&searchKey=%22timing%22)

[Chrome support for AnimationEvent](https://web-confluence.appspot.com/#!/catalog?releaseKeys=%5B%22Chrome_42.0.2311.135_Windows_10.0%22,%22Chrome_43.0.2357.81_Windows_10.0%22,%22Chrome_44.0.2403.89_Windows_10.0%22%5D&releaseOptions=null&numAvailable=null&currentPage=0&gap=5&itemPerPage=15&searchKey=%22AnimationEvent%22)

@jpmedley PTAL at Chrome case. Not sure how is best to review Firefox.