### PR TITLE
More accurate Animation API data for Safari

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -342,7 +342,8 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "10",
+              "version_removed": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1327,7 +1328,8 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "10",
+              "version_removed": "11"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
[Safari version info according to Web API Confluence Dashboard](https://web-confluence.appspot.com/#!/catalog?releaseKeys=%5B%22Safari_8.0.8_OSX_10.10.5%22,%22Safari_9.1.3_OSX_10.11.6%22,%22Safari_10.1.2_OSX_10.12.6%22,%22Safari_11.0_OSX_10.12.6%22%5D&releaseOptions=null&numAvailable=null&currentPage=0&gap=5&itemPerPage=15&searchKey=%22Animation%23%22)

I'm less confident that this change than [my other animation update](https://github.com/mdn/browser-compat-data/pull/1331). It appears to be true that Safari shipped-then-unshipped this feature, but is that useful for developers?