### PR TITLE
update PerformanceResourceTiming support since safari(mac/ios) 11

### DIFF
--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -35,10 +35,10 @@
             "version_added": "30"
           },
           "safari": {
-            "version_added": false
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11"
           }
         },
         "status": {
@@ -82,10 +82,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             }
           },
           "status": {
@@ -130,10 +130,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             }
           },
           "status": {
@@ -226,10 +226,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             }
           },
           "status": {
@@ -274,10 +274,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             }
           },
           "status": {
@@ -370,10 +370,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             }
           },
           "status": {
@@ -418,10 +418,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             }
           },
           "status": {
@@ -514,10 +514,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             }
           },
           "status": {
@@ -562,10 +562,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             }
           },
           "status": {
@@ -610,10 +610,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             }
           },
           "status": {
@@ -658,10 +658,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             }
           },
           "status": {
@@ -706,10 +706,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             }
           },
           "status": {
@@ -754,10 +754,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             }
           },
           "status": {
@@ -850,10 +850,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             }
           },
           "status": {
@@ -898,10 +898,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             }
           },
           "status": {


### PR DESCRIPTION
Update PerformanceResourceTiming support for Safari 11.

Reference:
https://webkit.org/blog/7956/new-webkit-features-in-safari-11/

Testing done:
<img width="378" alt="image" src="https://user-images.githubusercontent.com/97426/37239189-c50281ea-23eb-11e8-8fbe-0303b1c61dc8.png">
