### PR TITLE
Fix cosmetic details in text-align-last

### DIFF
--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -10,6 +10,9 @@
             },
             "chrome": [
               {
+                "version_added": "47"
+              },
+              {
                 "version_added": "35",
                 "version_removed": "47",
                 "flags": [
@@ -19,13 +22,13 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "47"
               }
             ],
             "chrome_android": [
               {
+                "version_added": "47"
+              },
+              {
                 "version_added": "35",
                 "version_removed": "47",
                 "flags": [
@@ -35,9 +38,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "47"
               }
             ],
             "edge": {
@@ -48,22 +48,22 @@
             },
             "firefox": [
               {
+                "version_added": "49"
+              },
+              {
                 "prefix": "-moz-",
                 "version_added": "12",
                 "version_removed": "53"
-              },
-              {
-                "version_added": "49"
               }
             ],
             "firefox_android": [
               {
+                "version_added": "49"
+              },
+              {
                 "prefix": "-moz-",
                 "version_added": "14",
                 "version_removed": "53"
-              },
-              {
-                "version_added": "49"
               }
             ],
             "ie": {
@@ -77,11 +77,11 @@
             },
             "safari": {
               "version_added": false,
-              "notes": "See Webkit bug 76173."
+              "notes": "See WebKit <a href='https://bugs.webkit.org/show_bug.cgi?id=76173'>bug 76173</a>."
             },
             "safari_ios": {
               "version_added": false,
-              "notes": "See Webkit bug 76173."
+              "notes": "See WebKit <a href='https://bugs.webkit.org/show_bug.cgi?id=76173'>bug 76173</a>."
             }
           },
           "status": {


### PR DESCRIPTION
This PR fixes a couple of cosmetic details for `text-align-last`. It moves the most recent version support statements to the top of their respective arrays and makes the bug references links. This ought to make it a little easier to understand as a compat table on MDN (in particular, on first look, it appears that Chrome and Firefox don't support it even though they do).