### PR TITLE
Fix note about "defer" attribute in IE

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -171,7 +171,7 @@
               },
               "ie": {
                 "version_added": "10",
-                "notes": "In versions prior to Internet Explorer 10, it implemented &gt;script&lt; by a proprietary specification. Since version 10 it conforms to the W3C specification."
+                "notes": "In versions prior to Internet Explorer 10, it implemented <code>defer</code> by a proprietary specification. Since version 10 it conforms to the W3C specification."
               },
               "opera": {
                 "version_added": false


### PR DESCRIPTION
Entities were inverted and it was displayed as &gt;script&lt;.

But the meaning also had to be fixed. We are talking about the implementation of "defer" in IE<10, which was existing but apparently wrong on many levels (ref: https://github.com/h5bp/lazyweb-requests/issues/42).