### PR TITLE
Update object.entries() and object.values().

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -601,10 +601,10 @@
                 "version_added": "7"
               },
               "opera": {
-                "version_added": false
+                "version_added": "41"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "41"
               },
               "safari": {
                 "version_added": "10.1"
@@ -2297,10 +2297,10 @@
                 "version_added": "7"
               },
               "opera": {
-                "version_added": true
+                "version_added": "41"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "41"
               },
               "safari": {
                 "version_added": "10.1"


### PR DESCRIPTION
Corrects #1343 as per https://www.chromestatus.com/features/5710160244768768.