### PR TITLE
Clean data for AudioBufferSourceNode

### DIFF
--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -410,8 +410,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25",
-              "version_removed": "53"
+              "version_added": "25"
             },
             "firefox_android": {
               "version_added": "26"

--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -157,7 +157,7 @@
               "version_added": true
             },
             "chrome": {
-              "version_added": true
+              "version_added": "44"
             },
             "chrome_android": {
               "version_added": true
@@ -397,7 +397,8 @@
               "version_added": true
             },
             "chrome": {
-              "version_added": "14"
+              "version_added": "14",
+              "version_removed": "57"
             },
             "chrome_android": {
               "version_added": "14"
@@ -409,7 +410,8 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "25",
+              "version_removed": "53"
             },
             "firefox_android": {
               "version_added": "26"


### PR DESCRIPTION
There are a couple differences between [Confluence](https://web-confluence.appspot.com/#!/catalog) and existing data that I didn't include here, mostly because I suspect Confluence is wrong based on how radically it claims the data should change; this noise may be caused by browsers shipping features without exposing them on JavaScript prototypes where Confluence can pick them up.

Confluence links:

[Shipped in Chrome 44](https://web-confluence.appspot.com/#!/catalog?searchKey=%22AudioBufferSourceNode%22&releaseKeys=%5B%22Chrome_42.0.2311.135_Windows_10.0%22%2C%22Chrome_43.0.2357.81_Windows_10.0%22%2C%22Chrome_44.0.2403.89_Windows_10.0%22%2C%22Chrome_45.0.2454.85_Windows_10.0%22%5D)

[Removed in Chrome 57](https://web-confluence.appspot.com/#!/catalog?searchKey=%22AudioBufferSourceNode%22&releaseKeys=%5B%22Chrome_55.0.2883.75_Windows_10.0%22%2C%22Chrome_56.0.2924.87_Windows_10.0%22%2C%22Chrome_57.0.2987.110_Windows_10.0%22%2C%22Chrome_58.0.3029.81_Windows_10.0%22%5D)

[Removed in Firefox 53](https://web-confluence.appspot.com/#!/catalog?searchKey=%22AudioBufferSourceNode%22&releaseKeys=%5B%22Firefox_51.0_Windows_10.0%22%2C%22Firefox_52.0_Windows_10.0%22%2C%22Firefox_53.0_Windows_10.0%22%2C%22Firefox_54.0_Windows_10.0%22%5D)