### PR TITLE
update firefox and firefox_android versions data

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -309,22 +309,22 @@
         "57": {
           "release_date": "2017-11-14",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/57",
-          "status": "current"
+          "status": "retired"
         },
         "58": {
           "release_date": "2018-01-23",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/58",
-          "status": "beta"
+          "status": "retired"
         },
         "59": {
           "release_date": "2018-03-13",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/59",
-          "status": "nightly"
+          "status": "current"
         },
         "60": {
           "release_date": "2018-05-08",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/60",
-          "status": "planned"
+          "status": "nightly"
         },
         "61": {
           "release_date": "2018-07-03",

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -255,22 +255,22 @@
         "57": {
           "release_date": "2017-11-28",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/57",
-          "status": "current"
+          "status": "retired"
         },
         "58": {
           "release_date": "2018-01-22",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/58",
-          "status": "beta"
+          "status": "retired"
         },
         "59": {
           "release_date": "2018-03-13",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/59",
-          "status": "nightly"
+          "status": "current"
         },
         "60": {
           "release_date": "2018-05-08",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/60",
-          "status": "planned"
+          "status": "nightly"
         },
         "61": {
           "release_date": "2018-07-03",


### PR DESCRIPTION
Updated the data according to the following sources
https://developer.mozilla.org/en-US/Firefox/Releases
https://wiki.mozilla.org/RapidRelease/Calendar