### PR TITLE
Add chrome_android data

### DIFF
--- a/api/AbstractWorker.json
+++ b/api/AbstractWorker.json
@@ -11,7 +11,7 @@
             "version_added": "4"
           },
           "chrome_android": {
-            "version_added": "4.4"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -61,7 +61,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "4.4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/AnalyserNode.json
+++ b/api/AnalyserNode.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -113,7 +113,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -164,7 +164,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -215,7 +215,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -266,7 +266,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -317,7 +317,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -368,7 +368,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -419,7 +419,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -470,7 +470,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -521,7 +521,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/AudioBuffer.json
+++ b/api/AudioBuffer.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -118,7 +118,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -169,7 +169,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -220,7 +220,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -271,7 +271,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -322,7 +322,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "13"
@@ -373,7 +373,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "13"
@@ -424,7 +424,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -116,7 +116,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -220,7 +220,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -271,7 +271,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -322,7 +322,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -373,7 +373,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": null
@@ -426,7 +426,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -478,7 +478,7 @@
               "version_removed": "57"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -529,7 +529,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": null

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -22,7 +22,7 @@
               "version_added": "35"
             },
             {
-              "version_added": "14",
+              "version_added": "18",
               "version_removed": "57",
               "prefix": "webkit"
             }
@@ -423,7 +423,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -474,7 +474,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -525,7 +525,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/api/AudioDestinationNode.json
+++ b/api/AudioDestinationNode.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -61,7 +61,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/AudioListener.json
+++ b/api/AudioListener.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -63,7 +63,7 @@
               "version_removed": "56"
             },
             "chrome_android": {
-              "version_added": "14",
+              "version_added": "18",
               "version_removed": "56"
             },
             "edge": {
@@ -439,7 +439,7 @@
               "version_removed": "56"
             },
             "chrome_android": {
-              "version_added": "14",
+              "version_added": "18",
               "version_removed": "56"
             },
             "edge": {
@@ -654,10 +654,10 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": false
@@ -705,7 +705,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/AudioNode.json
+++ b/api/AudioNode.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -61,7 +61,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -112,7 +112,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -163,7 +163,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -214,7 +214,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -265,7 +265,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -316,7 +316,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -367,7 +367,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -418,7 +418,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -61,7 +61,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -214,7 +214,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -351,7 +351,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -402,7 +402,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -453,7 +453,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -504,7 +504,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -555,7 +555,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -606,7 +606,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/AudioProcessingEvent.json
+++ b/api/AudioProcessingEvent.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -61,7 +61,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -112,7 +112,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -163,7 +163,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -29,7 +29,7 @@
               "version_added": "57"
             },
             {
-              "version_added": "14",
+              "version_added": "18",
               "version_removed": "56",
               "alternative_name": "AudioSourceNode"
             }
@@ -128,7 +128,7 @@
                 "version_added": "57"
               },
               {
-                "version_added": "14",
+                "version_added": "18",
                 "version_removed": "56",
                 "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
@@ -200,7 +200,7 @@
                 "version_added": "57"
               },
               {
-                "version_added": "14",
+                "version_added": "18",
                 "version_removed": "56",
                 "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
@@ -272,7 +272,7 @@
                 "version_added": "57"
               },
               {
-                "version_added": "14",
+                "version_added": "18",
                 "version_removed": "56",
                 "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }

--- a/api/BiquadFilterNode.json
+++ b/api/BiquadFilterNode.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -118,7 +118,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -169,7 +169,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -220,7 +220,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -271,7 +271,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -322,7 +322,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -373,7 +373,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/CSSRule.json
+++ b/api/CSSRule.json
@@ -11,7 +11,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "1"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -58,7 +58,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": null
@@ -106,7 +106,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": null
@@ -154,7 +154,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": null
@@ -202,7 +202,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": null

--- a/api/CanvasGradient.json
+++ b/api/CanvasGradient.json
@@ -11,7 +11,7 @@
             "version_added": "4"
           },
           "chrome_android": {
-            "version_added": "2.1"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true

--- a/api/CanvasPattern.json
+++ b/api/CanvasPattern.json
@@ -11,7 +11,7 @@
             "version_added": "4"
           },
           "chrome_android": {
-            "version_added": "2.1"
+            "version_added": "18"
           },
           "edge": {
             "version_added": null

--- a/api/ChannelMergerNode.json
+++ b/api/ChannelMergerNode.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true

--- a/api/ChannelSplitterNode.json
+++ b/api/ChannelSplitterNode.json
@@ -13,7 +13,7 @@
             "notes": "Starting in Chrome 56, <code>channelCountMode</code> is set to <code>explicit</code> and <code>channelCount</code> is fixed to the number of outputs, as per the latest spec."
           },
           "chrome_android": {
-            "version_added": "14",
+            "version_added": "18",
             "notes": "Starting in Chrome 56, <code>channelCountMode</code> is set to <code>explicit</code> and <code>channelCount</code> is fixed to the number of outputs, as per the latest spec."
           },
           "edge": {

--- a/api/ConstantSourceNode.json
+++ b/api/ConstantSourceNode.json
@@ -170,7 +170,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -225,7 +225,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -280,7 +280,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": false

--- a/api/ConvolverNode.json
+++ b/api/ConvolverNode.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -113,7 +113,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -164,7 +164,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -8,7 +8,7 @@
             "version_added": "11"
           },
           "chrome_android": {
-            "version_added": "11"
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -148,7 +148,7 @@
               "version_added": "11"
             },
             "chrome_android": {
-              "version_added": "11"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/DOMHighResTimestamp.json
+++ b/api/DOMHighResTimestamp.json
@@ -8,7 +8,7 @@
             "version_added": "6"
           },
           "chrome_android": {
-            "version_added": "6"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true

--- a/api/DelayNode.json
+++ b/api/DelayNode.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -116,7 +116,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/DirectoryEntrySync.json
+++ b/api/DirectoryEntrySync.json
@@ -12,7 +12,7 @@
             "prefix": "webkit"
           },
           "chrome_android": {
-            "version_added": "1",
+            "version_added": "18",
             "prefix": "webkit"
           },
           "edge": {

--- a/api/DirectoryReaderSync.json
+++ b/api/DirectoryReaderSync.json
@@ -12,7 +12,7 @@
             "prefix": "webkit"
           },
           "chrome_android": {
-            "version_added": "1",
+            "version_added": "18",
             "prefix": "webkit"
           },
           "edge": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -1944,7 +1944,7 @@
             ],
             "chrome_android": [
               {
-                "version_added": "22",
+                "version_added": "25",
                 "version_removed": "66"
               },
               {
@@ -2007,7 +2007,7 @@
               "version_added": "22"
             },
             "chrome_android": {
-              "version_added": "22"
+              "version_added": "25"
             },
             "edge": {
               "version_added": true
@@ -3805,7 +3805,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/api/DynamicsCompressorNode.json
+++ b/api/DynamicsCompressorNode.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -116,7 +116,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -167,7 +167,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -218,7 +218,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -271,7 +271,7 @@
               "notes": "Before version 52, this was an <code>AudioParam.</code>."
             },
             "chrome_android": {
-              "version_added": "14",
+              "version_added": "18",
               "notes": "Before version 52, this was an <code>AudioParam.</code>."
             },
             "edge": {
@@ -323,7 +323,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -374,7 +374,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/Element.json
+++ b/api/Element.json
@@ -11,7 +11,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "1"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true

--- a/api/EntrySync.json
+++ b/api/EntrySync.json
@@ -12,7 +12,7 @@
             "prefix": "webkit"
           },
           "chrome_android": {
-            "version_added": "1",
+            "version_added": "18",
             "prefix": "webkit"
           },
           "edge": {

--- a/api/Event.json
+++ b/api/Event.json
@@ -56,7 +56,7 @@
               "version_added": "15"
             },
             "chrome_android": {
-              "version_added": "15"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -1248,7 +1248,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": "6"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/api/EventListener.json
+++ b/api/EventListener.json
@@ -11,7 +11,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "1"
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -58,7 +58,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/EventSource.json
+++ b/api/EventSource.json
@@ -8,7 +8,7 @@
             "version_added": "6"
           },
           "chrome_android": {
-            "version_added": "6"
+            "version_added": "18"
           },
           "edge": {
             "version_added": false
@@ -104,7 +104,7 @@
               "version_added": "9"
             },
             "chrome_android": {
-              "version_added": "9"
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -200,7 +200,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": "6"
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -248,7 +248,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": "6"
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -296,7 +296,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": "6"
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -344,7 +344,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": "6"
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -392,7 +392,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": "6"
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -440,7 +440,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": "6"
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -488,7 +488,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": "6"
+              "version_added": "18"
             },
             "edge": {
               "version_added": false

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -11,7 +11,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "1"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -129,7 +129,7 @@
               "notes": "Before Chrome 49, the <code>type</code> and <code>listener</code> parameters were optional."
             },
             "chrome_android": {
-              "version_added": "1",
+              "version_added": "18",
               "notes": "Before Chrome 49, the <code>type</code> and <code>listener</code> parameters were optional."
             },
             "edge": {
@@ -188,7 +188,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -495,7 +495,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -554,7 +554,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -612,7 +612,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -665,7 +665,7 @@
                 "version_removed": "49"
               },
               "chrome_android": {
-                "version_added": "1",
+                "version_added": "18",
                 "version_removed": "49"
               },
               "edge": {

--- a/api/FileEntrySync.json
+++ b/api/FileEntrySync.json
@@ -12,7 +12,7 @@
             "prefix": "webkit"
           },
           "chrome_android": {
-            "version_added": "0.16",
+            "version_added": "18",
             "prefix": "webkit"
           },
           "edge": {

--- a/api/FileError.json
+++ b/api/FileError.json
@@ -15,7 +15,7 @@
             "prefix": "webkit"
           },
           "chrome_android": {
-            "version_added": "0.16",
+            "version_added": "18",
             "version_removed": "53",
             "prefix": "webkit"
           },

--- a/api/GainNode.json
+++ b/api/GainNode.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -116,7 +116,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -20,7 +20,7 @@
             },
             {
               "prefix": "webkit",
-              "version_added": "21",
+              "version_added": "25",
               "version_removed": "34"
             }
           ],
@@ -176,7 +176,7 @@
               },
               {
                 "prefix": "webkit",
-                "version_added": "21",
+                "version_added": "25",
                 "version_removed": "34"
               }
             ],
@@ -268,7 +268,7 @@
               },
               {
                 "prefix": "webkit",
-                "version_added": "21",
+                "version_added": "25",
                 "version_removed": "34"
               }
             ],
@@ -350,7 +350,7 @@
               },
               {
                 "prefix": "webkit",
-                "version_added": "21",
+                "version_added": "25",
                 "version_removed": "34"
               }
             ],
@@ -360,7 +360,7 @@
               },
               {
                 "prefix": "webkit",
-                "version_added": "21",
+                "version_added": "25",
                 "version_removed": "34"
               }
             ],
@@ -615,7 +615,7 @@
               },
               {
                 "prefix": "webkit",
-                "version_added": "21",
+                "version_added": "25",
                 "version_removed": "34"
               }
             ],
@@ -700,7 +700,7 @@
               },
               {
                 "prefix": "webkit",
-                "version_added": "21",
+                "version_added": "25",
                 "version_removed": "34"
               }
             ],
@@ -785,7 +785,7 @@
               },
               {
                 "prefix": "webkit",
-                "version_added": "21",
+                "version_added": "25",
                 "version_removed": "34"
               }
             ],
@@ -936,7 +936,7 @@
               },
               {
                 "prefix": "webkit",
-                "version_added": "21",
+                "version_added": "25",
                 "version_removed": "34"
               }
             ],

--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -112,7 +112,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "13"

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -201,7 +201,7 @@
             },
             "chrome_android": {
               "prefix": "webkit",
-              "version_added": "17",
+              "version_added": "18",
               "notes": "Daily test builds only."
             },
             "edge": {
@@ -1910,7 +1910,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": "4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -2300,7 +2300,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": "4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -8,7 +8,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "1"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -56,7 +56,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -105,7 +105,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -154,7 +154,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -203,7 +203,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -350,7 +350,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -399,7 +399,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -546,7 +546,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -11,7 +11,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "1"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -635,7 +635,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/api/HTMLTrackElement.json
+++ b/api/HTMLTrackElement.json
@@ -8,7 +8,7 @@
             "version_added": "23"
           },
           "chrome_android": {
-            "version_added": "23"
+            "version_added": "25"
           },
           "edge": {
             "version_added": true
@@ -83,7 +83,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "23"
+              "version_added": "25"
             },
             "edge": {
               "version_added": true
@@ -157,7 +157,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "23"
+              "version_added": "25"
             },
             "edge": {
               "version_added": true
@@ -231,7 +231,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "23"
+              "version_added": "25"
             },
             "edge": {
               "version_added": true
@@ -305,7 +305,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "23"
+              "version_added": "25"
             },
             "edge": {
               "version_added": true
@@ -379,7 +379,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "23"
+              "version_added": "25"
             },
             "edge": {
               "version_added": true
@@ -455,7 +455,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "23"
+              "version_added": "25"
             },
             "edge": {
               "version_added": true
@@ -529,7 +529,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "23"
+              "version_added": "25"
             },
             "edge": {
               "version_added": true

--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -26,10 +26,10 @@
           ],
           "chrome_android": [
             {
-              "version_added": "24"
+              "version_added": "25"
             },
             {
-              "version_added": "23",
+              "version_added": "25",
               "version_removed": "57",
               "prefix": "webkit"
             }
@@ -126,10 +126,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }

--- a/api/IDBCursorWithValue.json
+++ b/api/IDBCursorWithValue.json
@@ -26,10 +26,10 @@
           ],
           "chrome_android": [
             {
-              "version_added": "24"
+              "version_added": "25"
             },
             {
-              "version_added": "23",
+              "version_added": "25",
               "version_removed": "57",
               "prefix": "webkit"
             }

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -26,10 +26,10 @@
           ],
           "chrome_android": [
             {
-              "version_added": "24"
+              "version_added": "25"
             },
             {
-              "version_added": "23",
+              "version_added": "25",
               "version_removed": "57",
               "prefix": "webkit"
             }
@@ -115,7 +115,7 @@
                 "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }

--- a/api/IDBEnvironment.json
+++ b/api/IDBEnvironment.json
@@ -18,7 +18,7 @@
             }
           ],
           "chrome_android": {
-            "version_added": "24"
+            "version_added": "25"
           },
           "edge": {
             "version_added": true

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -26,10 +26,10 @@
           ],
           "chrome_android": [
             {
-              "version_added": "24"
+              "version_added": "25"
             },
             {
-              "version_added": "23",
+              "version_added": "25",
               "version_removed": "57",
               "prefix": "webkit"
             }
@@ -161,16 +161,9 @@
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -241,16 +234,9 @@
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -321,16 +307,9 @@
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -26,10 +26,10 @@
           ],
           "chrome_android": [
             {
-              "version_added": "24"
+              "version_added": "25"
             },
             {
-              "version_added": "23",
+              "version_added": "25",
               "version_removed": "57",
               "prefix": "webkit"
             }
@@ -212,16 +212,9 @@
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -343,16 +336,9 @@
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": null
             },
@@ -423,16 +409,9 @@
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -554,16 +533,9 @@
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -634,16 +606,9 @@
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -714,16 +679,9 @@
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -794,16 +752,9 @@
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -1000,16 +951,9 @@
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -1080,16 +1024,9 @@
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -1160,16 +1097,9 @@
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -26,10 +26,10 @@
           ],
           "chrome_android": [
             {
-              "version_added": "24"
+              "version_added": "25"
             },
             {
-              "version_added": "23",
+              "version_added": "25",
               "version_removed": "57",
               "prefix": "webkit"
             }
@@ -163,10 +163,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -250,10 +250,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -337,10 +337,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -424,10 +424,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -562,10 +562,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -649,10 +649,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -736,10 +736,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -823,10 +823,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -910,10 +910,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -997,10 +997,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -1084,10 +1084,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -1171,10 +1171,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -1417,10 +1417,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -1504,10 +1504,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -1591,10 +1591,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -1677,10 +1677,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }

--- a/api/IDBOpenDBRequest.json
+++ b/api/IDBOpenDBRequest.json
@@ -26,10 +26,10 @@
           ],
           "chrome_android": [
             {
-              "version_added": "24"
+              "version_added": "25"
             },
             {
-              "version_added": "23",
+              "version_added": "25",
               "version_removed": "57",
               "prefix": "webkit"
             }
@@ -163,10 +163,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -250,10 +250,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }

--- a/api/IDBRequest.json
+++ b/api/IDBRequest.json
@@ -19,17 +19,17 @@
               "version_added": "24"
             },
             {
-              "version_added": "23",
+              "version_added": "2",
               "version_removed": "57",
               "prefix": "webkit"
             }
           ],
           "chrome_android": [
             {
-              "version_added": "24"
+              "version_added": "25"
             },
             {
-              "version_added": "23",
+              "version_added": "25",
               "version_removed": "57",
               "prefix": "webkit"
             }
@@ -163,10 +163,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -26,10 +26,10 @@
           ],
           "chrome_android": [
             {
-              "version_added": "24"
+              "version_added": "25"
             },
             {
-              "version_added": "23",
+              "version_added": "25",
               "version_removed": "57",
               "prefix": "webkit"
             }
@@ -163,10 +163,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -250,10 +250,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }

--- a/api/IDBVersionChangeEvent.json
+++ b/api/IDBVersionChangeEvent.json
@@ -141,10 +141,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -228,10 +228,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "24"
+                "version_added": "25"
               },
               {
-                "version_added": "23",
+                "version_added": "25",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -300,7 +300,7 @@
               "version_added": "12"
             },
             "chrome_android": {
-              "version_added": "4.4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true

--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -8,7 +8,7 @@
             "version_added": "9"
           },
           "chrome_android": {
-            "version_added": "9"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true

--- a/api/MediaStreamAudioDestinationNode.json
+++ b/api/MediaStreamAudioDestinationNode.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -116,7 +116,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/api/MediaStreamAudioSourceNode.json
+++ b/api/MediaStreamAudioSourceNode.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true

--- a/api/MessageChannel.json
+++ b/api/MessageChannel.json
@@ -8,7 +8,7 @@
             "version_added": "4"
           },
           "chrome_android": {
-            "version_added": "4"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -58,7 +58,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -109,7 +109,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -160,7 +160,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -8,7 +8,7 @@
             "version_added": "4"
           },
           "chrome_android": {
-            "version_added": "4"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -109,7 +109,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -160,7 +160,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -262,7 +262,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -313,7 +313,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/api/Node.json
+++ b/api/Node.json
@@ -830,7 +830,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -2086,7 +2086,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/api/OfflineAudioCompletionEvent.json
+++ b/api/OfflineAudioCompletionEvent.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -116,7 +116,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -218,7 +218,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -371,7 +371,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/OscillatorNode.json
+++ b/api/OscillatorNode.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -116,7 +116,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -167,7 +167,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -218,7 +218,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -269,7 +269,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -320,7 +320,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -371,7 +371,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -424,7 +424,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -116,7 +116,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -167,7 +167,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -218,7 +218,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -269,7 +269,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -320,7 +320,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -524,7 +524,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -728,7 +728,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -779,7 +779,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -830,7 +830,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -881,7 +881,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -934,7 +934,7 @@
               "version_removed": "56"
             },
             "chrome_android": {
-              "version_added": "14",
+              "version_added": "18",
               "version_removed": "56"
             },
             "edge": {

--- a/api/PeriodicWave.json
+++ b/api/PeriodicWave.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true

--- a/api/PopStateEvent.json
+++ b/api/PopStateEvent.json
@@ -11,7 +11,7 @@
             "version_added": "4"
           },
           "chrome_android": {
-            "version_added": "4"
+            "version_added": "18"
           },
           "edge": {
             "version_added": null
@@ -58,7 +58,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": null

--- a/api/Position.json
+++ b/api/Position.json
@@ -8,7 +8,7 @@
             "version_added": "5"
           },
           "chrome_android": {
-            "version_added": "5"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -103,7 +103,7 @@
               "version_added": "5"
             },
             "chrome_android": {
-              "version_added": "5"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -151,7 +151,7 @@
               "version_added": "5"
             },
             "chrome_android": {
-              "version_added": "5"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/api/PositionError.json
+++ b/api/PositionError.json
@@ -8,7 +8,7 @@
             "version_added": "5"
           },
           "chrome_android": {
-            "version_added": "5"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -103,7 +103,7 @@
               "version_added": "5"
             },
             "chrome_android": {
-              "version_added": "5"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -151,7 +151,7 @@
               "version_added": "5"
             },
             "chrome_android": {
-              "version_added": "5"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/api/PositionOptions.json
+++ b/api/PositionOptions.json
@@ -8,7 +8,7 @@
             "version_added": "5"
           },
           "chrome_android": {
-            "version_added": "5"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -122,7 +122,7 @@
               "version_added": "5"
             },
             "chrome_android": {
-              "version_added": "5"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -185,7 +185,7 @@
               "version_added": "5"
             },
             "chrome_android": {
-              "version_added": "5"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -248,7 +248,7 @@
               "version_added": "5"
             },
             "chrome_android": {
-              "version_added": "5"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/api/SVGCircleElement.json
+++ b/api/SVGCircleElement.json
@@ -11,7 +11,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "1"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true

--- a/api/SVGRect.json
+++ b/api/SVGRect.json
@@ -11,7 +11,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "1"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -57,7 +57,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": null
@@ -104,7 +104,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": null
@@ -151,7 +151,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": null
@@ -198,7 +198,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": null

--- a/api/SharedWorkerGlobalScope.json
+++ b/api/SharedWorkerGlobalScope.json
@@ -163,7 +163,7 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": "3"
+              "version_added": "18"
             },
             "edge": {
               "version_added": null

--- a/api/Text.json
+++ b/api/Text.json
@@ -281,7 +281,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "1",
+              "version_added": "18",
               "notes": [
                 "Before Chrome 30, the <code>offset</code> argument was optional."
               ]

--- a/api/WaveShaperNode.json
+++ b/api/WaveShaperNode.json
@@ -11,7 +11,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -116,7 +116,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -167,7 +167,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/Window.json
+++ b/api/Window.json
@@ -8,7 +8,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "1"
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"

--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -243,7 +243,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -303,7 +303,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -1057,7 +1057,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -1165,7 +1165,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -11,7 +11,7 @@
             "version_added": "4"
           },
           "chrome_android": {
-            "version_added": "4"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -62,7 +62,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -164,7 +164,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -318,7 +318,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -11,7 +11,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "1"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -61,7 +61,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -113,7 +113,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -162,7 +162,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -786,7 +786,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -895,7 +895,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -997,7 +997,7 @@
               "version_added": true
             },
             "chrome": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "chrome_android": {
               "version_added": true
@@ -1116,7 +1116,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1175,7 +1175,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1234,7 +1234,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1291,7 +1291,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1664,7 +1664,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/XMLHttpRequestEventTarget.json
+++ b/api/XMLHttpRequestEventTarget.json
@@ -11,7 +11,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "1"
+            "version_added": "18"
           },
           "edge": {
             "version_added": true

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -1,0 +1,240 @@
+{
+  "browsers": {
+    "chrome_android": {
+      "name": "Chrome Android",
+      "releases": {
+        "18": {
+          "release_date": "2012-06-27",
+          "release_notes": "https://chromereleases.googleblog.com/2012/06/chrome-for-android-out-of-beta.html",
+          "status": "retired"
+        },
+        "25": {
+          "release_date": "2013-02-27",
+          "release_notes": "https://chromereleases.googleblog.com/2013/02/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "26": {
+          "release_date": "2013-03-03",
+          "release_notes": "https://chromereleases.googleblog.com/2013/04/chrome-for-android-stable-channel-update.html",
+          "status": "retired"
+        },
+        "27": {
+          "release_date": "2013-05-22",
+          "release_notes": "https://chromereleases.googleblog.com/2013/05/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "28": {
+          "release_date": "2013-07-10",
+          "release_notes": "https://chromereleases.googleblog.com/2013/07/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "29": {
+          "release_date": "2013-08-21",
+          "release_notes": "https://chromereleases.googleblog.com/2013/08/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "30": {
+          "release_date": "2013-10-02",
+          "release_notes": "https://chromereleases.googleblog.com/2013/10/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "31": {
+          "release_date": "2013-11-14",
+          "release_notes": "https://chromereleases.googleblog.com/2013/11/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "32": {
+          "release_date": "2014-01-15",
+          "release_notes": "https://chromereleases.googleblog.com/2014/01/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "33": {
+          "release_date": "2014-02-26",
+          "release_notes": "https://chromereleases.googleblog.com/2014/02/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "34": {
+          "release_date": "2014-04-02",
+          "release_notes": "https://chromereleases.googleblog.com/2014/04/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "35": {
+          "release_date": "2014-05-20",
+          "release_notes": "https://chromereleases.googleblog.com/2014/05/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "36": {
+          "release_date": "2014-07-16",
+          "release_notes": "https://chromereleases.googleblog.com/2014/07/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "37": {
+          "release_date": "2014-09-03",
+          "release_notes": "https://chromereleases.googleblog.com/2014/09/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "38": {
+          "release_date": "2014-10-08",
+          "release_notes": "https://chromereleases.googleblog.com/2014/10/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "39": {
+          "release_date": "2014-11-12",
+          "release_notes": "https://chromereleases.googleblog.com/2014/11/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "40": {
+          "release_date": "2015-01-21",
+          "release_notes": "https://chromereleases.googleblog.com/2015/01/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "41": {
+          "release_date": "2015-03-11",
+          "release_notes": "https://chromereleases.googleblog.com/2015/03/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "42": {
+          "release_date": "2015-04-15",
+          "release_notes": "https://chromereleases.googleblog.com/2015/04/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "43": {
+          "release_date": "2015-05-27",
+          "release_notes": "https://chromereleases.googleblog.com/2015/05/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "44": {
+          "release_date": "2015-07-29",
+          "release_notes": "https://chromereleases.googleblog.com/2015/07/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "45": {
+          "release_date": "2015-09-01",
+          "release_notes": "https://chromereleases.googleblog.com/2015/09/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "46": {
+          "release_date": "2015-10-14",
+          "release_notes": "https://chromereleases.googleblog.com/2015/10/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "47": {
+          "release_date": "2015-12-02",
+          "release_notes": "https://chromereleases.googleblog.com/2015/12/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "48": {
+          "release_date": "2016-01-26",
+          "release_notes": "https://chromereleases.googleblog.com/2016/01/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "49": {
+          "release_date": "2016-03-09",
+          "release_notes": "https://chromereleases.googleblog.com/2016/03/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "50": {
+          "release_date": "2016-04-13",
+          "status": "retired"
+        },
+        "51": {
+          "release_date": "2016-06-08",
+          "release_notes": "https://chromereleases.googleblog.com/2016/06/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "52": {
+          "release_date": "2016-07-27",
+          "release_notes": "https://chromereleases.googleblog.com/2016/07/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "53": {
+          "release_date": "2016-09-07",
+          "release_notes": "https://chromereleases.googleblog.com/2016/09/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "54": {
+          "release_date": "2016-10-19",
+          "release_notes": "https://chromereleases.googleblog.com/2016/10/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "55": {
+          "release_date": "2016-12-06",
+          "release_notes": "https://chromereleases.googleblog.com/2016/12/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "56": {
+          "release_date": "2017-02-01",
+          "release_notes": "https://chromereleases.googleblog.com/2017/02/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "57": {
+          "release_date": "2017-03-16",
+          "release_notes": "https://chromereleases.googleblog.com/2017/03/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "58": {
+          "release_date": "2017-04-25",
+          "release_notes": "https://chromereleases.googleblog.com/2017/04/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "59": {
+          "release_date": "2017-06-06",
+          "release_notes": "https://chromereleases.googleblog.com/2017/06/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "60": {
+          "release_date": "2017-08-01",
+          "release_notes": "https://chromereleases.googleblog.com/2017/08/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "61": {
+          "release_date": "2017-09-05",
+          "release_notes": "https://chromereleases.googleblog.com/2017/09/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "62": {
+          "release_date": "2017-10-24",
+          "release_notes": "https://chromereleases.googleblog.com/2017/10/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "63": {
+          "release_date": "2017-12-05",
+          "release_notes": "https://chromereleases.googleblog.com/2017/12/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "64": {
+          "release_date": "2018-01-23",
+          "release_notes": "https://chromereleases.googleblog.com/2018/01/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "65": {
+          "release_date": "2017-03-06",
+          "release_notes": "https://chromereleases.googleblog.com/2018/03/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "66": {
+          "release_date": "2017-04-17",
+          "release_notes": "https://chromereleases.googleblog.com/2018/04/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "67": {
+          "release_date": "2018-05-31",
+          "release_notes": "https://chromereleases.googleblog.com/2018/05/chrome-for-android-update_31.html",
+          "status": "retired"
+        },
+        "68": {
+          "release_date": "2018-07-24",
+          "release_notes": "https://chromereleases.googleblog.com/2018/07/chrome-for-android-update.html",
+          "status": "current"
+        },
+        "69": {
+          "release_date": "2018-09-04",
+          "status": "beta"
+        },
+        "70": {
+          "status": "nightly"
+        }
+      }
+    }
+  }
+}

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -14,7 +14,7 @@
           "status": "retired"
         },
         "26": {
-          "release_date": "2013-03-03",
+          "release_date": "2013-04-03",
           "release_notes": "https://chromereleases.googleblog.com/2013/04/chrome-for-android-stable-channel-update.html",
           "status": "retired"
         },
@@ -125,7 +125,6 @@
         },
         "48": {
           "release_date": "2016-01-26",
-          "release_notes": "https://chromereleases.googleblog.com/2016/01/chrome-for-android-update.html",
           "status": "retired"
         },
         "49": {
@@ -228,7 +227,6 @@
           "status": "current"
         },
         "69": {
-          "release_date": "2018-09-04",
           "status": "beta"
         },
         "70": {

--- a/css/properties/-webkit-appearance.json
+++ b/css/properties/-webkit-appearance.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/-webkit-text-stroke.json
+++ b/css/properties/-webkit-text-stroke.json
@@ -9,7 +9,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "15"

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -22,7 +22,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "21"
+                  "version_added": "25"
                 }
               ],
               "edge": [

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -32,7 +32,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "21"
+                  "version_added": "25"
                 }
               ],
               "edge": [

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -32,7 +32,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "21"
+                  "version_added": "25"
                 }
               ],
               "edge": {

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -11,7 +11,7 @@
               "prefix": "-webkit-"
             },
             "chrome_android": {
-              "version_added": "1",
+              "version_added": "18",
               "partial_implementation": true,
               "prefix": "-webkit-"
             },
@@ -82,7 +82,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -16,7 +16,7 @@
             },
             "chrome_android": {
               "prefix": "-webkit-",
-              "version_added": "4.4",
+              "version_added": "18",
               "notes": "This property is only supported for inline elements."
             },
             "edge": {

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -328,7 +328,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "21"
+                  "version_added": "25"
                 }
               ],
               "edge": {
@@ -462,7 +462,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "21"
+                  "version_added": "25"
                 }
               ],
               "edge": {

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": "25"
               }
             ],
             "edge": [

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": "25"
               }
             ],
             "edge": [

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": "25"
               }
             ],
             "edge": {

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": "25"
               }
             ],
             "edge": [

--- a/css/properties/flex-shrink.json
+++ b/css/properties/flex-shrink.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": "25"
               }
             ],
             "edge": [

--- a/css/properties/flex-wrap.json
+++ b/css/properties/flex-wrap.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": "25"
               }
             ],
             "edge": {

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": "25"
               }
             ],
             "edge": [

--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -32,7 +32,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "21"
+                  "version_added": "25"
                 }
               ],
               "edge": [

--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -19,7 +19,7 @@
                 "version_added": "69"
               },
               {
-                "version_added": "2",
+                "version_added": "18",
                 "alternative_name": "-webkit-margin-end"
               }
             ],

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -19,7 +19,7 @@
                 "version_added": "69"
               },
               {
-                "version_added": "2",
+                "version_added": "18",
                 "alternative_name": "-webkit-margin-end"
               }
             ],

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -15,7 +15,7 @@
             },
             "chrome_android": {
               "prefix": "-webkit-",
-              "version_added": "6.1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": false

--- a/css/properties/order.json
+++ b/css/properties/order.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": "25"
               }
             ],
             "edge": [

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -19,7 +19,7 @@
                 "version_added": "69"
               },
               {
-                "version_added": "2",
+                "version_added": "18",
                 "alternative_name": "-webkit-padding-end"
               }
             ],

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -19,7 +19,7 @@
                 "version_added": "69"
               },
               {
-                "version_added": "2",
+                "version_added": "18",
                 "alternative_name": "-webkit-padding-start"
               }
             ],

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "6"
+                "version_added": "18"
               }
             ],
             "edge": [

--- a/css/properties/vertical-align.json
+++ b/css/properties/vertical-align.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/visibility.json
+++ b/css/properties/visibility.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/selectors/matches.json
+++ b/css/selectors/matches.json
@@ -29,7 +29,7 @@
                 "version_added": "66"
               },
               {
-                "version_added": "12",
+                "version_added": "18",
                 "alternative_name": ":-webkit-any"
               }
             ],

--- a/css/selectors/optional.json
+++ b/css/selectors/optional.json
@@ -13,7 +13,7 @@
               "version_added": "10"
             },
             "chrome_android": {
-              "version_added": "4.4"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -12,7 +12,7 @@
               "version_added": "3"
             },
             "chrome_android": {
-              "version_added": "3"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -63,7 +63,7 @@
                 "version_added": "3"
               },
               "chrome_android": {
-                "version_added": "3"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -163,7 +163,7 @@
                 "version_added": "3"
               },
               "chrome_android": {
-                "version_added": "3"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -213,7 +213,7 @@
                 "version_added": "3"
               },
               "chrome_android": {
-                "version_added": "3"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -413,7 +413,7 @@
                 "version_added": "3"
               },
               "chrome_android": {
-                "version_added": "3"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -484,7 +484,7 @@
                 "version_added": "3"
               },
               "chrome_android": {
-                "version_added": "3"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true

--- a/html/elements/body.json
+++ b/html/elements/body.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -61,7 +61,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -111,7 +111,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -161,7 +161,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -315,7 +315,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -365,7 +365,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -415,7 +415,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -465,7 +465,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -515,7 +515,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -565,7 +565,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -615,7 +615,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -665,7 +665,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -765,7 +765,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -815,7 +815,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -865,7 +865,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -915,7 +915,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -965,7 +965,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1015,7 +1015,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1065,7 +1065,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1115,7 +1115,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1165,7 +1165,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1215,7 +1215,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1317,7 +1317,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1419,7 +1419,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/html/elements/html.json
+++ b/html/elements/html.json
@@ -59,7 +59,7 @@
                 "version_added": "4"
               },
               "chrome_android": {
-                "version_added": "4"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true

--- a/html/elements/input/button.json
+++ b/html/elements/input/button.json
@@ -11,7 +11,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true

--- a/html/elements/input/time.json
+++ b/html/elements/input/time.json
@@ -11,7 +11,7 @@
                 "version_added": "20"
               },
               "chrome_android": {
-                "version_added": "20"
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -711,7 +711,7 @@
                   "version_added": false
                 },
                 "chrome_android": {
-                  "version_added": "39.09"
+                  "version_added": "39"
                 },
                 "edge": {
                   "version_added": null

--- a/html/elements/map.json
+++ b/html/elements/map.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -65,7 +65,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true

--- a/html/elements/marquee.json
+++ b/html/elements/marquee.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -58,7 +58,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -108,7 +108,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -158,7 +158,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -208,7 +208,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -358,7 +358,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -408,7 +408,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -558,7 +558,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true

--- a/html/elements/style.json
+++ b/html/elements/style.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -61,7 +61,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -111,7 +111,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -161,7 +161,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true

--- a/html/elements/table.json
+++ b/html/elements/table.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -61,7 +61,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -111,7 +111,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -161,7 +161,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -211,7 +211,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -261,7 +261,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -311,7 +311,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -361,7 +361,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -411,7 +411,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -461,7 +461,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true

--- a/http/headers/x-dns-prefetch-control.json
+++ b/http/headers/x-dns-prefetch-control.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": null

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -713,7 +713,7 @@
                 "version_added": "7"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -1028,7 +1028,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -1136,7 +1136,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/javascript/operators/object_initializer.json
+++ b/javascript/operators/object_initializer.json
@@ -13,7 +13,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/mathml/elements/math.json
+++ b/mathml/elements/math.json
@@ -10,7 +10,7 @@
               "version_removed": "26"
             },
             "chrome_android": {
-              "version_added": "24",
+              "version_added": "25",
               "version_removed": "26"
             },
             "edge": {
@@ -121,7 +121,7 @@
                 "version_removed": "26"
               },
               "chrome_android": {
-                "version_added": "24",
+                "version_added": "25",
                 "version_removed": "26"
               },
               "edge": {
@@ -222,7 +222,7 @@
                 "version_removed": "26"
               },
               "chrome_android": {
-                "version_added": "24",
+                "version_added": "25",
                 "version_removed": "26"
               },
               "edge": {
@@ -273,7 +273,7 @@
                 "version_removed": "26"
               },
               "chrome_android": {
-                "version_added": "24",
+                "version_added": "25",
                 "version_removed": "26"
               },
               "edge": {
@@ -324,7 +324,7 @@
                 "version_removed": "26"
               },
               "chrome_android": {
-                "version_added": "24",
+                "version_added": "25",
                 "version_removed": "26"
               },
               "edge": {

--- a/svg/elements/altGlyph.json
+++ b/svg/elements/altGlyph.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/svg/elements/animate.json
+++ b/svg/elements/animate.json
@@ -12,7 +12,7 @@
               "version_added": "2"
             },
             "chrome_android": {
-              "version_added": "2"
+              "version_added": "18"
             },
             "edge": {
               "version_added": null

--- a/svg/elements/cursor.json
+++ b/svg/elements/cursor.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": null

--- a/svg/elements/defs.json
+++ b/svg/elements/defs.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/svg/elements/desc.json
+++ b/svg/elements/desc.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/svg/elements/filter.json
+++ b/svg/elements/filter.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/svg/elements/font.json
+++ b/svg/elements/font.json
@@ -21,7 +21,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": "4",
+              "version_added": "18",
               "version_removed": "38"
             },
             "edge": {

--- a/svg/elements/image.json
+++ b/svg/elements/image.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/svg/elements/linearGradient.json
+++ b/svg/elements/linearGradient.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/svg/elements/radialGradient.json
+++ b/svg/elements/radialGradient.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/svg/elements/script.json
+++ b/svg/elements/script.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/svg/elements/stop.json
+++ b/svg/elements/stop.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -58,7 +58,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -105,7 +105,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -152,7 +152,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true

--- a/svg/elements/style.json
+++ b/svg/elements/style.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/svg/elements/switch.json
+++ b/svg/elements/switch.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/svg/elements/symbol.json
+++ b/svg/elements/symbol.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/xslt/elements/stylesheet.json
+++ b/xslt/elements/stylesheet.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -204,7 +204,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "1"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"


### PR DESCRIPTION
The build will fail here until we've fixed the chrome_android versions in the data. I'm opening it to discuss the correct chrome_android versions.

Sources are: https://en.wikipedia.org/wiki/Google_Chrome_version_history and the posts on https://chromereleases.googleblog.com

Note that there has been Chrome for Android 18, then 25, and then 26-66.

Once we merge this, the current open PRs and future PRs shouldn't commit invalid Chrome for Android versions anymore as the build will fail otherwise.

This fixes https://github.com/mdn/browser-compat-data/issues/1353 and another item on https://github.com/mdn/browser-compat-data/issues/591.

CC'ing @jpmedley 