### PR TITLE
Add HMDVRDevice

### DIFF
--- a/api/HMDVRDevice.json
+++ b/api/HMDVRDevice.json
@@ -1,0 +1,214 @@
+{
+  "api": {
+    "HMDVRDevice": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HMDVRDevice",
+        "support": {
+          "webview_android": {
+            "version_added": false
+          },
+          "chrome": {
+            "version_added": true,
+            "notes": "The support in Chrome is currently experimental. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "39",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.vr*"
+              }
+            ],
+            "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>"
+          },
+          "firefox_android": [
+            {
+              "version_added": "44",
+              "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
+            },
+            {
+              "version_added": "39",
+              "version_removed": "44",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.vr*"
+                }
+              ],
+              "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>."
+            }
+          ],
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      },
+      "getEyeParameters": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HMDVRDevice/getEyeParameters",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": true,
+              "notes": "The support in Chrome is currently experimental. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "39",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.vr*"
+                }
+              ],
+              "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>"
+            },
+            "firefox_android": [
+              {
+                "version_added": "44",
+                "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
+              },
+              {
+                "version_added": "39",
+                "version_removed": "44",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr*"
+                  }
+                ],
+                "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>."
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "setFieldOfView": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HMDVRDevice/setFieldOfView",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": true,
+              "notes": "The support in Chrome is currently experimental. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "39",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.vr*"
+                }
+              ],
+              "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>"
+            },
+            "firefox_android": [
+              {
+                "version_added": "44",
+                "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
+              },
+              {
+                "version_added": "39",
+                "version_removed": "44",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr*"
+                  }
+                ],
+                "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>."
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/HMDVRDevice.json
+++ b/api/HMDVRDevice.json
@@ -8,11 +8,11 @@
             "version_added": false
           },
           "chrome": {
-            "version_added": true,
-            "notes": "The support in Chrome is currently experimental. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
+            "version_added": false
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "62",
+            "notes": "The support in Chrome is currently experimental. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
           },
           "edge": {
             "version_added": false
@@ -77,11 +77,11 @@
               "version_added": false
             },
             "chrome": {
-              "version_added": true,
-              "notes": "The support in Chrome is currently experimental. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "62",
+              "notes": "The support in Chrome is currently experimental. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
             },
             "edge": {
               "version_added": false
@@ -147,11 +147,11 @@
               "version_added": false
             },
             "chrome": {
-              "version_added": true,
-              "notes": "The support in Chrome is currently experimental. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "62",
+              "notes": "The support in Chrome is currently experimental. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
             },
             "edge": {
               "version_added": false


### PR DESCRIPTION
This adds the browser compatibility table data for the [`HMDVRDevice` API](https://developer.mozilla.org/docs/Web/API/HMDVRDevice).