### PR TITLE
Trailing arrow function parameter commas do work in node

### DIFF
--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -394,7 +394,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
                 "version_added": "45"


### PR DESCRIPTION
This does work in node, and if there needs to be a version, it's from 8.0.0 from https://node.green. All the other node compat versions seemed to be true, though, so I think it's fine