### PR TITLE
Opera support

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -33,7 +33,7 @@
             "version_added": "4"
           },
           "opera": {
-            "version_added": "43"
+            "version_added": "36"
           },
           "opera_android": {
             "version_added": null
@@ -84,7 +84,7 @@
               "version_added": "4"
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "36"
             },
             "opera_android": {
               "version_added": null
@@ -136,7 +136,7 @@
               "version_added": "4"
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "36"
             },
             "opera_android": {
               "version_added": null
@@ -188,7 +188,7 @@
               "version_added": "4"
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "36"
             },
             "opera_android": {
               "version_added": null


### PR DESCRIPTION
Opera supports classes since version 36.

The version 43 was probably based on the counter-Chrome release, not on the Opera version itself.