### PR TITLE
Correct HTMLStyleElement

### DIFF
--- a/api/HTMLStyleElement.json
+++ b/api/HTMLStyleElement.json
@@ -247,7 +247,15 @@
               "version_added": false
             },
             "chrome": {
-              "version_added": false
+              "version_added": "19",
+              "version_removed": "35",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable <code>&lt;style scoped&gt;</code>",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": false
@@ -258,12 +266,40 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "21"
-            },
-            "firefox_android": {
-              "version_added": "21"
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scoped-style.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "This property was hidden behind a pref because no other browsers support it (See <a href='https://bugzil.la/1291515'>bug 1291515</a>)."
+              },
+              {
+                "version_added": "21",
+                "version_removed": "55"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "55",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scoped-style.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "This property was hidden behind a pref because no other browsers support it (See <a href='https://bugzil.la/1291515'>bug 1291515</a>)."
+              },
+              {
+                "version_added": "21",
+                "version_removed": "55"
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/HTMLStyleElement.json
+++ b/api/HTMLStyleElement.json
@@ -193,7 +193,7 @@
       },
       "sheet": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLStyleElement/sheet",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/LinkStyle/sheet",
           "support": {
             "webview_android": {
               "version_added": true
@@ -239,9 +239,9 @@
           }
         }
       },
-      "scope": {
+      "scoped": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLStyleElement/scope",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLStyleElement/scoped",
           "support": {
             "webview_android": {
               "version_added": false
@@ -282,7 +282,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }


### PR DESCRIPTION
This corrects the browser compatibility table data for the [`HTMLStyleElement` API](https://developer.mozilla.org/en-US/docs/Web/API/HTMLStyleElement).