### PR TITLE
Fix and Update structure of BCD data for WebGL interfaces

### DIFF
--- a/api/WebGLObject.json
+++ b/api/WebGLObject.json
@@ -1,0 +1,55 @@
+{
+  "api": {
+    "WebGLObject": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLObject",
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": null
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          },
+          "samsunginternet_android": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/WebGLShaderPrecisionFormat.json
+++ b/api/WebGLShaderPrecisionFormat.json
@@ -101,149 +101,149 @@
             "deprecated": false
           }
         }
-      }
-    },
-    "rangeMin": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLShaderPrecisionFormat/rangeMin",
-        "support": {
-          "webview_android": {
-            "version_added": true
+      },
+      "rangeMin": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLShaderPrecisionFormat/rangeMin",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
           },
-          "chrome": {
-            "version_added": "9"
-          },
-          "chrome_android": {
-            "version_added": "25"
-          },
-          "edge": {
-            "version_added": "12"
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "4"
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "ie": {
-            "version_added": "11"
-          },
-          "opera": {
-            "version_added": "12"
-          },
-          "opera_android": {
-            "version_added": "12"
-          },
-          "safari": {
-            "version_added": "5.1"
-          },
-          "safari_ios": {
-            "version_added": "8.1"
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "rangeMax": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLShaderPrecisionFormat/rangeMax",
-        "support": {
-          "webview_android": {
-            "version_added": true
+      },
+      "rangeMax": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLShaderPrecisionFormat/rangeMax",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
           },
-          "chrome": {
-            "version_added": "9"
-          },
-          "chrome_android": {
-            "version_added": "25"
-          },
-          "edge": {
-            "version_added": "12"
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "4"
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "ie": {
-            "version_added": "11"
-          },
-          "opera": {
-            "version_added": "12"
-          },
-          "opera_android": {
-            "version_added": "12"
-          },
-          "safari": {
-            "version_added": "5.1"
-          },
-          "safari_ios": {
-            "version_added": "8.1"
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "precision": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLShaderPrecisionFormat/precision",
-        "support": {
-          "webview_android": {
-            "version_added": true
+      },
+      "precision": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLShaderPrecisionFormat/precision",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "9"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8.1"
+            }
           },
-          "chrome": {
-            "version_added": "9"
-          },
-          "chrome_android": {
-            "version_added": "25"
-          },
-          "edge": {
-            "version_added": "12"
-          },
-          "edge_mobile": {
-            "version_added": true
-          },
-          "firefox": {
-            "version_added": "4"
-          },
-          "firefox_android": {
-            "version_added": true
-          },
-          "ie": {
-            "version_added": "11"
-          },
-          "opera": {
-            "version_added": "12"
-          },
-          "opera_android": {
-            "version_added": "12"
-          },
-          "safari": {
-            "version_added": "5.1"
-          },
-          "safari_ios": {
-            "version_added": "8.1"
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
         }
       }
     }


### PR DESCRIPTION
Generated via https://github.com/dontcallmedom/webidl2mdnbcd from https://www.khronos.org/registry/webgl/specs/latest/1.0/
WebGLShaderPrecisionFormat had the wrong data structure (forthcoming patch to schema to detect this)