### PR TITLE
Remove <code> tag from HTMLStyleElement.scoped Chrome flag name

### DIFF
--- a/api/HTMLStyleElement.json
+++ b/api/HTMLStyleElement.json
@@ -252,7 +252,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "Enable <code>&lt;style scoped&gt;</code>",
+                  "name": "Enable &lt;style scoped&gt;",
                   "value_to_set": "true"
                 }
               ]


### PR DESCRIPTION
MDN wraps the whole flag name inside a `<code>` element, so this is unnecessary.

---

I accidentally missed this in #1387.