### PR TITLE
Update structure of BCD data for getUserMedia interfaces

### DIFF
--- a/api/InputDeviceInfo.json
+++ b/api/InputDeviceInfo.json
@@ -1,17 +1,17 @@
 {
   "api": {
-    "MediaStreamTrackEvent": {
+    "InputDeviceInfo": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackEvent",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/InputDeviceInfo",
         "support": {
           "webview_android": {
-            "version_added": "55"
+            "version_added": null
           },
           "chrome": {
-            "version_added": "55"
+            "version_added": null
           },
           "chrome_android": {
-            "version_added": "55"
+            "version_added": null
           },
           "edge": {
             "version_added": null
@@ -20,22 +20,19 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": "50"
+            "version_added": null
           },
           "firefox_android": {
-            "version_added": "50"
+            "version_added": null
           },
           "ie": {
-            "version_added": false
-          },
-          "nodejs": {
             "version_added": null
           },
           "opera": {
-            "version_added": "42"
+            "version_added": null
           },
           "opera_android": {
-            "version_added": "42"
+            "version_added": null
           },
           "safari": {
             "version_added": null
@@ -53,64 +50,9 @@
           "deprecated": false
         }
       },
-      "MediaStreamTrackEvent": {
+      "getCapabilities": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackEvent/MediaStreamTrackEvent",
-          "description": "<code>MediaStreamTrackEvent</code> constructor",
-          "support": {
-            "webview_android": {
-              "version_added": "55"
-            },
-            "chrome": {
-              "version_added": "55"
-            },
-            "chrome_android": {
-              "version_added": "55"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "50"
-            },
-            "firefox_android": {
-              "version_added": "50"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "nodejs": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "track": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackEvent/track",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/InputDeviceInfo/getCapabilities",
           "support": {
             "webview_android": {
               "version_added": null

--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -313,6 +313,57 @@
             "deprecated": false
           }
         }
+      },
+      "toJSON": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDeviceInfo/toJSON",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -151,6 +151,108 @@
             "deprecated": false
           }
         }
+      },
+      "getSupportedConstraints": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/getSupportedConstraints",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getUserMedia": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/getUserMedia",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -1,17 +1,17 @@
 {
   "api": {
-    "MediaStreamTrackEvent": {
+    "MediaDevices": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackEvent",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices",
         "support": {
           "webview_android": {
-            "version_added": "55"
+            "version_added": null
           },
           "chrome": {
-            "version_added": "55"
+            "version_added": null
           },
           "chrome_android": {
-            "version_added": "55"
+            "version_added": null
           },
           "edge": {
             "version_added": null
@@ -20,22 +20,19 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": "50"
+            "version_added": null
           },
           "firefox_android": {
-            "version_added": "50"
+            "version_added": null
           },
           "ie": {
-            "version_added": false
-          },
-          "nodejs": {
             "version_added": null
           },
           "opera": {
-            "version_added": "42"
+            "version_added": null
           },
           "opera_android": {
-            "version_added": "42"
+            "version_added": null
           },
           "safari": {
             "version_added": null
@@ -53,19 +50,18 @@
           "deprecated": false
         }
       },
-      "MediaStreamTrackEvent": {
+      "ondevicechange": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackEvent/MediaStreamTrackEvent",
-          "description": "<code>MediaStreamTrackEvent</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/ondevicechange",
           "support": {
             "webview_android": {
-              "version_added": "55"
+              "version_added": null
             },
             "chrome": {
-              "version_added": "55"
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": "55"
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -74,22 +70,19 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "50"
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": "50"
+              "version_added": null
             },
             "ie": {
-              "version_added": false
-            },
-            "nodejs": {
               "version_added": null
             },
             "opera": {
-              "version_added": "42"
+              "version_added": null
             },
             "opera_android": {
-              "version_added": "42"
+              "version_added": null
             },
             "safari": {
               "version_added": null
@@ -108,9 +101,9 @@
           }
         }
       },
-      "track": {
+      "enumerateDevices": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackEvent/track",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/enumerateDevices",
           "support": {
             "webview_android": {
               "version_added": null

--- a/api/OverconstrainedErrorEvent.json
+++ b/api/OverconstrainedErrorEvent.json
@@ -1,17 +1,17 @@
 {
   "api": {
-    "MediaStreamTrackEvent": {
+    "OverconstrainedErrorEvent": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackEvent",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/OverconstrainedErrorEvent",
         "support": {
           "webview_android": {
-            "version_added": "55"
+            "version_added": null
           },
           "chrome": {
-            "version_added": "55"
+            "version_added": null
           },
           "chrome_android": {
-            "version_added": "55"
+            "version_added": null
           },
           "edge": {
             "version_added": null
@@ -20,22 +20,19 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": "50"
+            "version_added": null
           },
           "firefox_android": {
-            "version_added": "50"
+            "version_added": null
           },
           "ie": {
-            "version_added": false
-          },
-          "nodejs": {
             "version_added": null
           },
           "opera": {
-            "version_added": "42"
+            "version_added": null
           },
           "opera_android": {
-            "version_added": "42"
+            "version_added": null
           },
           "safari": {
             "version_added": null
@@ -53,64 +50,9 @@
           "deprecated": false
         }
       },
-      "MediaStreamTrackEvent": {
+      "error": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackEvent/MediaStreamTrackEvent",
-          "description": "<code>MediaStreamTrackEvent</code> constructor",
-          "support": {
-            "webview_android": {
-              "version_added": "55"
-            },
-            "chrome": {
-              "version_added": "55"
-            },
-            "chrome_android": {
-              "version_added": "55"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "50"
-            },
-            "firefox_android": {
-              "version_added": "50"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "nodejs": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "track": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackEvent/track",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/OverconstrainedErrorEvent/error",
           "support": {
             "webview_android": {
               "version_added": null


### PR DESCRIPTION
Generated via https://github.com/dontcallmedom/webidl2mdnbcd from https://w3c.github.io/mediacapture-main/getusermedia.html