### PR TITLE
Add compat data for HTMLFontElement

### DIFF
--- a/api/HTMLFontElement.json
+++ b/api/HTMLFontElement.json
@@ -1,0 +1,76 @@
+{
+  "api": {
+    "HTMLFontElement": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFontElement",
+        "support": {
+          "firefox": {
+            "version_added": "22"
+          },
+          "firefox_android": {
+            "version_added": "22"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      },
+      "color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFontElement/color",
+          "support": {
+            "firefox": {
+              "version_added": "22"
+            },
+            "firefox_android": {
+              "version_added": "22"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "face": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFontElement/face",
+          "support": {
+            "firefox": {
+              "version_added": "22"
+            },
+            "firefox_android": {
+              "version_added": "22"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "size": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFontElement/size",
+          "support": {
+            "firefox": {
+              "version_added": "22"
+            },
+            "firefox_android": {
+              "version_added": "22"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Based on the old compat table, it looks like this deprecated API was only ever implemented in Firefox. So I only included firefox and firefox_android data, and left the other browsers out of the file.