### PR TITLE
Clean up the Opera animation prefixes story

### DIFF
--- a/css/properties/animation-delay.json
+++ b/css/properties/animation-delay.json
@@ -92,12 +92,15 @@
             },
             "opera": [
               {
-                "version_added": "12.1",
-                "version_removed": "15"
+                "version_added": "30"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",
@@ -107,12 +110,15 @@
             ],
             "opera_android": [
               {
-                "version_added": "12.1",
-                "version_removed": "15"
+                "version_added": "30"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",

--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -103,12 +103,15 @@
             },
             "opera": [
               {
-                "version_added": "12.1",
-                "version_removed": "15"
+                "version_added": "30"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",
@@ -118,12 +121,15 @@
             ],
             "opera_android": [
               {
-                "version_added": "12.1",
-                "version_removed": "15"
+                "version_added": "30"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",

--- a/css/properties/animation-duration.json
+++ b/css/properties/animation-duration.json
@@ -103,12 +103,15 @@
             },
             "opera": [
               {
-                "version_added": "12.1",
-                "version_removed": "15"
+                "version_added": "30"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",
@@ -118,12 +121,15 @@
             ],
             "opera_android": [
               {
-                "version_added": "12.1",
-                "version_removed": "15"
+                "version_added": "30"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",

--- a/css/properties/animation-fill-mode.json
+++ b/css/properties/animation-fill-mode.json
@@ -103,12 +103,15 @@
             },
             "opera": [
               {
-                "version_added": "12.1",
-                "version_removed": "15"
+                "version_added": "30"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",
@@ -118,12 +121,15 @@
             ],
             "opera_android": [
               {
-                "version_added": "12.1",
-                "version_removed": "15"
+                "version_added": "30"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",

--- a/css/properties/animation-iteration-count.json
+++ b/css/properties/animation-iteration-count.json
@@ -103,12 +103,15 @@
             },
             "opera": [
               {
-                "version_added": "12.1",
-                "version_removed": "15"
+                "version_added": "30"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",
@@ -118,12 +121,15 @@
             ],
             "opera_android": [
               {
-                "version_added": "12.1",
-                "version_removed": "15"
+                "version_added": "30"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",

--- a/css/properties/animation-name.json
+++ b/css/properties/animation-name.json
@@ -103,12 +103,15 @@
             },
             "opera": [
               {
-                "version_added": "12.1",
-                "version_removed": "15"
+                "version_added": "30"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",
@@ -118,12 +121,15 @@
             ],
             "opera_android": [
               {
-                "version_added": "12.1",
-                "version_removed": "15"
+                "version_added": "30"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",

--- a/css/properties/animation-play-state.json
+++ b/css/properties/animation-play-state.json
@@ -103,12 +103,15 @@
             },
             "opera": [
               {
-                "version_added": "12.1",
-                "version_removed": "15"
+                "version_added": "30"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",
@@ -118,12 +121,15 @@
             ],
             "opera_android": [
               {
-                "version_added": "12.1",
-                "version_removed": "15"
+                "version_added": "30"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -103,12 +103,15 @@
             },
             "opera": [
               {
-                "version_added": "12.1",
-                "version_removed": "15"
+                "version_added": "30"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",
@@ -118,12 +121,15 @@
             ],
             "opera_android": [
               {
-                "version_added": "12.1",
-                "version_removed": "15"
+                "version_added": "30"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",

--- a/css/properties/animation.json
+++ b/css/properties/animation.json
@@ -102,9 +102,42 @@
             "ie": {
               "version_added": "10"
             },
-            "opera": {
-              "version_added": "12"
-            },
+            "opera": [
+              {
+                "version_added": "30"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "12",
+                "version_removed": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "30"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "12",
+                "version_removed": "15"
+              }
+            ],
             "safari": [
               {
                 "version_added": true


### PR DESCRIPTION
This PR (hopefully) fixes some issues with the way CSS animation prefixes are described in the data. The story I was able to piece together from caniuse and trolling through Opera blog posts ([example](https://dev.opera.com/blog/opera-30/)) was this:

1. Opera 12: added `-o-` prefixed support.
2. Opera 12.1: added unprefixed support.
3. Opera 15: dropped `-o-` prefixed support, dropped unprefixed support, and added `-webkit-` prefixed support.
4. Opera 30: restored unprefixed support.

I think I've captured that in this PR. Let me know if you want to see any changes. Thanks!