### PR TITLE
Add :has(…)

### DIFF
--- a/css/selectors/has.json
+++ b/css/selectors/has.json
@@ -1,0 +1,69 @@
+{
+  "css": {
+    "selectors": {
+      "has": {
+        "__compat": {
+          "description": "<code>:has()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:has",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/418039'>bug 418039</a>"
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/418039'>bug 418039</a>"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "qq_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "uc_android": {
+              "version_added": false
+            },
+            "uc_chinese_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/has.json
+++ b/css/selectors/has.json
@@ -6,9 +6,6 @@
           "description": "<code>:has()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:has",
           "support": {
-            "webview_android": {
-              "version_added": false
-            },
             "chrome": {
               "version_added": false
             },
@@ -54,6 +51,9 @@
               "version_added": false
             },
             "uc_chinese_android": {
+              "version_added": false
+            },
+            "webview_android": {
               "version_added": false
             }
           },


### PR DESCRIPTION
This adds the browser compatibility table data for the [`:has()` CSS Selector](https://developer.mozilla.org/docs/Web/CSS/:has).