### PR TITLE
adding all the other WebDriver commands

### DIFF
--- a/webdriver/commands/Accept_Alert.json
+++ b/webdriver/commands/Accept_Alert.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Accept_Alert.json
+++ b/webdriver/commands/Accept_Alert.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Accept_Alert": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Accept_Alert",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Accept_Alert.json
+++ b/webdriver/commands/Accept_Alert.json
@@ -19,11 +19,11 @@
             },
             "edge": {
               "version_added": false,
-              "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
               "version_added": false,
-              "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -44,11 +44,11 @@
             },
             "safari": {
               "version_added": false,
-              "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
               "version_added": false,
-              "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
               "version_added": false,

--- a/webdriver/commands/Add_Cookie.json
+++ b/webdriver/commands/Add_Cookie.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Add_Cookie.json
+++ b/webdriver/commands/Add_Cookie.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Add_Cookie": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Add_Cookie",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Back.json
+++ b/webdriver/commands/Back.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Back.json
+++ b/webdriver/commands/Back.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Back": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Back",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Close_Window.json
+++ b/webdriver/commands/Close_Window.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Close_Window.json
+++ b/webdriver/commands/Close_Window.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Close_Window": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Close_Window",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Delete_All_Cookies.json
+++ b/webdriver/commands/Delete_All_Cookies.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Delete_All_Cookies.json
+++ b/webdriver/commands/Delete_All_Cookies.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Delete_All_Cookies": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Delete_All_Cookies",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Delete_Cookie.json
+++ b/webdriver/commands/Delete_Cookie.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Delete_Cookie.json
+++ b/webdriver/commands/Delete_Cookie.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Delete_Cookie": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Delete_Cookie",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Delete_Session.json
+++ b/webdriver/commands/Delete_Session.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Delete_Session.json
+++ b/webdriver/commands/Delete_Session.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Delete_Session": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Delete_Session",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Dismiss_Alert.json
+++ b/webdriver/commands/Dismiss_Alert.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Dismiss_Alert.json
+++ b/webdriver/commands/Dismiss_Alert.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Dismiss_Alert": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Dismiss_Alert",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Element_Clear.json
+++ b/webdriver/commands/Element_Clear.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Element_Clear.json
+++ b/webdriver/commands/Element_Clear.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Element_Clear": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Element_Clear",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Element_Click.json
+++ b/webdriver/commands/Element_Click.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Element_Click.json
+++ b/webdriver/commands/Element_Click.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Element_Click": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Element_Click",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Element_Send_Keys.json
+++ b/webdriver/commands/Element_Send_Keys.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Element_Send_Keys.json
+++ b/webdriver/commands/Element_Send_Keys.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Element_Send_Keys": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Element_Send_Keys",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Execute_Async_Script.json
+++ b/webdriver/commands/Execute_Async_Script.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Execute_Async_Script.json
+++ b/webdriver/commands/Execute_Async_Script.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Execute_Async_Script": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Execute_Async_Script",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Execute_Script.json
+++ b/webdriver/commands/Execute_Script.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Execute_Script.json
+++ b/webdriver/commands/Execute_Script.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Execute_Script": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Execute_Script",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Find_Element.json
+++ b/webdriver/commands/Find_Element.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Find_Element.json
+++ b/webdriver/commands/Find_Element.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Find_Element": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Find_Element",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Find_Element_From_Element.json
+++ b/webdriver/commands/Find_Element_From_Element.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Find_Element_From_Element.json
+++ b/webdriver/commands/Find_Element_From_Element.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Find_Element_From_Element": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Find_Element_From_Element",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Find_Elements.json
+++ b/webdriver/commands/Find_Elements.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Find_Elements.json
+++ b/webdriver/commands/Find_Elements.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Find_Elements": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Find_Elements",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Find_Elements_From_Element.json
+++ b/webdriver/commands/Find_Elements_From_Element.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Find_Elements_From_Element.json
+++ b/webdriver/commands/Find_Elements_From_Element.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Find_Elements_From_Element": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Find_Elements_From_Element",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Forward.json
+++ b/webdriver/commands/Forward.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Forward.json
+++ b/webdriver/commands/Forward.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Forward": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Forward",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Fullscreen_Window.json
+++ b/webdriver/commands/Fullscreen_Window.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Fullscreen_Window.json
+++ b/webdriver/commands/Fullscreen_Window.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Fullscreen_Window": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Fullscreen_Window",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Get_Active_Element.json
+++ b/webdriver/commands/Get_Active_Element.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Get_Active_Element.json
+++ b/webdriver/commands/Get_Active_Element.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Get_Active_Element": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Get_Active_Element",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Get_Alert_Text.json
+++ b/webdriver/commands/Get_Alert_Text.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Get_Alert_Text.json
+++ b/webdriver/commands/Get_Alert_Text.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Get_Alert_Text": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Get_Alert_Text",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Get_All_Cookies.json
+++ b/webdriver/commands/Get_All_Cookies.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Get_All_Cookies.json
+++ b/webdriver/commands/Get_All_Cookies.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Get_All_Cookies": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Get_All_Cookies",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Get_Current_URL.json
+++ b/webdriver/commands/Get_Current_URL.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Get_Current_URL.json
+++ b/webdriver/commands/Get_Current_URL.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Get_Current_URL": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Get_Current_URL",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Get_Element_Attribute.json
+++ b/webdriver/commands/Get_Element_Attribute.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Get_Element_Attribute.json
+++ b/webdriver/commands/Get_Element_Attribute.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Get_Element_Attribute": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Get_Element_Attribute",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Get_Element_CSS_Value.json
+++ b/webdriver/commands/Get_Element_CSS_Value.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Get_Element_CSS_Value.json
+++ b/webdriver/commands/Get_Element_CSS_Value.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Get_Element_CSS_Value": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Get_Element_CSS_Value",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Get_Element_Property.json
+++ b/webdriver/commands/Get_Element_Property.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Get_Element_Property.json
+++ b/webdriver/commands/Get_Element_Property.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Get_Element_Property": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Get_Element_Property",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Get_Element_Rect.json
+++ b/webdriver/commands/Get_Element_Rect.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Get_Element_Rect.json
+++ b/webdriver/commands/Get_Element_Rect.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Get_Element_Rect": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Get_Element_Rect",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Get_Element_Tag_Name.json
+++ b/webdriver/commands/Get_Element_Tag_Name.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Get_Element_Text.json
+++ b/webdriver/commands/Get_Element_Text.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Get_Element_Text.json
+++ b/webdriver/commands/Get_Element_Text.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Get_Element_Text": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Get_Element_Text",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Get_Named_Cookie.json
+++ b/webdriver/commands/Get_Named_Cookie.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Get_Named_Cookie.json
+++ b/webdriver/commands/Get_Named_Cookie.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Get_Named_Cookie": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Get_Named_Cookie",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Get_Page_Source.json
+++ b/webdriver/commands/Get_Page_Source.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Get_Page_Source.json
+++ b/webdriver/commands/Get_Page_Source.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Get_Page_Source": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Get_Page_Source",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Get_Timeouts.json
+++ b/webdriver/commands/Get_Timeouts.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Get_Timeouts.json
+++ b/webdriver/commands/Get_Timeouts.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Get_Timeouts": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Get_Timeouts",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Get_Title.json
+++ b/webdriver/commands/Get_Title.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Get_Title.json
+++ b/webdriver/commands/Get_Title.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Get_Title": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Get_Title",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Get_Window_Handle.json
+++ b/webdriver/commands/Get_Window_Handle.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Get_Window_Handle.json
+++ b/webdriver/commands/Get_Window_Handle.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Get_Window_Handle": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Get_Window_Handle",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Get_Window_Handles.json
+++ b/webdriver/commands/Get_Window_Handles.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Get_Window_Handles.json
+++ b/webdriver/commands/Get_Window_Handles.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Get_Window_Handles": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Get_Window_Handles",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Get_Window_Rect.json
+++ b/webdriver/commands/Get_Window_Rect.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Get_Window_Rect.json
+++ b/webdriver/commands/Get_Window_Rect.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Get_Window_Rect": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Get_Window_Rect",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Is_Element_Enabled.json
+++ b/webdriver/commands/Is_Element_Enabled.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Is_Element_Enabled.json
+++ b/webdriver/commands/Is_Element_Enabled.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Is_Element_Enabled": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Is_Element_Enabled",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Is_Element_Selected.json
+++ b/webdriver/commands/Is_Element_Selected.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Is_Element_Selected.json
+++ b/webdriver/commands/Is_Element_Selected.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Is_Element_Selected": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Is_Element_Selected",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Maximize_Window.json
+++ b/webdriver/commands/Maximize_Window.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Maximize_Window.json
+++ b/webdriver/commands/Maximize_Window.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Maximize_Window": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Maximize_Window",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Minimize_Window.json
+++ b/webdriver/commands/Minimize_Window.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Minimize_Window.json
+++ b/webdriver/commands/Minimize_Window.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Minimize_Window": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Minimize_Window",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Navigate_To.json
+++ b/webdriver/commands/Navigate_To.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Navigate_To.json
+++ b/webdriver/commands/Navigate_To.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Navigate_To": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Navigate_To",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/New_Session.json
+++ b/webdriver/commands/New_Session.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/New_Session.json
+++ b/webdriver/commands/New_Session.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "New_Session": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/New_Session",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Perform_Actions.json
+++ b/webdriver/commands/Perform_Actions.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Perform_Actions.json
+++ b/webdriver/commands/Perform_Actions.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Perform_Actions": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Perform_Actions",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Refresh.json
+++ b/webdriver/commands/Refresh.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Refresh.json
+++ b/webdriver/commands/Refresh.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Refresh": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Refresh",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Release_Actions.json
+++ b/webdriver/commands/Release_Actions.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Release_Actions.json
+++ b/webdriver/commands/Release_Actions.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Release_Actions": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Release_Actions",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Send_Alert_Text.json
+++ b/webdriver/commands/Send_Alert_Text.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Send_Alert_Text.json
+++ b/webdriver/commands/Send_Alert_Text.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Send_Alert_Text": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Send_Alert_Text",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Set_Timeouts.json
+++ b/webdriver/commands/Set_Timeouts.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Set_Timeouts.json
+++ b/webdriver/commands/Set_Timeouts.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Set_Timeouts": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Set_Timeouts",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Set_Window_Rect.json
+++ b/webdriver/commands/Set_Window_Rect.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Set_Window_Rect.json
+++ b/webdriver/commands/Set_Window_Rect.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Set_Window_Rect": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Set_Window_Rect",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Status.json
+++ b/webdriver/commands/Status.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Status.json
+++ b/webdriver/commands/Status.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Status": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Status",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Switch_To_Frame.json
+++ b/webdriver/commands/Switch_To_Frame.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Switch_To_Frame.json
+++ b/webdriver/commands/Switch_To_Frame.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Switch_To_Frame": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Switch_To_Frame",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Switch_To_Parent_Frame.json
+++ b/webdriver/commands/Switch_To_Parent_Frame.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Switch_To_Parent_Frame.json
+++ b/webdriver/commands/Switch_To_Parent_Frame.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Switch_To_Parent_Frame": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Switch_To_Parent_Frame",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Switch_To_Window.json
+++ b/webdriver/commands/Switch_To_Window.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Switch_To_Window.json
+++ b/webdriver/commands/Switch_To_Window.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Switch_To_Window": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Switch_To_Window",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Take_Element_Screenshot.json
+++ b/webdriver/commands/Take_Element_Screenshot.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Take_Element_Screenshot.json
+++ b/webdriver/commands/Take_Element_Screenshot.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Take_Element_Screenshot": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Take_Element_Screenshot",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/Take_Screenshot.json
+++ b/webdriver/commands/Take_Screenshot.json
@@ -18,10 +18,12 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +32,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "opera": {
               "version_added": false,
@@ -41,13 +43,16 @@
               "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
             }
           },
           "status": {

--- a/webdriver/commands/Take_Screenshot.json
+++ b/webdriver/commands/Take_Screenshot.json
@@ -1,0 +1,62 @@
+{
+  "webdriver": {
+    "commands": {
+      "Take_Screenshot": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/Take_Screenshot",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds all the WebDriver commands to the repo, a total of 54.

Andreas has assured me that to his knowledge, support of all the commands is the same. The idea here is to get these in the repo, and then we can make adjustments if any differences are encountered.