### PR TITLE
Add -webkit-touch-callout

### DIFF
--- a/css/properties/-webkit-touch-callout.json
+++ b/css/properties/-webkit-touch-callout.json
@@ -30,7 +30,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false
             },
             "safari": {
               "version_added": "4"

--- a/css/properties/-webkit-touch-callout.json
+++ b/css/properties/-webkit-touch-callout.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "-webkit-touch-callout": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-touch-callout",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "2"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-webkit-touch-callout.json
+++ b/css/properties/-webkit-touch-callout.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-touch-callout",
           "support": {
-            "webview_android": {
-              "version_added": false
-            },
             "chrome": {
               "version_added": false
             },
@@ -40,6 +37,9 @@
             },
             "safari_ios": {
               "version_added": "2"
+            },
+            "webview_android": {
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
This adds the browser compatibility table data for the [`‑webkit‑touch‑callout` CSS Property](https://developer.mozilla.org/docs/Web/CSS/-webkit-touch-callout).