### PR TITLE
Extract BCD skeleton for Navigator interface from HTML LS

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1,0 +1,55 @@
+{
+  "api": {
+    "Navigator": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator",
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": null
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          },
+          "samsunginternet_android": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Extracted with https://github.com/dontcallmedom/webidl2mdnbcd from http://html.spec.whatwg.org/