### PR TITLE
Adding data for HTMTableHeaderCellElement

### DIFF
--- a/api/HTMLTableHeaderCellElement.json
+++ b/api/HTMLTableHeaderCellElement.json
@@ -6,50 +6,50 @@
         "support": {
           "webview_android": {
             "version_added": false,
-            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
           },
           "chrome": {
             "version_added": false,
-            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
           },
           "chrome_android": {
             "version_added": false,
-            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
           },
           "edge": {
             "version_added": false,
-            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
           },
           "edge_mobile": {
             "version_added": false,
-            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
           },
           "firefox": {
             "version_added": false,
-            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
           },
           "firefox_android": {
             "version_added": false,
-            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
           },
           "ie": {
             "version_added": true
           },
           "opera": {
             "version_added": false,
-            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
           },
           "opera_android": {
             "version_added": false,
-            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
           },
           "safari": {
             "version_added": false,
-            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
           },
           "safari_ios": {
             "version_added": false,
-            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
           }
         },
         "status": {
@@ -64,50 +64,50 @@
           "support": {
             "webview_android": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "chrome": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "edge": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "edge_mobile": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "firefox": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "firefox_android": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "ie": {
               "version_added": true
             },
             "opera": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "safari": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "safari_ios": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             }
           },
           "status": {
@@ -123,50 +123,50 @@
           "support": {
             "webview_android": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "chrome": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "edge": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "edge_mobile": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "firefox": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "firefox_android": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "ie": {
               "version_added": true
             },
             "opera": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "safari": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "safari_ios": {
               "version_added": false,
-              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             }
           },
           "status": {

--- a/api/HTMLTableHeaderCellElement.json
+++ b/api/HTMLTableHeaderCellElement.json
@@ -1,0 +1,229 @@
+{
+  "api": {
+    "HTMLTableHeaderCellElement": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableHeaderCellElement",
+        "support": {
+          "webview_android": {
+            "version_added": false,
+            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+          },
+          "chrome": {
+            "version_added": false,
+            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+          },
+          "chrome_android": {
+            "version_added": false,
+            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+          },
+          "edge": {
+            "version_added": false,
+            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+          },
+          "edge_mobile": {
+            "version_added": false,
+            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+          },
+          "firefox": {
+            "version_added": false,
+            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+          },
+          "firefox_android": {
+            "version_added": false,
+            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+          },
+          "ie": {
+            "version_added": true
+          },
+          "opera": {
+            "version_added": false,
+            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+          },
+          "opera_android": {
+            "version_added": false,
+            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+          },
+          "safari": {
+            "version_added": false,
+            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+          },
+          "safari_ios": {
+            "version_added": false,
+            "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      },
+      "abbr": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableHeaderCellElement/abbr",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "edge": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "edge_mobile": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "scope": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableHeaderCellElement/scope",
+          "support": {
+            "webview_android": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "edge": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "edge_mobile": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Members of the HTMLTableHeaderCellElement interface now implemented on HTMLTableCellElement."
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "sorted": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableHeaderCellElement/sorted",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Note that I'm really not sure if this is the right way to represent this. The trouble is that this interface existed at some point, but it was completely removed from browsers and the spec a couple of years ago (see https://github.com/whatwg/html/issues/1115), and its members are now implemented on HTMLTableCellElement (see #1526).

The same problems will be seen for HTMLTableDataCellElement too (#1534 ) too.

We could just kill it with fire, but this is not the MDN way ;-)