### PR TITLE
Add HTMLTimeElement

### DIFF
--- a/api/HTMLTimeElement.json
+++ b/api/HTMLTimeElement.json
@@ -1,0 +1,124 @@
+{
+  "api": {
+    "HTMLTimeElement": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTimeElement",
+        "support": {
+          "chrome": {
+            "version_added": "62"
+          },
+          "chrome_android": {
+            "version_added": "62"
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "22"
+          },
+          "firefox_android": {
+            "version_added": "22"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": [
+            {
+              "version_added": "49"
+            },
+            {
+              "version_added": "11.5",
+              "version_removed": "15"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "49"
+            },
+            {
+              "version_added": "11.5",
+              "version_removed": "15"
+            }
+          ],
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "62"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "dateTime": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTimeElement/dateTime",
+          "support": {
+            "chrome": {
+              "version_added": "62"
+            },
+            "chrome_android": {
+              "version_added": "62"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "22"
+            },
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_added": "11.5",
+                "version_removed": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_added": "11.5",
+                "version_removed": "15"
+              }
+            ],
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "62"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds the browser compatibility table data for the [`HTMLTimeElement` API](https://developer.mozilla.org/docs/Web/API/HTMLTimeElement).