### PR TITLE
Add compat data for CSSRule

### DIFF
--- a/api/CSSRule.json
+++ b/api/CSSRule.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "CSSRule": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSRule",
+        "support": {
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The wiki page contains compat info for some specific CSSRule types, such as CSSKeyframesRule. I omitted those from this file, since they will be covered by separate JSON files for those interfaces, such as CSSKeyframesRule.json