### PR TITLE
Add compat data for DOMParser

### DIFF
--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -96,9 +96,9 @@
           }
         }
       },
-      "xml": {
+      "parseFromString": {
         "__compat": {
-          "description": "XML (<code>application/xml</code>) support",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMParser/parseFromString",
           "support": {
             "webview_android": {
               "version_added": true
@@ -142,101 +142,149 @@
             "standard_track": true,
             "deprecated": false
           }
-        }
-      },
-      "svg": {
-        "__compat": {
-          "description": "SVG (<code>image/svg+xml</code>) support",
-          "support": {
-            "webview_android": {
-              "version_added": null
+        },
+        "xml": {
+          "__compat": {
+            "description": "XML (<code>application/xml</code>) support",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "opera": {
+                "version_added": "8"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "3.2"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
             },
-            "chrome": {
-              "version_added": "4"
-            },
-            "chrome_android": {
-              "version_added": null
-            },
-            "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": "10"
-            },
-            "firefox_android": {
-              "version_added": "10"
-            },
-            "ie": {
-              "version_added": "10"
-            },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": "3.2"
-            },
-            "safari_ios": {
-              "version_added": null
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
           }
-        }
-      },
-      "html": {
-        "__compat": {
-          "description": "HTML (<code>text/html</code>) support",
-          "support": {
-            "webview_android": {
-              "version_added": null
+        },
+        "svg": {
+          "__compat": {
+            "description": "SVG (<code>image/svg+xml</code>) support",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "4"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "10"
+              },
+              "firefox_android": {
+                "version_added": "10"
+              },
+              "ie": {
+                "version_added": "10"
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "3.2"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
             },
-            "chrome": {
-              "version_added": "30"
-            },
-            "chrome_android": {
-              "version_added": null
-            },
-            "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": "12"
-            },
-            "firefox_android": {
-              "version_added": "14"
-            },
-            "ie": {
-              "version_added": "10"
-            },
-            "opera": {
-              "version_added": "17"
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": "9.1"
-            },
-            "safari_ios": {
-              "version_added": null
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+          }
+        },
+        "html": {
+          "__compat": {
+            "description": "HTML (<code>text/html</code>) support",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "30"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "12"
+              },
+              "firefox_android": {
+                "version_added": "14"
+              },
+              "ie": {
+                "version_added": "10"
+              },
+              "opera": {
+                "version_added": "17"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "9.1"
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -4,9 +4,6 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMParser",
         "support": {
-          "webview_android": {
-            "version_added": true
-          },
           "chrome": {
             "version_added": "1"
           },
@@ -39,6 +36,9 @@
           },
           "safari_ios": {
             "version_added": null
+          },
+          "webview_android": {
+            "version_added": true
           }
         },
         "status": {
@@ -52,9 +52,6 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMParser/DOMParser",
           "description": "<code>DOMParser()</code> constructor",
           "support": {
-            "webview_android": {
-              "version_added": true
-            },
             "chrome": {
               "version_added": "1"
             },
@@ -87,6 +84,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -100,9 +100,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMParser/parseFromString",
           "support": {
-            "webview_android": {
-              "version_added": true
-            },
             "chrome": {
               "version_added": "1"
             },
@@ -135,6 +132,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -147,9 +147,6 @@
           "__compat": {
             "description": "XML (<code>application/xml</code>) support",
             "support": {
-              "webview_android": {
-                "version_added": true
-              },
               "chrome": {
                 "version_added": "1"
               },
@@ -182,6 +179,9 @@
               },
               "safari_ios": {
                 "version_added": null
+              },
+              "webview_android": {
+                "version_added": true
               }
             },
             "status": {
@@ -195,9 +195,6 @@
           "__compat": {
             "description": "SVG (<code>image/svg+xml</code>) support",
             "support": {
-              "webview_android": {
-                "version_added": null
-              },
               "chrome": {
                 "version_added": "4"
               },
@@ -230,6 +227,9 @@
               },
               "safari_ios": {
                 "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
               }
             },
             "status": {
@@ -243,9 +243,6 @@
           "__compat": {
             "description": "HTML (<code>text/html</code>) support",
             "support": {
-              "webview_android": {
-                "version_added": null
-              },
               "chrome": {
                 "version_added": "30"
               },
@@ -277,6 +274,9 @@
                 "version_added": "9.1"
               },
               "safari_ios": {
+                "version_added": null
+              },
+              "webview_android": {
                 "version_added": null
               }
             },

--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -47,6 +47,55 @@
           "deprecated": false
         }
       },
+      "DOMParser": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMParser/DOMParser",
+          "description": "<code>DOMParser()</code> constructor",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "8"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.2"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "xml": {
         "__compat": {
           "description": "XML (<code>application/xml</code>) support",

--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -3,7 +3,6 @@
     "DOMParser": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMParser",
-        "description": "XML support",
         "support": {
           "webview_android": {
             "version_added": true
@@ -48,10 +47,57 @@
           "deprecated": false
         }
       },
-      "SVG_support": {
+      "xml": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMParser",
-          "description": "SVG support",
+          "description": "XML (<code>application/xml</code>) support",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "8"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.2"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "svg": {
+        "__compat": {
+          "description": "SVG (<code>image/svg+xml</code>) support",
           "support": {
             "webview_android": {
               "version_added": null
@@ -97,10 +143,9 @@
           }
         }
       },
-      "HTML_support": {
+      "html": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMParser",
-          "description": "HTML support",
+          "description": "HTML (<code>text/html</code>) support",
           "support": {
             "webview_android": {
               "version_added": null

--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -1,0 +1,151 @@
+{
+  "api": {
+    "DOMParser": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMParser",
+        "description": "XML support",
+        "support": {
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome": {
+            "version_added": "1"
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "1"
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": "8"
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": "3.2"
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      },
+      "SVG_support": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMParser",
+          "description": "SVG support",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "10"
+            },
+            "firefox_android": {
+              "version_added": "10"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.2"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "HTML_support": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMParser",
+          "description": "HTML support",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "30"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "12"
+            },
+            "firefox_android": {
+              "version_added": "14"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "17"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "9.1"
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -44,8 +44,8 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
-          "deprecated": true
+          "standard_track": true,
+          "deprecated": false
         }
       },
       "SVG_support": {
@@ -92,8 +92,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -141,8 +141,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
The first line of the wiki table is labelled "XML support", so I used that as the description for the basic feature __compat object.