### PR TITLE
Migrate data for Paint Timing API

### DIFF
--- a/api/PerformancePaintTiming.json
+++ b/api/PerformancePaintTiming.json
@@ -1,0 +1,55 @@
+{
+  "api": {
+    "PerformancePaintTiming": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformancePaintTiming",
+        "support": {
+          "webview_android": {
+            "version_added": "60"
+          },
+          "chrome": {
+            "version_added": "60"
+          },
+          "chrome_android": {
+            "version_added": "60"
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": null
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "47"
+          },
+          "opera_android": {
+            "version_added": "47"
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          },
+          "samsunginternet_android": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Skeleton generated via https://github.com/dontcallmedom/webidl2mdnbcd from https://w3c.github.io/paint-timing/

Data copied from https://developer.mozilla.org/en-US/docs/Web/API/PerformancePaintTiming