### PR TITLE
Migrate and update data on Vibration API

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -159,13 +159,26 @@
             "webview_android": {
               "version_added": null
             },
-            "chrome": {
-              "version_added": true,
-              "prefix": "webkit"
-            },
-            "chrome_android": {
-              "version_added": null
-            },
+            "chrome": [
+              {
+                "version_added": true,
+                "version_removed": true,
+                "prefix": "webkit"
+              },
+              {
+                "version_added": true
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": true,
+                "version_removed": true,
+                "prefix": "webkit"
+              },
+              {
+                "version_added": true
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -182,7 +195,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": "11",
+              "version_added": true,
               "prefix": "moz"
             },
             "ie": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -160,7 +160,8 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": null
+              "version_added": true,
+              "prefix": "webkit"
             },
             "chrome_android": {
               "version_added": null
@@ -171,26 +172,33 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": null
-            },
+            "firefox": [
+              {
+                "version_added": "11",
+                "prefix": "moz"
+              },
+              {
+                "version_added": "16"
+              }
+            ],
             "firefox_android": {
-              "version_added": null
+              "version_added": "11",
+              "prefix": "moz"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -151,6 +151,57 @@
             "deprecated": false
           }
         }
+      },
+      "vibrate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/vibrate",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Note that this pull request also updates compat data for Chrome (which no longer support the prefixed API but does support the unprefixed one)