### PR TITLE
update edge data

### DIFF
--- a/css/properties/-webkit-text-fill-color.json
+++ b/css/properties/-webkit-text-fill-color.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/-webkit-text-stroke-color.json
+++ b/css/properties/-webkit-text-stroke-color.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -22,11 +22,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -17,11 +17,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -21,7 +21,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": [
               {

--- a/css/properties/animation-delay.json
+++ b/css/properties/animation-delay.json
@@ -27,7 +27,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": [
               {

--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -34,11 +34,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [
@@ -176,7 +176,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -218,7 +218,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true

--- a/css/properties/animation-duration.json
+++ b/css/properties/animation-duration.json
@@ -34,11 +34,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/animation-fill-mode.json
+++ b/css/properties/animation-fill-mode.json
@@ -34,11 +34,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/animation-iteration-count.json
+++ b/css/properties/animation-iteration-count.json
@@ -34,11 +34,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/animation-play-state.json
+++ b/css/properties/animation-play-state.json
@@ -34,11 +34,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -34,11 +34,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/animation.json
+++ b/css/properties/animation.json
@@ -35,11 +35,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/backface-visibility.json
+++ b/css/properties/backface-visibility.json
@@ -19,11 +19,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/border-bottom-color.json
+++ b/css/properties/border-bottom-color.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-bottom-left-radius.json
+++ b/css/properties/border-bottom-left-radius.json
@@ -16,11 +16,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [
@@ -92,7 +92,7 @@
                 "version_added": "4"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -134,7 +134,7 @@
                 "version_added": "1"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true

--- a/css/properties/border-bottom-right-radius.json
+++ b/css/properties/border-bottom-right-radius.json
@@ -16,11 +16,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [
@@ -92,7 +92,7 @@
                 "version_added": "4"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -134,7 +134,7 @@
                 "version_added": "1"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true

--- a/css/properties/border-bottom-style.json
+++ b/css/properties/border-bottom-style.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-bottom-width.json
+++ b/css/properties/border-bottom-width.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-bottom.json
+++ b/css/properties/border-bottom.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-collapse.json
+++ b/css/properties/border-collapse.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-color.json
+++ b/css/properties/border-color.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-image-outset.json
+++ b/css/properties/border-image-outset.json
@@ -9,7 +9,7 @@
               "version_added": "15"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-image-repeat.json
+++ b/css/properties/border-image-repeat.json
@@ -9,7 +9,7 @@
               "version_added": "15"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true
@@ -47,7 +47,7 @@
                 "version_added": "30"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -80,7 +80,7 @@
                 "version_added": "56"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true

--- a/css/properties/border-image-slice.json
+++ b/css/properties/border-image-slice.json
@@ -16,7 +16,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-image-source.json
+++ b/css/properties/border-image-source.json
@@ -9,7 +9,7 @@
               "version_added": "15"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-image-width.json
+++ b/css/properties/border-image-width.json
@@ -9,7 +9,7 @@
               "version_added": "15"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -23,11 +23,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/border-left-color.json
+++ b/css/properties/border-left-color.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-left-style.json
+++ b/css/properties/border-left-style.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-left-width.json
+++ b/css/properties/border-left-width.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-left.json
+++ b/css/properties/border-left.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -21,11 +21,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [
@@ -94,7 +94,7 @@
                 "notes": "Prior to Chrome 4, the slash <code>/</code> notation is unsupported. If two values are specified, an elliptical border is drawn on all four corners. <code>-webkit-border-radius: 40px 10px;</code> is equivalent to <code>border-radius: 40px/10px;</code>."
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -134,7 +134,7 @@
                 "version_added": "4"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -178,7 +178,7 @@
                 "notes": "<code>&lt;percentage&gt;</code> values are not supported in older Chrome and Safari versions (it was <a href='http://trac.webkit.org/changeset/66615'>fixed in Sepember 2010</a>)."
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true

--- a/css/properties/border-right-color.json
+++ b/css/properties/border-right-color.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-right-style.json
+++ b/css/properties/border-right-style.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-right-width.json
+++ b/css/properties/border-right-width.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-right.json
+++ b/css/properties/border-right.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-spacing.json
+++ b/css/properties/border-spacing.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-top-color.json
+++ b/css/properties/border-top-color.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-top-left-radius.json
+++ b/css/properties/border-top-left-radius.json
@@ -16,11 +16,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [
@@ -92,7 +92,7 @@
                 "version_added": "4"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -134,7 +134,7 @@
                 "version_added": "1"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true

--- a/css/properties/border-top-right-radius.json
+++ b/css/properties/border-top-right-radius.json
@@ -16,11 +16,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [
@@ -92,7 +92,7 @@
                 "version_added": "4"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -134,7 +134,7 @@
                 "version_added": "1"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true

--- a/css/properties/border-top-style.json
+++ b/css/properties/border-top-style.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-top-width.json
+++ b/css/properties/border-top-width.json
@@ -12,7 +12,7 @@
               "version_added": "2.3"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-top.json
+++ b/css/properties/border-top.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border-width.json
+++ b/css/properties/border-width.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/border.json
+++ b/css/properties/border.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/bottom.json
+++ b/css/properties/bottom.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/box-direction.json
+++ b/css/properties/box-direction.json
@@ -17,7 +17,7 @@
             },
             "edge": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "prefix": "-webkit-",

--- a/css/properties/box-flex.json
+++ b/css/properties/box-flex.json
@@ -17,7 +17,7 @@
             },
             "edge": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "prefix": "-webkit-",

--- a/css/properties/box-orient.json
+++ b/css/properties/box-orient.json
@@ -17,7 +17,7 @@
             },
             "edge": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "prefix": "-webkit-",

--- a/css/properties/box-pack.json
+++ b/css/properties/box-pack.json
@@ -17,7 +17,7 @@
             },
             "edge": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "prefix": "-webkit-",

--- a/css/properties/box-shadow.json
+++ b/css/properties/box-shadow.json
@@ -24,7 +24,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true
@@ -121,7 +121,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -196,7 +196,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -271,7 +271,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true

--- a/css/properties/box-sizing.json
+++ b/css/properties/box-sizing.json
@@ -30,11 +30,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -15,7 +15,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -15,7 +15,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/break-inside.json
+++ b/css/properties/break-inside.json
@@ -15,7 +15,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/caption-side.json
+++ b/css/properties/caption-side.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/clear.json
+++ b/css/properties/clear.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/clip.json
+++ b/css/properties/clip.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -63,7 +63,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -113,7 +113,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -162,7 +162,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -211,7 +211,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -260,7 +260,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -465,10 +465,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "49"

--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -22,11 +22,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/column-fill.json
+++ b/css/properties/column-fill.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -22,11 +22,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/column-rule-color.json
+++ b/css/properties/column-rule-color.json
@@ -28,11 +28,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/column-rule-style.json
+++ b/css/properties/column-rule-style.json
@@ -28,11 +28,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/column-rule-width.json
+++ b/css/properties/column-rule-width.json
@@ -28,7 +28,7 @@
             ],
             "edge": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "prefix": "-webkit-",

--- a/css/properties/column-rule.json
+++ b/css/properties/column-rule.json
@@ -28,7 +28,7 @@
             ],
             "edge": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/column-span.json
+++ b/css/properties/column-span.json
@@ -34,11 +34,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -28,11 +28,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/columns.json
+++ b/css/properties/columns.json
@@ -28,11 +28,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true
@@ -63,7 +63,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true

--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true
@@ -63,7 +63,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -111,7 +111,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -159,7 +159,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -207,7 +207,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -256,7 +256,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -305,7 +305,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -353,7 +353,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -401,7 +401,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -449,7 +449,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -497,7 +497,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -545,7 +545,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -593,7 +593,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -641,7 +641,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -689,7 +689,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -737,7 +737,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -785,7 +785,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -833,7 +833,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -881,7 +881,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -929,7 +929,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -977,7 +977,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -1025,7 +1025,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -1073,7 +1073,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -1121,7 +1121,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -1175,7 +1175,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -1244,7 +1244,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "14"
               },
               "edge_mobile": {
                 "version_added": true
@@ -1299,7 +1299,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true

--- a/css/properties/direction.json
+++ b/css/properties/direction.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true
@@ -62,7 +62,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null
@@ -110,7 +110,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null
@@ -159,7 +159,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null
@@ -207,7 +207,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null
@@ -261,7 +261,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null
@@ -336,7 +336,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null
@@ -461,7 +461,7 @@
               },
               "edge": {
                 "prefix": "-ms-",
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null
@@ -558,7 +558,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null

--- a/css/properties/empty-cells.json
+++ b/css/properties/empty-cells.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/filter.json
+++ b/css/properties/filter.json
@@ -29,11 +29,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [
@@ -158,10 +158,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
                 "version_added": "35"

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -11,11 +11,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [
@@ -140,7 +140,7 @@
                 "version_added": "21"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -183,7 +183,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -11,11 +11,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -15,7 +15,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -11,11 +11,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/flex-shrink.json
+++ b/css/properties/flex-shrink.json
@@ -11,11 +11,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -28,11 +28,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/float.json
+++ b/css/properties/float.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -15,7 +15,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/font-kerning.json
+++ b/css/properties/font-kerning.json
@@ -16,10 +16,10 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": [
               {

--- a/css/properties/font-weight.json
+++ b/css/properties/font-weight.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/font.json
+++ b/css/properties/font.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true
@@ -62,7 +62,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -15,7 +15,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -24,11 +24,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/justify-items.json
+++ b/css/properties/justify-items.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "16"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "16"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/left.json
+++ b/css/properties/left.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/letter-spacing.json
+++ b/css/properties/letter-spacing.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/line-break.json
+++ b/css/properties/line-break.json
@@ -33,7 +33,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -116,7 +116,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -429,7 +429,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null
@@ -682,7 +682,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -1527,7 +1527,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -1575,7 +1575,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -2265,7 +2265,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true

--- a/css/properties/margin-bottom.json
+++ b/css/properties/margin-bottom.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/margin-left.json
+++ b/css/properties/margin-left.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/margin-right.json
+++ b/css/properties/margin-right.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/margin-top.json
+++ b/css/properties/margin-top.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/margin.json
+++ b/css/properties/margin.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -19,7 +19,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "16"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -30,7 +30,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true
@@ -165,7 +165,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true,
+                "version_added": "12",
                 "notes": "Edge uses <code>auto</code> as the initial value for <code>min-width</code>."
               },
               "edge_mobile": {

--- a/css/properties/opacity.json
+++ b/css/properties/opacity.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/order.json
+++ b/css/properties/order.json
@@ -22,11 +22,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [
@@ -156,7 +156,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null

--- a/css/properties/orphans.json
+++ b/css/properties/orphans.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/outline-color.json
+++ b/css/properties/outline-color.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/outline-style.json
+++ b/css/properties/outline-style.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/outline-width.json
+++ b/css/properties/outline-width.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/outline.json
+++ b/css/properties/outline.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -32,7 +32,7 @@
               },
               {
                 "alternative_name": "word-wrap",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/padding-bottom.json
+++ b/css/properties/padding-bottom.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/padding-left.json
+++ b/css/properties/padding-left.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/padding-right.json
+++ b/css/properties/padding-right.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/padding-top.json
+++ b/css/properties/padding-top.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/padding.json
+++ b/css/properties/padding.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/page-break-after.json
+++ b/css/properties/page-break-after.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/page-break-before.json
+++ b/css/properties/page-break-before.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/page-break-inside.json
+++ b/css/properties/page-break-inside.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -18,11 +18,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -23,11 +23,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/pointer-events.json
+++ b/css/properties/pointer-events.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true
@@ -62,7 +62,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null

--- a/css/properties/quotes.json
+++ b/css/properties/quotes.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/right.json
+++ b/css/properties/right.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/ruby-position.json
+++ b/css/properties/ruby-position.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/table-layout.json
+++ b/css/properties/table-layout.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -54,7 +54,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -23,7 +23,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": true
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true
@@ -65,7 +65,7 @@
                 "notes": "The <code>blink</code> value does not have any effect."
               },
               "edge": {
-                "version_added": true,
+                "version_added": "12",
                 "notes": "The <code>blink</code> value does not have any effect."
               },
               "edge_mobile": {

--- a/css/properties/text-indent.json
+++ b/css/properties/text-indent.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/text-overflow.json
+++ b/css/properties/text-overflow.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/text-shadow.json
+++ b/css/properties/text-shadow.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/text-size-adjust.json
+++ b/css/properties/text-size-adjust.json
@@ -21,16 +21,10 @@
             "chrome_android": {
               "version_added": "54"
             },
-            "edge": [
-              {
-                "prefix": "-ms-",
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
+            "edge": {
+              "prefix": "-webkit-",
+              "version_added": "12"
+            },
             "edge_mobile": [
               {
                 "prefix": "-ms-",

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -17,7 +17,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/top.json
+++ b/css/properties/top.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/touch-action.json
+++ b/css/properties/touch-action.json
@@ -16,7 +16,7 @@
               "version_added": "36"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true
@@ -96,7 +96,7 @@
                 "version_added": "36"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -175,7 +175,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -228,7 +228,7 @@
                 "version_added": "56"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -17,11 +17,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/transform-style.json
+++ b/css/properties/transform-style.json
@@ -18,11 +18,11 @@
             },
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -25,7 +25,7 @@
             },
             "edge": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "prefix": "-webkit-",
@@ -144,7 +144,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -178,7 +178,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true

--- a/css/properties/unicode-bidi.json
+++ b/css/properties/unicode-bidi.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -23,11 +23,11 @@
             "edge": [
               {
                 "prefix": "-ms-",
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [
@@ -107,7 +107,8 @@
                 },
                 {
                   "alternative_name": "element",
-                  "version_added": true
+                  "prefix": "-webkit-",
+                  "version_added": "12"
                 }
               ],
               "edge_mobile": [
@@ -116,6 +117,7 @@
                 },
                 {
                   "alternative_name": "element",
+                  "prefix": "-webkit-",
                   "version_added": true
                 }
               ],

--- a/css/properties/vertical-align.json
+++ b/css/properties/vertical-align.json
@@ -15,7 +15,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/visibility.json
+++ b/css/properties/visibility.json
@@ -15,7 +15,7 @@
               "version_added": "1"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true
@@ -74,7 +74,7 @@
                 ]
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true
@@ -62,7 +62,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null
@@ -110,7 +110,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null
@@ -165,7 +165,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null

--- a/css/properties/widows.json
+++ b/css/properties/widows.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -15,7 +15,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -15,7 +15,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/word-wrap.json
+++ b/css/properties/word-wrap.json
@@ -27,7 +27,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -34,11 +34,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [
@@ -125,7 +125,7 @@
                 "version_added": "48"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true

--- a/css/properties/z-index.json
+++ b/css/properties/z-index.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true
@@ -62,7 +62,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true


### PR DESCRIPTION
updates (nearly) all `true` versions of CSS props in Edge. Data was pulled from [Edge's docs](https://github.com/MicrosoftEdge/MicrosoftEdge-Documentation)