### PR TITLE
Adding DOMPointReadOnly data to BCD

### DIFF
--- a/api/DOMPointReadOnly.json
+++ b/api/DOMPointReadOnly.json
@@ -20,10 +20,10 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": true
+            "version_added": "31"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "31"
           },
           "ie": {
             "version_added": false
@@ -68,10 +68,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -116,10 +116,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -164,10 +164,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -212,10 +212,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -260,10 +260,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -308,10 +308,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -356,10 +356,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -404,10 +404,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false

--- a/api/DOMPointReadOnly.json
+++ b/api/DOMPointReadOnly.json
@@ -1,0 +1,437 @@
+{
+  "api": {
+    "DOMPointReadOnly": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPointReadOnly",
+        "support": {
+          "webview_android": {
+            "version_added": "61"
+          },
+          "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": {
+            "version_added": "61"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "48"
+          },
+          "opera_android": {
+            "version_added": "48"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "DOMPointReadOnly": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPointReadOnly/DOMPointReadOnly",
+          "description": "<code>DOMPointReadOnly()</code> constructor",
+          "support": {
+            "webview_android": {
+              "version_added": "61"
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "x": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPointReadOnly/x",
+          "support": {
+            "webview_android": {
+              "version_added": "61"
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "y": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPointReadOnly/y",
+          "support": {
+            "webview_android": {
+              "version_added": "61"
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "z": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPointReadOnly/z",
+          "support": {
+            "webview_android": {
+              "version_added": "61"
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "w": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPointReadOnly/w",
+          "support": {
+            "webview_android": {
+              "version_added": "61"
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "fromPoint": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPointReadOnly/fromPoint",
+          "support": {
+            "webview_android": {
+              "version_added": "61"
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "matrixTransform": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPointReadOnly/matrixTransform",
+          "support": {
+            "webview_android": {
+              "version_added": "61"
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "toJSON": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPointReadOnly/toJSON",
+          "support": {
+            "webview_android": {
+              "version_added": "61"
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
see https://developer.mozilla.org/en-US/docs/Web/API/DOMPointReadOnly.

I took the data from https://developer.mozilla.org/en-US/docs/Web/API/DOMPoint really — there is no chance that this would be implemented and the ReadOnly version wouldn't be.

Also, I added in Opera support info as it is supported, and I suspect it will follow the usual pattern of Chrome version -13.