### PR TITLE
Added browser compatiblity information for NotificationOptions properties

### DIFF
--- a/webextensions/api/notifications.json
+++ b/webextensions/api/notifications.json
@@ -13,19 +13,311 @@
                 "version_added": false
               },
               "firefox": {
-                "notes": [
-                  "Only 'type', 'iconUrl', 'title', and 'message' are supported."
-                ],
                 "version_added": "45"
               },
               "firefox_android": {
-                "notes": [
-                  "Only 'type', 'iconUrl', 'title', and 'message' are supported."
-                ],
                 "version_added": "48"
               },
               "opera": {
                 "version_added": true
+              }
+            }
+          },
+          "appIconMaskUrl": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                },
+                "opera": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error. It might or might not have any effect."
+                  ],
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": true
+              }
+            }
+          },
+          "buttons": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "notes": [
+                    "Specifying the 'buttons' option will cause an asynchronous error on Opera."
+                  ],
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "contextMessage": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "31"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                },
+                "opera": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored, on Opera 18 and above."
+                  ],
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "eventTime": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                },
+                "opera": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error. It might or might not have any effect."
+                  ],
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "imageUrl": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                },
+                "opera": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": true
+              }
+            }
+          },
+          "isClickable": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "32"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                },
+                "opera": {
+                  "notes": [
+                    "Setting 'isClickable' to false will cause an asynchronous error on Opera 19 and above. Older Opera versions throw an error synchronously if this options is given."
+                  ],
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "items": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "notes": [
+                    "On macOS only the first item is shown."
+                  ],
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                },
+                "opera": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "priority": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "progress": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "30"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored."
+                  ],
+                  "version_added": false
+                },
+                "opera": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored, on Opera 17 and above."
+                  ],
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "requireInteraction": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "50"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "notes": [
+                    "Specifying this option doesn't throw an error, but its value is ignored, on Opera 37 and above."
+                  ],
+                  "version_added": false
+                }
               }
             }
           }


### PR DESCRIPTION
These changes are based on the [Chrome docs](https://developer.chrome.com/apps/notifications#type-NotificationOptions), and tests, I performed on Firefox 58 and Opera 50.

On Firefox, the only options that cause an error are `buttons` and `requireInteraction`. However, none of the other optional options have any effect either but are ignored silently.

On Opera, the only options that cause an error (asynchronously) are `buttons` and `isClickable`. However, most of the other options are just ignored silently.