### PR TITLE
Opera 36 supports default parameters

### DIFF
--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -501,10 +501,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": "45"
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": "45"
+              "version_added": "36"
             },
             "safari": {
               "version_added": "10"
@@ -551,10 +551,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": "45"
+                "version_added": "36"
               },
               "opera_android": {
-                "version_added": "45"
+                "version_added": "36"
               },
               "safari": {
                 "version_added": "10"


### PR DESCRIPTION
It looks that once again the Android Webview version ended up as Opera version.

As you can see in the [what's new in Opera 36](https://dev.opera.com/blog/opera-36/) post, and you can counter-verify it live too, Opera 36 already supports default parameters.