### PR TITLE
Correct Shadow DOM v0 Firefox support

### DIFF
--- a/api/HTMLContentElement.json
+++ b/api/HTMLContentElement.json
@@ -59,7 +59,7 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
@@ -122,7 +122,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -186,7 +186,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/HTMLShadowElement.json
+++ b/api/HTMLShadowElement.json
@@ -21,6 +21,7 @@
           },
           "firefox": {
             "version_added": "28",
+            "version_removed": "58",
             "flags": [
               {
                 "type": "preference",
@@ -31,6 +32,7 @@
           },
           "firefox_android": {
             "version_added": "28",
+            "version_removed": "58",
             "flags": [
               {
                 "type": "preference",
@@ -56,14 +58,14 @@
           }
         },
         "status": {
-          "experimental": true,
-          "standard_track": true,
+          "experimental": false,
+          "standard_track": false,
           "deprecated": true
         }
       },
       "getDistributedNodes": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/getDistributedNodes",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLShadowElement/getDistributedNodes",
           "support": {
             "webview_android": {
               "version_added": "35"
@@ -103,8 +105,8 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
+            "experimental": false,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/html/elements/content.json
+++ b/html/elements/content.json
@@ -22,6 +22,7 @@
             },
             "firefox": {
               "version_added": "33",
+              "version_removed": "59",
               "flags": [
                 {
                   "type": "preference",
@@ -32,6 +33,7 @@
             },
             "firefox_android": {
               "version_added": "33",
+              "version_removed": "59",
               "flags": [
                 {
                   "type": "preference",

--- a/html/elements/shadow.json
+++ b/html/elements/shadow.json
@@ -22,6 +22,7 @@
             },
             "firefox": {
               "version_added": "33",
+              "version_removed": "59",
               "flags": [
                 {
                   "type": "preference",
@@ -32,6 +33,7 @@
             },
             "firefox_android": {
               "version_added": "33",
+              "version_removed": "58",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
All legacy Shadow DOM v0 element code was removed from Firefox in versions 58 and 59.

### Relevant bugs:
- [bug 1396584](https://bugzil.la/1396584 "1396584 - Remove support for multiple ShadowRoots")
- [bug 1418002](https://bugzil.la/1418002 "1418002 - Remove HTMLContentElement")

---

Also, as per #1305, the `experimental` status flags were updated.