### PR TITLE
update set-cookie info for Edge and IE

### DIFF
--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -62,7 +62,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -158,10 +158,10 @@
                 "version_added": "49"
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
                 "version_added": "50"
@@ -170,7 +170,7 @@
                 "version_added": "50"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "36"


### PR DESCRIPTION
fixes #36

The original reporter was not correct. `max-age` is supported. Some of the esoteric edge cases are broken as shown in the cookie test suite, but the normal use case has been functional since IE 8.

They were correct that cookie prefixes are not supported, however.