### PR TITLE
Bug 1438139 – JavaScript Modules are shipping in Firefox 60

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -306,26 +306,38 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true,
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.moduleScripts.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "firefox_android": {
-                "version_added": true,
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.moduleScripts.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "60"
+                },
+                {
+                  "version_added": true,
+                  "version_removed": "60",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.moduleScripts.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "60"
+                },
+                {
+                  "version_added": true,
+                  "version_removed": "60",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.moduleScripts.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -507,26 +519,38 @@
                 "edge_mobile": {
                   "version_added": "16"
                 },
-                "firefox": {
-                  "version_added": true,
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.moduleScripts.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                "firefox_android": {
-                  "version_added": true,
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.moduleScripts.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
+                "firefox": [
+                  {
+                    "version_added": "60"
+                  },
+                  {
+                    "version_added": true,
+                    "version_removed": "60",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "dom.moduleScripts.enabled",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
+                "firefox_android": [
+                  {
+                    "version_added": "60"
+                  },
+                  {
+                    "version_added": true,
+                    "version_removed": "60",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "dom.moduleScripts.enabled",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
                 "ie": {
                   "version_added": false
                 },

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -311,7 +311,7 @@
                   "version_added": "60"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "55",
                   "version_removed": "60",
                   "flags": [
                     {
@@ -327,7 +327,7 @@
                   "version_added": "60"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "55",
                   "version_removed": "60",
                   "flags": [
                     {
@@ -524,7 +524,7 @@
                     "version_added": "60"
                   },
                   {
-                    "version_added": true,
+                    "version_added": "54",
                     "version_removed": "60",
                     "flags": [
                       {
@@ -540,7 +540,7 @@
                     "version_added": "60"
                   },
                   {
-                    "version_added": true,
+                    "version_added": "54",
                     "version_removed": "60",
                     "flags": [
                       {

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -607,24 +607,36 @@
               "edge_mobile": {
                 "version_added": true
               },
-              "firefox": {
-                "version_added": "54",
-                "flags": [
-                  {
-                    "name": "dom.moduleScripts.enabled",
-                    "type": "preference"
-                  }
-                ]
-              },
-              "firefox_android": {
-                "version_added": "54",
-                "flags": [
-                  {
-                    "name": "dom.moduleScripts.enabled",
-                    "type": "preference"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "60"
+                },
+                {
+                  "version_added": "54",
+                  "version_removed": "60",
+                  "flags": [
+                    {
+                      "name": "dom.moduleScripts.enabled",
+                      "type": "preference"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "60"
+                },
+                {
+                  "version_added": "54",
+                  "version_removed": "60",
+                  "flags": [
+                    {
+                      "name": "dom.moduleScripts.enabled",
+                      "type": "preference"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -786,24 +798,36 @@
             "edge_mobile": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "54",
-              "flags": [
-                {
-                  "name": "dom.moduleScripts.enabled",
-                  "type": "preference"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "54",
-              "flags": [
-                {
-                  "name": "dom.moduleScripts.enabled",
-                  "type": "preference"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "60"
+              },
+              {
+                "version_added": "54",
+                "version_removed": "60",
+                "flags": [
+                  {
+                    "name": "dom.moduleScripts.enabled",
+                    "type": "preference"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "60"
+              },
+              {
+                "version_added": "54",
+                "version_removed": "60",
+                "flags": [
+                  {
+                    "name": "dom.moduleScripts.enabled",
+                    "type": "preference"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -1532,24 +1556,36 @@
             "edge_mobile": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "54",
-              "flags": [
-                {
-                  "name": "dom.moduleScripts.enabled",
-                  "type": "preference"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "54",
-              "flags": [
-                {
-                  "name": "dom.moduleScripts.enabled",
-                  "type": "preference"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "60"
+              },
+              {
+                "version_added": "54",
+                "version_removed": "60",
+                "flags": [
+                  {
+                    "name": "dom.moduleScripts.enabled",
+                    "type": "preference"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "60"
+              },
+              {
+                "version_added": "54",
+                "version_removed": "60",
+                "flags": [
+                  {
+                    "name": "dom.moduleScripts.enabled",
+                    "type": "preference"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
See [bug 1438139](https://bugzil.la/1438139 "RESOLVED FIXED - Enable JS modules by default for all builds") on Bugzilla for more info.