### PR TITLE
Make downloads permission optional

### DIFF
--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -85,6 +85,27 @@
             }
           }
         },
+        "downloads": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "version_added": "60"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "cookies": {
           "__compat": {
             "support": {


### PR DESCRIPTION
In Firefox 60, the `downloads` permission was added to [`optional_permissions`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/optional_permissions): https://bugzilla.mozilla.org/show_bug.cgi?id=1420778.