### PR TITLE
Fix tabs.queryInfo.highlighted

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -2292,10 +2292,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "45"
+                    "version_added": "60"
                   },
                   "firefox_android": {
-                    "version_added": "54"
+                    "version_added": "60"
                   },
                   "opera": {
                     "version_added": true


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1438666#c12. Firefox 60 fixed a bug in which querying for highlighted tabs didn't work, and this PR fixes the compat data, which claimed that it worked before 60.