### PR TITLE
Added note about tabs.executeScript

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1201,7 +1201,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "notes": [
+                  "Extensions can't inject scripts into their own pages using this API."
+                ]
               },
               "edge": {
                 "version_added": true
@@ -1216,7 +1219,10 @@
                 "version_added": "54"
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "notes": [
+                  "Extensions can't inject scripts into their own pages using this API."
+                ]
               }
             }
           },


### PR DESCRIPTION
-> https://bugzilla.mozilla.org/show_bug.cgi?id=1439012

In Firefox (but not Chrome) extensions can use [`tabs.executeScript`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/executeScript) to inject code into their own pages.