### PR TITLE
Added data for dns namespace

### DIFF
--- a/webextensions/api/dns.json
+++ b/webextensions/api/dns.json
@@ -1,0 +1,30 @@
+{
+  "webextensions": {
+    "api": {
+      "dns": {
+        "resolve": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/dns/resolve",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "version_added": "60"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -311,6 +311,28 @@
             }
           }
         },
+        "dns": {
+          "__compat": {
+            "description": "<code>dns</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "version_added": "60"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "downloads": {
           "__compat": {
             "description": "<code>downloads</code>",


### PR DESCRIPTION
`dns` is a new Firefox-only API added in Firefox 60:

https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/dns
https://bugzilla.mozilla.org/show_bug.cgi?id=1373640

It's protected with a permission, so I've also updated the data for the [`permissions`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/permissions) key.