### PR TITLE
Correct removed `-moz-` prefixed CSS properties support information

### DIFF
--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -30,28 +30,25 @@
             },
             "firefox": [
               {
+                "version_added": "4"
+              },
+              {
                 "prefix": "-moz-",
-                "version_added": "3.6"
+                "version_added": "3.6",
+                "version_removed": "4"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "version_added": "4"
               }
             ],
             "firefox_android": [
               {
-                "prefix": "-moz-",
                 "version_added": "4"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "version_added": "4"
               }
             ],
             "ie": {

--- a/css/properties/outline-color.json
+++ b/css/properties/outline-color.json
@@ -27,7 +27,7 @@
               {
                 "prefix": "-moz-",
                 "version_added": "1",
-                "version_removed": true
+                "version_removed": "3.6"
               }
             ],
             "firefox_android": {

--- a/css/properties/outline-style.json
+++ b/css/properties/outline-style.json
@@ -27,7 +27,7 @@
               {
                 "prefix": "-moz-",
                 "version_added": "1",
-                "version_removed": true
+                "version_removed": "3.6"
               }
             ],
             "firefox_android": {

--- a/css/properties/outline-width.json
+++ b/css/properties/outline-width.json
@@ -27,7 +27,7 @@
               {
                 "prefix": "-moz-",
                 "version_added": "1",
-                "version_removed": true
+                "version_removed": "3.6"
               }
             ],
             "firefox_android": {

--- a/css/properties/outline.json
+++ b/css/properties/outline.json
@@ -28,7 +28,7 @@
               {
                 "prefix": "-moz-",
                 "version_added": "1",
-                "version_removed": true
+                "version_removed": "3.6"
               }
             ],
             "firefox_android": {

--- a/css/properties/resize.json
+++ b/css/properties/resize.json
@@ -20,10 +20,16 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "prefix": "-moz-",
-              "version_added": "4"
-            },
+            "firefox": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4",
+                "version_removed": true
+              }
+            ],
             "firefox_android": {
               "version_added": null
             },

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -121,7 +121,8 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "1"
+                  "version_added": "1",
+                  "version_removed": "3.6"
                 }
               ],
               "firefox_android": {


### PR DESCRIPTION
I was able to find the versions when many features were unprefixed in old bugs, but I was unable to find which version unprefixed `resize`, only that the prefixed version is no longer supported in Firefox by testing it myself.

### Relevant bugs:
- https://bugzil.la/433065
- https://bugzil.la/458588
- https://bugzil.la/549809