### PR TITLE
add in HTTP TRACE method data to BCD

### DIFF
--- a/http/methods.json
+++ b/http/methods.json
@@ -357,6 +357,57 @@
             "deprecated": false
           }
         }
+      },
+      "TRACE": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/TRACE",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
See page created here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/TRACE, created in response to https://bugzilla.mozilla.org/show_bug.cgi?id=1445015.

(this could also do with a review, thanks!)