### PR TITLE
Fix Chrome/Opera versions for RTCPeerConnection.getSenders

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2651,13 +2651,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getSenders",
           "support": {
             "webview_android": {
-              "version_added": "56"
+              "version_added": "64"
             },
             "chrome": {
-              "version_added": "56"
+              "version_added": "64"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "64"
             },
             "edge": {
               "version_added": true
@@ -2674,26 +2674,12 @@
             "ie": {
               "version_added": null
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "51"
+            },
+            "opera_android": {
+              "version_added": "51"
+            },
             "safari": {
               "version_added": null
             },


### PR DESCRIPTION
Chrome only supports getSenders from version 64 onwards, see:

  https://www.chromestatus.com/feature/5644723490390016

Opera only supports getSenders from version 51 onwards, see:

  https://dev.opera.com/blog/opera-51/

The comment about a "promise-based version" was just plain wrong, there
never was a promise-based getSenders. It looks as though it was copy-pasted
from some other feature.