### PR TITLE
Fix Chrome/Opera versions for RTCPeerConnection.getReceivers

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2527,13 +2527,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getReceivers",
           "support": {
             "webview_android": {
-              "version_added": "56"
+              "version_added": "59"
             },
             "chrome": {
-              "version_added": "56"
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "59"
             },
             "edge": {
               "version_added": true
@@ -2550,26 +2550,12 @@
             "ie": {
               "version_added": null
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "46"
+            },
+            "opera_android": {
+              "version_added": "46"
+            },
             "safari": {
               "version_added": null
             },


### PR DESCRIPTION
Chrome only supports getReceivers from version 59 onwards, see:

  https://www.chromestatus.com/feature/5715393821802496

I can't find any explicit release notes for the Opera version, but Opera 46
is based on Chromium 59, so that's most likely the one:

  https://dev.opera.com/blog/opera-46/