### PR TITLE
Add firefox_android versions in browser versions schema

### DIFF
--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -2,6 +2,41 @@
   "browsers": {
     "firefox_android": {
       "releases": {
+        "1": {
+          "release_date": "2004-11-09",
+          "release_notes": "http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/releases/1.0.html",
+          "status": "retired"
+        },
+        "1.5": {
+          "release_date": "2005-11-29",
+          "release_notes": "https://developer.mozilla.org/Firefox/Releases/1.5",
+          "status": "retired"
+        },
+        "2": {
+          "release_date": "2006-10-24",
+          "release_notes": "https://developer.mozilla.org/Firefox/Releases/2",
+          "status": "retired"
+        },
+        "3": {
+          "release_date": "2008-06-17",
+          "release_notes": "https://developer.mozilla.org/Firefox/Releases/3",
+          "status": "retired"
+        },
+        "3.5": {
+          "release_date": "2009-06-30",
+          "release_notes": "https://developer.mozilla.org/Firefox/Releases/3.5",
+          "status": "retired"
+        },
+        "3.6": {
+          "release_date": "2010-01-21",
+          "release_notes": "https://developer.mozilla.org/Firefox/Releases/3.6",
+          "status": "retired"
+        },
+        "3.6.9": {
+          "release_date": "2010-09-07",
+          "release_notes": "https://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/3.6.9/releasenotes/",
+          "status": "retired"
+        },
         "4": {
           "release_date": "2011-03-29",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/4",
@@ -35,6 +70,21 @@
         "10": {
           "release_date": "2012-01-31",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/10",
+          "status": "retired"
+        },
+        "11": {
+          "release_date": "2012-03-13",
+          "release_notes": "https://developer.mozilla.org/Firefox/Releases/11",
+          "status": "retired"
+        },
+        "12": {
+          "release_date": "2012-04-24",
+          "release_notes": "https://developer.mozilla.org/Firefox/Releases/12",
+          "status": "retired"
+        },
+        "13": {
+          "release_date": "2012-06-05",
+          "release_notes": "https://developer.mozilla.org/Firefox/Releases/13",
           "status": "retired"
         },
         "14": {


### PR DESCRIPTION
I often ran into firefox android versions that are not in the browser versions schema and thus got linter/build errors. Was it done on purpose to omit them? Is there a reason to? If not, please accept my pull request. 
Versions copied from firefox schema.