### PR TITLE
Update SyncManager.json

### DIFF
--- a/api/SyncManager.json
+++ b/api/SyncManager.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SyncManager",
         "support": {
           "webview_android": {
-            "version_added": "61"
+            "version_added": null
           },
           "chrome": {
-            "version_added": "61"
+            "version_added": "49"
           },
           "chrome_android": {
-            "version_added": "61"
+            "version_added": "49"
           },
           "edge": {
-            "version_added": true
+            "version_added": false
           },
           "edge_mobile": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": null
           },
           "opera_android": {
-            "version_added": false
+            "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           }
         },
         "status": {
@@ -52,40 +52,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SyncManager/register",
           "support": {
             "webview_android": {
-              "version_added": "61"
+              "version_added": null
             },
             "chrome": {
-              "version_added": "61"
+              "version_added": "49"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "49"
             },
             "edge": {
-              "version_added": "15"
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -100,40 +100,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SyncManager/getTags",
           "support": {
             "webview_android": {
-              "version_added": "61"
+              "version_added": null
             },
             "chrome": {
-              "version_added": "61"
+              "version_added": "49"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "49"
             },
             "edge": {
-              "version_added": "15"
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
First timer -- excuse any mistakes please!

Primary reference: [caniuse](https://caniuse.com/#feat=background-sync)

A couple of explanations:
- This is introduced in [Chrome 49](https://developers.google.com/web/updates/2015/12/background-sync#the_solution), not Chrome 61
- Not sure when is it rolled out to Android Chrome WebView
- Not sure if Opera supports it. Interestingly MS says [no](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/backgroundsyncapi/)
- Not supported on Edge. [Says MS](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/backgroundsyncapi/) and tested on my Edge 16.