### PR TITLE
Complete information for link's rel="noopener"

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -866,10 +866,10 @@
                   "version_added": "49"
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge_mobile": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "52"
@@ -878,7 +878,7 @@
                   "version_added": "52"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": "36"
@@ -887,10 +887,10 @@
                   "version_added": "32"
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "10.1"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "10.3"
                 }
               },
               "status": {


### PR DESCRIPTION
source: https://caniuse.com/#search=noopener
(click "Show all" to see Safari 10.1)

(fwiw, ticket of the Safari implementation:
https://bugs.webkit.org/show_bug.cgi?id=155166)