### PR TITLE
Add alternative names to `fullscreenElement`

### DIFF
--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -391,19 +391,22 @@
               "version_added": "53"
             },
             "chrome": {
-              "version_added": "53"
+              "version_added": "53",
+              "alternative_name": "webkitFullscreenElement"
             },
             "chrome_android": {
               "version_added": "53"
             },
             "edge": {
-              "version_added": true
+              "version_added": true,
+              "alternative_name": "msFullscreenElement"
             },
             "edge_mobile": {
               "version_added": true
             },
             "firefox": {
               "version_added": true
+              "alternative_name": "mozFullscreenElement"
             },
             "firefox_android": {
               "version_added": true


### PR DESCRIPTION
From the docs at https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/fullscreenElement I would suppose the `fullscreenElement` API would be available in all current browsers and also unprefixed.

Unfortunately that is not the case, as can be seen at https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API under "Prefixing".

I just updated the first API as an example for the browsers that I was able to test. If this is the correct way to update the files I would suggest to update the other APIs as well, as it's not clear from the individual pages which APIs require a prefix.