### PR TITLE
updating macOS support for WebVR interfaces

### DIFF
--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "58",
-              "notes": "macOS support was enabled in Firefox 58."
+              "version_added": "60",
+              "notes": "macOS support was enabled in Firefox 60."
             }
           ],
           "ie": {
@@ -83,8 +83,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -134,8 +134,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -185,8 +185,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -236,8 +236,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -287,8 +287,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -338,8 +338,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -389,8 +389,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -440,8 +440,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -491,8 +491,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -542,8 +542,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -582,8 +582,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -633,8 +633,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -717,8 +717,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -768,8 +768,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -819,8 +819,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -870,8 +870,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -921,8 +921,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -972,8 +972,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -1023,8 +1023,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "58",
-              "notes": "macOS support was enabled in Firefox 58."
+              "version_added": "60",
+              "notes": "macOS support was enabled in Firefox 60."
             }
           ],
           "ie": {
@@ -83,8 +83,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -134,8 +134,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -185,8 +185,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -236,8 +236,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -287,8 +287,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "58",
-              "notes": "macOS support was enabled in Firefox 58."
+              "version_added": "60",
+              "notes": "macOS support was enabled in Firefox 60."
             }
           ],
           "ie": {
@@ -84,8 +84,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -135,8 +135,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -186,8 +186,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "58",
-              "notes": "macOS support was enabled in Firefox 58."
+              "version_added": "60",
+              "notes": "macOS support was enabled in Firefox 60."
             }
           ],
           "ie": {
@@ -83,8 +83,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -123,8 +123,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -163,8 +163,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -214,8 +214,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -298,8 +298,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -382,8 +382,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "58",
-              "notes": "macOS support was enabled in Firefox 58."
+              "version_added": "60",
+              "notes": "macOS support was enabled in Firefox 60."
             }
           ],
           "ie": {
@@ -117,8 +117,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -168,8 +168,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -219,8 +219,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -270,8 +270,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "58",
-              "notes": "macOS support was enabled in Firefox 58."
+              "version_added": "60",
+              "notes": "macOS support was enabled in Firefox 60."
             }
           ],
           "ie": {
@@ -84,8 +84,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -135,8 +135,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -186,8 +186,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -237,8 +237,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -288,8 +288,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -339,8 +339,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -390,8 +390,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {

--- a/api/VRLayerInit.json
+++ b/api/VRLayerInit.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "58",
-              "notes": "macOS support was enabled in Firefox 58."
+              "version_added": "60",
+              "notes": "macOS support was enabled in Firefox 60."
             }
           ],
           "ie": {
@@ -83,8 +83,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -134,8 +134,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -185,8 +185,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "58",
-              "notes": "macOS support was enabled in Firefox 58."
+              "version_added": "60",
+              "notes": "macOS support was enabled in Firefox 60."
             }
           ],
           "ie": {
@@ -83,8 +83,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -134,8 +134,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -248,8 +248,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -302,8 +302,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -353,8 +353,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -404,8 +404,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "58",
-              "notes": "macOS support was enabled in Firefox 58."
+              "version_added": "60",
+              "notes": "macOS support was enabled in Firefox 60."
             }
           ],
           "ie": {
@@ -83,8 +83,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -134,8 +134,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {
@@ -185,8 +185,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "58",
-                "notes": "macOS support was enabled in Firefox 58."
+                "version_added": "60",
+                "notes": "macOS support was enabled in Firefox 60."
               }
             ],
             "ie": {


### PR DESCRIPTION
As detailed on https://bugzilla.mozilla.org/show_bug.cgi?id=1438044, we got this information wrong. It was originally enabled on non-release versions in Firefox 58, then finally enabled on macOS in Firefox 60.