### PR TITLE
Chrome doesn't support HTMLVideoElement.getVideoPlaybackQuality

### DIFF
--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -7,7 +7,7 @@
           "chrome": {
             "version_added": false,
             "notes" : [
-              "Note implemented yet. Feature can be tracked here https://crbug.com/644731"
+              "Not implemented yet. Feature can be tracked here https://crbug.com/644731"
             ]
           },
           "edge": {

--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -6,7 +6,7 @@
         "support": {
           "chrome": {
             "version_added": false,
-            "notes" : [
+            "notes": [
               "Not implemented yet. Feature can be tracked here https://crbug.com/644731"
             ]
           },

--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -5,7 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoPlaybackQuality",
         "support": {
           "chrome": {
-            "version_added": "23"
+            "version_added": false,
+            "notes" : [
+              "Note implemented yet. Feature can be tracked here https://bugs.chromium.org/p/chromium/issues/detail?id=644731&desc=2"
+            ]
           },
           "edge": {
             "version_added": true
@@ -67,7 +70,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoPlaybackQuality/creationTime",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
@@ -130,7 +133,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoPlaybackQuality/droppedVideoFrames",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
@@ -193,7 +196,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoPlaybackQuality/corruptedVideoFrames",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
@@ -256,7 +259,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoPlaybackQuality/totalVideoFrames",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
@@ -319,7 +322,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoPlaybackQuality/totalFrameDelay",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": false
             },
             "edge": {
               "version_added": "12"

--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -7,7 +7,7 @@
           "chrome": {
             "version_added": false,
             "notes" : [
-              "Note implemented yet. Feature can be tracked here https://bugs.chromium.org/p/chromium/issues/detail?id=644731&desc=2"
+              "Note implemented yet. Feature can be tracked here https://crbug.com/644731"
             ]
           },
           "edge": {


### PR DESCRIPTION
Chrome doesn't support HTMLVideoElement.getVideoPlaybackQuality
https://bugs.chromium.org/p/chromium/issues/detail?id=644731&desc=2