### PR TITLE
Firefox does not support transceiver.setCodecPreferences()

### DIFF
--- a/api/RTCRtpTransceiver.json
+++ b/api/RTCRtpTransceiver.json
@@ -355,10 +355,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "59"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "59"
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Per [bug 1396922](https://bugzilla.mozilla.org/show_bug.cgi?id=1396922).