### PR TITLE
Add compat data for EventListener

### DIFF
--- a/api/EventListener.json
+++ b/api/EventListener.json
@@ -1,0 +1,100 @@
+{
+  "api": {
+    "EventListener": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/EventListener",
+        "support": {
+          "webview_android": {
+            "version_added": "1"
+          },
+          "chrome": {
+            "version_added": "1"
+          },
+          "chrome_android": {
+            "version_added": "1"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": {
+            "version_added": "1"
+          },
+          "firefox_android": {
+            "version_added": "4"
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": "7"
+          },
+          "opera_android": {
+            "version_added": "6"
+          },
+          "safari": {
+            "version_added": "1"
+          },
+          "safari_ios": {
+            "version_added": "1"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "handleEvent": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/EventListener/handleEvent",
+          "support": {
+            "webview_android": {
+              "version_added": "1"
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": "6"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Marked the [basic support](https://developer.mozilla.org/docs/Web/API/EventListener) same as its only [method](https://developer.mozilla.org/docs/Web/API/EventListener/handleEvent). Wrong assumption?