### PR TITLE
Correct CacheStorage

### DIFF
--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -219,9 +219,26 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CacheStorage/match",
           "support": {
-            "chrome": {
-              "version_added": "40"
-            },
+            "chrome": [
+              {
+                "version_added": "54"
+              },
+              {
+                "version_added": "40",
+                "partial_implementation": true,
+                "notes": "The options parameter only supports <code>ignoreSearch</code>, and <code>cacheName</code>."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "54"
+              },
+              {
+                "version_added": "40",
+                "partial_implementation": true,
+                "notes": "The options parameter only supports <code>ignoreSearch</code>, and <code>cacheName</code>."
+              }
+            ],
             "edge": {
               "version_added": true
             },
@@ -237,27 +254,45 @@
             "safari": {
               "version_added": false
             },
-            "webview_android": {
-              "version_added": "40"
-            },
             "firefox_android": {
               "version_added": "44"
             },
             "edge_mobile": {
               "version_added": true
             },
-            "opera": {
-              "version_added": "27"
-            },
-            "opera_android": {
-              "version_added": "27"
-            },
+            "opera": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "27",
+                "partial_implementation": true,
+                "notes": "The options parameter only supports <code>ignoreSearch</code>, and <code>cacheName</code>."
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "27",
+                "partial_implementation": true,
+                "notes": "The options parameter only supports <code>ignoreSearch</code>, and <code>cacheName</code>."
+              }
+            ],
             "safari_ios": {
               "version_added": true
             },
-            "chrome_android": {
-              "version_added": "40"
-            }
+            "webview_android": [
+              {
+                "version_added": "54"
+              },
+              {
+                "version_added": "40",
+                "partial_implementation": true,
+                "notes": "The options parameter only supports <code>ignoreSearch</code>, and <code>cacheName</code>."
+              }
+            ]
           },
           "status": {
             "experimental": true,


### PR DESCRIPTION
This PR corrects the [`CacheStorage.match(…)` API](https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/match) support information, see [`CacheStorage.match(…)` revision 1319468](https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/match$revision/1319468) for more information.