### PR TITLE
Update nodejs compat for javascript.function.rest_parameters

### DIFF
--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -856,9 +856,23 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": true
-            },
+            "nodejs": [
+              {
+                "version_added": "6",
+                "notes": "Added in <a href='https://github.com/nodejs/node/pull/4106'>PR #4106</a>."
+              },
+              {
+                "version_added": "4",
+                "version_removed": "6",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--harmony-rest-parameters"
+                  }
+                ],
+                "notes": "Added in <a href='https://github.com/nodejs/node/pull/2022'>PR #2022</a>. Removed in <a href='https://github.com/nodejs/node/pull/4722'>PR #4722</a>"
+              }
+            ],
             "opera": {
               "version_added": "34"
             },

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -858,8 +858,7 @@
             },
             "nodejs": [
               {
-                "version_added": "6",
-                "notes": "Added in <a href='https://github.com/nodejs/node/pull/4106'>PR #4106</a>."
+                "version_added": "6"
               },
               {
                 "version_added": "4",
@@ -869,8 +868,7 @@
                     "type": "runtime_flag",
                     "name": "--harmony-rest-parameters"
                   }
-                ],
-                "notes": "Added in <a href='https://github.com/nodejs/node/pull/2022'>PR #2022</a>. Removed in <a href='https://github.com/nodejs/node/pull/4722'>PR #4722</a>"
+                ]
               }
             ],
             "opera": {


### PR DESCRIPTION
This commit documents Node.js compatibility for function rest
parameters. This mainly depends on V8 but I tracked the relevant Node
versions, commits and PRs.

Note that I used `4` for the version of the flag addition because `3`
corresponds to the io.js fork and is not recognized as a valid `nodejs`
version by the linter.

Flagged support (io.js 3.0.0, V8 4.4):

- [Node.js changelog entry for version 3.0.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_IOJS.md#2015-08-04-version-300-rvagg)
- [Pull Request](https://github.com/nodejs/node/pull/2022)
- [Commit, with anchor to relevant line](https://github.com/nodejs/node/commit/70d1f32f56#diff-b2e04de0d939630d882245c2243e7e47R200)

Stable support (Node.js 6.0.0, V8 4.7):

- [Node.js changelog entry for version 6.0.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V6.md#2016-04-26-version-600-current-jasnell)
- [Pull Request](https://github.com/nodejs/node/pull/4106)
- [Commit, with anchor to relevant line](https://github.com/nodejs/node/commit/8a43a3d7619fde59f0d1f2fad05d8ae7d1732b02#diff-b2e04de0d939630d882245c2243e7e47R217)

Flag removal (Node.js 6.0.0, V8 4.9):
- [Node.js changelog entry for version 6.0.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V6.md#2016-04-26-version-600-current-jasnell)
- [Pull Request](https://github.com/nodejs/node/pull/4722)
- [Commit, with anchor to relevant line](https://github.com/nodejs/node/commit/069e02ab47656b3efd1b6829c65856b2e1c2d1db#diff-b2e04de0d939630d882245c2243e7e47L221)