### PR TITLE
Add -webkit-meter-* selectors

### DIFF
--- a/css/selectors/-webkit-meter-bar.json
+++ b/css/selectors/-webkit-meter-bar.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "-webkit-meter-bar": {
+        "__compat": {
+          "description": "<code>::-webkit-meter-bar</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-meter-bar",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/-webkit-meter-even-less-good-value.json
+++ b/css/selectors/-webkit-meter-even-less-good-value.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "-webkit-meter-even-less-good-value": {
+        "__compat": {
+          "description": "<code>::-webkit-meter-even-less-good-value</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-meter-even-less-good-value",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/-webkit-meter-inner-element.json
+++ b/css/selectors/-webkit-meter-inner-element.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "-webkit-meter-inner-element": {
+        "__compat": {
+          "description": "<code>::-webkit-meter-inner-element</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-meter-inner-element",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/-webkit-meter-optimum-value.json
+++ b/css/selectors/-webkit-meter-optimum-value.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "-webkit-meter-optimum-value": {
+        "__compat": {
+          "description": "<code>::-webkit-meter-optimum-value</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-meter-optimum-value",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/-webkit-meter-suboptimum-value.json
+++ b/css/selectors/-webkit-meter-suboptimum-value.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "-webkit-meter-suboptimum-value": {
+        "__compat": {
+          "description": "<code>::-webkit-meter-suboptimum-value</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-meter-suboptimum-value",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add JSON files for [::-webkit-meter-bar](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-meter-bar), [::-webkit-meter-inner-element](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-meter-inner-element), [::-webkit-meter-even-less-good-value](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-meter-even-less-good-value), [::-webkit-meter-suboptimum-value](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-meter-suboptimum-value), and [::-webkit-meter-optimum-value](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-meter-optimum-value).

The [spreadsheet](https://docs.google.com/spreadsheets/d/1ivgyPBr9Lj3Wvj5kyndT1rgGbX-pGggrxuMtrgcOmjM/edit#gid=680932322) doesn't seem to list all five of these, it's missing `::-webkit-meter-optimum-value` and `::-webkit-meter-suboptimum-value`.