### PR TITLE
Add ::-webkit-search-cancel-button and ::-webkit-search-results-button selectors

### DIFF
--- a/css/selectors/-webkit-search-cancel-button.json
+++ b/css/selectors/-webkit-search-cancel-button.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "-webkit-search-cancel-button": {
+        "__compat": {
+          "description": "<code>::-webkit-search-cancel-button</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-search-cancel-button",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/-webkit-search-results-button.json
+++ b/css/selectors/-webkit-search-results-button.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "-webkit-search-results-button": {
+        "__compat": {
+          "description": "<code>::-webkit-search-results-button</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-search-results-button",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add [::-webkit-search-cancel-button](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-search-cancel-button) and [::-webkit-search-results-button](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-search-results-button) selectors.

Some of these are null because that's how it was set on the MDN page and I don't want to make any assumptions (e.g. presumably Chrome for Android supports it, but I don't have an Android phone to test that with).