### PR TITLE
Safari iOS added <meter> support in version 10.3

### DIFF
--- a/html/elements/meter.json
+++ b/html/elements/meter.json
@@ -39,7 +39,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             }
           },
           "status": {


### PR DESCRIPTION
Bug: https://bugs.webkit.org/show_bug.cgi?id=161714