### PR TITLE
CSS :host and :host(…) have been implemented in Firefox Nightly 61

### DIFF
--- a/css/selectors/host.json
+++ b/css/selectors/host.json
@@ -16,16 +16,40 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "61",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": [
+                "See <a href='https://bugzil.la/1205323'>bug 1205323</a>",
+                "See <a href='https://bugzil.la/992245'>bug 992245</a>"
+              ]
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "61",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": [
+                "See <a href='https://bugzil.la/1205323'>bug 1205323</a>",
+                "See <a href='https://bugzil.la/992245'>bug 992245</a>"
+              ]
             },
             "ie": {
               "version_added": false

--- a/css/selectors/host.json
+++ b/css/selectors/host.json
@@ -32,10 +32,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": [
-                "See <a href='https://bugzil.la/1205323'>bug 1205323</a>",
-                "See <a href='https://bugzil.la/992245'>bug 992245</a>"
-              ]
+              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
             },
             "firefox_android": {
               "version_added": "61",
@@ -46,10 +43,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": [
-                "See <a href='https://bugzil.la/1205323'>bug 1205323</a>",
-                "See <a href='https://bugzil.la/992245'>bug 992245</a>"
-              ]
+              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
             },
             "ie": {
               "version_added": false

--- a/css/selectors/hostfunction.json
+++ b/css/selectors/hostfunction.json
@@ -16,16 +16,40 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": false,
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "61",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": [
+                "See <a href='https://bugzil.la/1205323'>bug 1205323</a>",
+                "See <a href='https://bugzil.la/1452640'>bug 1452640</a>"
+              ]
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "61",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": [
+                "See <a href='https://bugzil.la/1205323'>bug 1205323</a>",
+                "See <a href='https://bugzil.la/1452640'>bug 1452640</a>"
+              ]
             },
             "ie": {
               "version_added": false

--- a/css/selectors/hostfunction.json
+++ b/css/selectors/hostfunction.json
@@ -32,10 +32,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": [
-                "See <a href='https://bugzil.la/1205323'>bug 1205323</a>",
-                "See <a href='https://bugzil.la/1452640'>bug 1452640</a>"
-              ]
+              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
             },
             "firefox_android": {
               "version_added": "61",
@@ -46,10 +43,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": [
-                "See <a href='https://bugzil.la/1205323'>bug 1205323</a>",
-                "See <a href='https://bugzil.la/1452640'>bug 1452640</a>"
-              ]
+              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
The :host‑context(…) selector is taking longer, as it’s somewhat difficult to implement in an efficient manner (see [bug 1082060](https://bugzil.la/1082060 "1082060 - [WebComponents] Implement shadow-dom :host-context() CSS selector")).

### External links:
- [Bug 1452640](https://bugzil.la/1452640 "1452640 - Implement functional :host(..) selector.") – Implement functional :host(..) selector.
- [Bug 992245](https://bugzil.la/992245 "992245 - [WebComponents] Implement :host pseudo class") – [WebComponents] Implement :host pseudo class