### PR TITLE
Downloads open

### DIFF
--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -242,6 +242,28 @@
             }
           }
         },
+        "downloads_open": {
+          "__compat": {
+            "description": "<code>downloads.open</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "version_added": "60"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "geolocation": {
           "__compat": {
             "description": "<code>geolocation</code>",

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -22,6 +22,48 @@
             }
           }
         },
+        "activeTab": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "background": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
         "bookmarks": {
           "__compat": {
             "support": {
@@ -85,23 +127,44 @@
             }
           }
         },
-        "downloads": {
+        "contentSettings": {
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": true
               },
               "edge": {
                 "version_added": false
               },
               "firefox": {
-                "version_added": "60"
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": "60"
+                "version_added": false
               },
               "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "contextMenus": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
                 "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
               }
             }
           }
@@ -123,6 +186,69 @@
               },
               "opera": {
                 "version_added": true
+              }
+            }
+          }
+        },
+        "debugger": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "downloads": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "version_added": "60"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "geolocation": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": false
               }
             }
           }
@@ -169,6 +295,27 @@
             }
           }
         },
+        "management": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
         "notifications": {
           "__compat": {
             "support": {
@@ -183,6 +330,27 @@
               },
               "firefox_android": {
                 "version_added": "55"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "pageCapture": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
               },
               "opera": {
                 "version_added": true
@@ -291,174 +459,6 @@
               },
               "opera": {
                 "version_added": true
-              }
-            }
-          }
-        },
-        "background": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        },
-        "contentSettings": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        },
-        "contextMenus": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        },
-        "debugger": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        },
-        "management": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        },
-        "pageCapture": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              }
-            }
-          }
-        },
-        "activeTab": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "55"
-              },
-              "firefox_android": {
-                "version_added": "55"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        },
-        "geolocation": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "55"
-              },
-              "firefox_android": {
-                "version_added": "55"
-              },
-              "opera": {
-                "version_added": false
               }
             }
           }

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -24,6 +24,7 @@
         },
         "activeTab": {
           "__compat": {
+            "description": "<code>activeTab</code>",
             "support": {
               "chrome": {
                 "version_added": false
@@ -45,6 +46,7 @@
         },
         "background": {
           "__compat": {
+            "description": "<code>background</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -66,6 +68,7 @@
         },
         "bookmarks": {
           "__compat": {
+            "description": "<code>bookmarks</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -87,6 +90,7 @@
         },
         "clipboardRead": {
           "__compat": {
+            "description": "<code>clipboardRead</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -108,6 +112,7 @@
         },
         "clipboardWrite": {
           "__compat": {
+            "description": "<code>clipboardWrite</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -129,6 +134,7 @@
         },
         "contentSettings": {
           "__compat": {
+            "description": "<code>contentSettings</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -150,6 +156,7 @@
         },
         "contextMenus": {
           "__compat": {
+            "description": "<code>contextMenus</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -171,6 +178,7 @@
         },
         "cookies": {
           "__compat": {
+            "description": "<code>cookies</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -192,6 +200,7 @@
         },
         "debugger": {
           "__compat": {
+            "description": "<code>debugger</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -213,6 +222,7 @@
         },
         "downloads": {
           "__compat": {
+            "description": "<code>downloads</code>",
             "support": {
               "chrome": {
                 "version_added": false
@@ -234,6 +244,7 @@
         },
         "geolocation": {
           "__compat": {
+            "description": "<code>geolocation</code>",
             "support": {
               "chrome": {
                 "version_added": false
@@ -255,6 +266,7 @@
         },
         "history": {
           "__compat": {
+            "description": "<code>history</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -276,6 +288,7 @@
         },
         "idle": {
           "__compat": {
+            "description": "<code>idle</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -297,6 +310,7 @@
         },
         "management": {
           "__compat": {
+            "description": "<code>management</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -318,6 +332,7 @@
         },
         "notifications": {
           "__compat": {
+            "description": "<code>notifications</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -339,6 +354,7 @@
         },
         "pageCapture": {
           "__compat": {
+            "description": "<code>pageCapture</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -360,6 +376,7 @@
         },
         "tabs": {
           "__compat": {
+            "description": "<code>tabs</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -381,6 +398,7 @@
         },
         "topSites": {
           "__compat": {
+            "description": "<code>topSites</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -402,6 +420,7 @@
         },
         "webNavigation": {
           "__compat": {
+            "description": "<code>webNavigation</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -423,6 +442,7 @@
         },
         "webRequest": {
           "__compat": {
+            "description": "<code>webRequest</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -444,6 +464,7 @@
         },
         "webRequestBlocking": {
           "__compat": {
+            "description": "<code>webRequestBlocking</code>",
             "support": {
               "chrome": {
                 "version_added": true


### PR DESCRIPTION
[Bug 1420778]( https://bugzilla.mozilla.org/show_bug.cgi?id=1420778) enables the `downloads` and `downloads.open` to be optional, so they need to be added to the compat data for the `optional_permissions` key. We added `downloads` before but missed `downloads.open`.

This also means we need to use a description, because "downloads.open" is not a valid identifier. We did this before in https://github.com/mdn/browser-compat-data/pull/928 for the `permissions` key, and added it to all subfeatures, for consistency.

So this PR is in three commits, hopefully to make reviewing simpler:

1. alphabetize `optional_permissions`, but don't make any substantive changes
2. make all the subfeatures use descriptions
3. add `downloads.open`