### PR TITLE
proxy.onRequest added and proxy.onProxyError renamed

### DIFF
--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -2,7 +2,7 @@
   "webextensions": {
     "api": {
       "proxy": {
-        "onProxyError": {
+        "onError": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/proxy/onProxyError",
             "support": {
@@ -12,11 +12,45 @@
               "edge": {
                 "version_added": false
               },
+              "firefox": [
+                {
+                  "version_added": "60"
+                },
+                {
+                  "alternative_name": "onProxyError",
+                  "version_added": "55"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "60"
+                },
+                {
+                  "alternative_name": "onProxyError",
+                  "version_added": "55"
+                }
+              ],
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "onRequest": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/proxy/onRequest",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
               "firefox": {
-                "version_added": "55"
+                "version_added": "60"
               },
               "firefox_android": {
-                "version_added": "55"
+                "version_added": "60"
               },
               "opera": {
                 "version_added": false
@@ -43,9 +77,15 @@
                   "version_added": "55"
                 }
               ],
-              "firefox_android": {
-                "version_added": "55"
-              },
+              "firefox_android": [
+                {
+                  "version_added": "56"
+                },
+                {
+                  "alternative_name": "registerProxyScript",
+                  "version_added": "55"
+                }
+              ],
               "opera": {
                 "version_added": false
               }

--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -4,7 +4,7 @@
       "proxy": {
         "onError": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/proxy/onProxyError",
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/proxy/onError",
             "support": {
               "chrome": {
                 "version_added": false


### PR DESCRIPTION
[Bug 1409878](https://bugzilla.mozilla.org/show_bug.cgi?id=1409878) added a new event, `proxy.onRequest`, and renamed `proxy.onProxyError` to `proxy.onError`:

https://hg.mozilla.org/mozilla-central/diff/9f0ee2f582a2/toolkit/components/extensions/schemas/proxy.json

