### PR TITLE
adding compat data for SVGAnimatedLength

### DIFF
--- a/api/SVGAnimatedLength.json
+++ b/api/SVGAnimatedLength.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "SVGAnimatedLength": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedLength",
+        "support": {
+          "webview_android": {
+            "version_added": false
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": null
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimatedLength

Do the `baseVal ` and `animVal` properties need to be included? They don't have their own page but are of type `SVGLength`, which does.

Thanks in advance for your help!