### PR TITLE
updating compat data for css.selectors.marker

### DIFF
--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -16,10 +16,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
added data for Edge and Edge Mobile.
Tested on Desktop (Win 10 1709): Edge 42.16299.371.0 ; EdgeHTML 16.16299
Tested on Mobile (Win 10 Mobile 1703): Edge 40.15063.138.0 ; EdgeHTML 15.16063