### PR TITLE
Add missing colon to alternative selectors

### DIFF
--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -10,7 +10,7 @@
               "version_added": null
             },
             "chrome": {
-              "alternative_name": "-webkit-full-screen",
+              "alternative_name": ":-webkit-full-screen",
               "version_added": "15"
             },
             "chrome_android": {
@@ -24,7 +24,7 @@
             },
             "firefox": [
               {
-                "alternative_name": "-moz-full-screen",
+                "alternative_name": ":-moz-full-screen",
                 "version_added": "9"
               },
               {
@@ -40,7 +40,7 @@
             ],
             "firefox_android": [
               {
-                "alternative_name": "-moz-full-screen",
+                "alternative_name": ":-moz-full-screen",
                 "version_added": "9"
               },
               {
@@ -65,7 +65,7 @@
               "version_added": false
             },
             "safari": {
-              "alternative_name": "-webkit-full-screen",
+              "alternative_name": ":-webkit-full-screen",
               "version_added": "6"
             },
             "safari_ios": {


### PR DESCRIPTION
Other alternative selectors are prefixed with `:`. It should be consistent.