### PR TITLE
Move basic support note near top

### DIFF
--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -64,6 +64,57 @@
           "deprecated": false
         }
       },
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required (HTTPS)",
+          "support": {
+            "webview_android": {
+              "version_added": "61"
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "PresentationRequest": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationRequest/PresentationRequest",
@@ -437,58 +488,6 @@
             },
             "opera_android": {
               "version_added": "35"
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "secure_context_required": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationRequest",
-          "description": "Secure context required (HTTPS)",
-          "support": {
-            "webview_android": {
-              "version_added": "61"
-            },
-            "chrome": {
-              "version_added": "61"
-            },
-            "chrome_android": {
-              "version_added": "61"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": "48"
-            },
-            "opera_android": {
-              "version_added": "48"
             },
             "safari": {
               "version_added": null


### PR DESCRIPTION
Seeing as notes about an API are usually near the basic support, I found it strange that the "secure context required" note was at the bottom of the list, [see what I mean](https://developer.mozilla.org/docs/Web/API/PresentationRequest). Is this adjustment ok?