### PR TITLE
Add `Element.createShadowRoot(…)`

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -698,6 +698,141 @@
           }
         }
       },
+      "createShadowRoot": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/createShadowRoot",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "35"
+              },
+              {
+                "version_added": "25",
+                "version_removed": true,
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "35"
+              },
+              {
+                "version_added": "25",
+                "version_removed": true,
+                "prefix": "webkit"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "59",
+                "version_removed": "61",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "29",
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "59",
+                "version_removed": "61",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "29",
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "version_removed": true,
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "14",
+                "version_removed": true,
+                "prefix": "webkit"
+              }
+            ],
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": [
+              {
+                "version_added": "5"
+              },
+              {
+                "version_added": "4",
+                "version_removed": true,
+                "prefix": "webkit"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "35"
+              },
+              {
+                "version_added": "25",
+                "version_removed": true,
+                "prefix": "webkit"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getAttribute": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/getAttribute",

--- a/api/Element.json
+++ b/api/Element.json
@@ -828,8 +828,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },

--- a/api/Element.json
+++ b/api/Element.json
@@ -807,10 +807,10 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": "5"
+                "version_added": "5.0"
               },
               {
-                "version_added": "4",
+                "version_added": "4.0",
                 "version_removed": true,
                 "prefix": "webkit"
               }


### PR DESCRIPTION
`Element.createShadowRoot(…)` was the Shadow DOM v0 equivalent of `Element.attachShadow(…)` from Shadow DOM v1, but has somewhat different semantics from its Shadow DOM v1 counterpart.

It was removed in Firefox 61 by [~~bug 1453789~~](https://bugzil.la/1453789 "1453789 - Remove Element.createShadowRoot.").