### PR TITLE
Correct Opera compat for summary and details elements.

### DIFF
--- a/html/elements/details.json
+++ b/html/elements/details.json
@@ -37,7 +37,7 @@
               "version_added": "15"
             },
             "opera_android": {
-              "version_added": "37"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "6"
@@ -88,7 +88,7 @@
                 "version_added": "15"
               },
               "opera_android": {
-                "version_added": "37"
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "6"

--- a/html/elements/details.json
+++ b/html/elements/details.json
@@ -37,7 +37,7 @@
               "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "37"
             },
             "safari": {
               "version_added": "6"
@@ -88,7 +88,7 @@
                 "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "37"
               },
               "safari": {
                 "version_added": "6"

--- a/html/elements/summary.json
+++ b/html/elements/summary.json
@@ -35,7 +35,7 @@
               "version_added": "15"
             },
             "opera_android": {
-              "version_added": "37"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "6"

--- a/html/elements/summary.json
+++ b/html/elements/summary.json
@@ -32,10 +32,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "37"
             },
             "safari": {
               "version_added": "6"


### PR DESCRIPTION

## Opera
Per caniuse and personal testing, Opera has the same support for the `<summary>` element as it does for the `<details>` element.

_Opera 52.0.2871.64 on OSX 10.11.6_
![summary-element-opera-52 0 2871 64](https://user-images.githubusercontent.com/545605/38779298-e707cff4-408b-11e8-969c-085e9b106015.gif)

## Opera Mobile
Support per caniuse claims Opera Mobile has supported the `<details>` and `<summary>` elements since version 37. Through personal testing, I can verify that the elements work at least with version 45, so I'm inclined to trust their claim.

## Links
* [caniuse](https://caniuse.com/#feat=details)
* [MDN `<details>` Examples](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#Examples)
