### PR TITLE
Complete the HTML Application Cache Manifest Compatibility Data

### DIFF
--- a/html/elements/html.json
+++ b/html/elements/html.json
@@ -53,15 +53,13 @@
         },
         "manifest": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Using_the_application_cache",
             "support": {
-              "webview_android": {
-                "version_added": true
-              },
               "chrome": {
-                "version_added": true
+                "version_added": "4"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "edge": {
                 "version_added": true
@@ -69,35 +67,96 @@
               "edge_mobile": {
                 "version_added": true
               },
-              "firefox": {
-                "version_added": "3"
-              },
+              "firefox": [
+                {
+                  "version_added": "3.5"
+                },
+                {
+                  "version_added": "3",
+                  "partial_implementation": true,
+                  "notes": "Versions of Firefox prior to 3.5 ignore the <code>NETWORK</code> and <code>FALLBACK</code> sections of the cache manifest file."
+                }
+              ],
               "firefox_android": {
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "10"
               },
               "opera": {
-                "version_added": true
+                "version_added": "10.6"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
-                "version_added": true
+                "version_added": "4"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "3.2"
               },
               "samsunginternet_android": {
                 "version_added": true
+              },
+              "webview_android": {
+                "version_added": "4"
               }
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": true
+            }
+          },
+          "secure_context_required": {
+            "__compat": {
+              "description": "Secure context required (HTTPS)",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": true
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": true
+              }
             }
           }
         },


### PR DESCRIPTION
This completes the HTML application cache manifest compatibility data using information from [the MDN article on the application cache](https://developer.mozilla.org/en-US/docs/Web/HTML/Using_the_application_cache#Browser_compatibility).

## External links:
- https://developer.mozilla.org/en-US/docs/Web/HTML/Using_the_application_cache#Browser_compatibility