### PR TITLE
Disallow additional properties in release_statement

### DIFF
--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -49,7 +49,8 @@
           "enum": ["retired", "current", "limited", "beta", "nightly", "esr", "planned"]
         }
       },
-      "required": ["status"]
+      "required": ["status"],
+      "additionalProperties": false
     }
 
   },


### PR DESCRIPTION
There was indeed an error in one browser file! See the failing build against the erroneous data before PR  https://github.com/mdn/browser-compat-data/pull/1788: https://travis-ci.org/mdn/browser-compat-data/builds/367328372

Fixes #1789