### PR TITLE
[Bug 1454316] | Fix IE compatibility version for overrideMimeType

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1245,7 +1245,7 @@
             },
             "ie": [
               {
-                "version_added": "7"
+                "version_added": "11"
               },
               {
                 "notes": "Implemented via <code>ActiveXObject</code>",


### PR DESCRIPTION
Hello, 
As discussed here : https://bugzilla.mozilla.org/show_bug.cgi?id=1454316, I've fixed IE version for XMLHttpRequest.overrideMimeType . 
Thanks . 