### PR TITLE
Correct ::-moz-placeholder version information

### DIFF
--- a/css/selectors/placeholder.json
+++ b/css/selectors/placeholder.json
@@ -47,16 +47,16 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "19"
               }
             ],
             "firefox_android": [
               {
-                "version_added": "52"
+                "version_added": "51"
               },
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "19"
               }
             ],
             "ie": {


### PR DESCRIPTION
## External links:
- [~~bug 1069012~~](https://bugzil.la/1069012 "RESOLVED FIXED - unprefix :placeholder-shown pseudo-class and ::placeholder pseudo-element")
- [bug 1300896](https://bugzil.la/1300896 "NEW - Remove prefixed ::-moz-placeholder pseudo-element and pseudo-class.")