### PR TITLE
WIP: Implement feature imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ var fs = require('fs'),
     path = require('path'),
     extend = require('extend');
 
+const resolveImports = require('./process-imports').resolveImports;
+
 function load() {
   // Recursively load one or more directories passed as arguments.
   var dir, result = {};
@@ -30,7 +32,7 @@ function load() {
   return result;
 }
 
-module.exports = load(
+module.exports = resolveImports(load(
   'api',
   'browsers',
   'css',
@@ -41,4 +43,4 @@ module.exports = load(
   'svg',
   'webdriver',
   'webextensions'
-);
+));

--- a/process-imports.js
+++ b/process-imports.js
@@ -1,0 +1,71 @@
+const extend = require('extend');
+
+function processImports(feature, data, stack) {
+  const imports = feature.__import;
+
+  for (const ref in imports) {
+    const import_ = imports[ref];
+    let empty = true;
+    for (const override in import_) {
+      if (override === '__as') continue;
+      // If the import overrides something, then we clone the target instead.
+      empty = false;
+      break;
+    }
+    let target = data;
+    let name;
+    for (name of ref.split('.')) {
+      if (name in target && name !== '__compat' && name !== '__import') {
+        target = target[name];
+      } else {
+        throw `Invalid import: "${stack.join('.')}" imports "${ref}", which doesn’t exist.`;
+      }
+    }
+    if ('__as' in import_) {
+      name = import_.__as;
+    }
+    if (!empty) {
+      target = Object.assign({}, target);
+      for (const override in import_) {
+        if (override === '__as') continue;
+        if (override in target) {
+          extend(true, target[override], import_[override]);
+        } else {
+          target[override] = import_[override];
+        }
+      }
+    }
+    feature[name] = target;
+  }
+
+  delete feature.__import;
+}
+
+function resolveImports(data, allData = data, stack = []) {
+  if (stack.length > 100) {
+    throw `Probable stack overflow at: ${stack.join('.')}`;
+  }
+
+  for (const key in data) {
+    if (stack.length === 0 && key === 'browsers') continue;
+    if (key !== '__compat' && key !== '__import') {
+      resolveImports(data[key], allData, [...stack, key]);
+    }
+  }
+
+  if (stack.length > 0 ) {
+    // Process imports after children to lessen issues with cycles,
+    // which are currently allowed unless overrides are also used
+    if ('__import' in data) {
+      processImports(data, allData, stack);
+    }
+  }
+
+  return data;
+}
+
+module.exports = {
+  resolveImports: function (data) {
+    return resolveImports(data);
+  }
+};

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -109,13 +109,37 @@
       "additionalProperties": false
     },
 
-    "identifier": {
+    "import_statement": {
       "type": "object",
       "properties": {
+        "__as": {
+          "type": "string",
+          "pattern": "^(?!__as)(?!__compat)[a-zA-Z_0-9-$@]*$"
+        },
         "__compat": { "$ref": "#/definitions/compat_statement" }
       },
       "patternProperties":{
-        "^(?!__compat)[a-zA-Z_0-9-$@]*$" : { "$ref": "#/definitions/identifier" }
+        "^(?!__as)(?!__compat)[a-zA-Z_0-9-$@]*$" : { "$ref": "#/definitions/identifier" }
+      },
+      "additionalProperties": false
+    },
+
+    "import_block": {
+      "type": "object",
+      "patternProperties":{
+        "^[a-zA-Z_0-9-$@.]*$" : { "$ref": "#/definitions/import_statement" }
+      },
+      "additionalProperties": false
+    },
+
+    "identifier": {
+      "type": "object",
+      "properties": {
+        "__import": { "$ref": "#/definitions/import_block" },
+        "__compat": { "$ref": "#/definitions/compat_statement" }
+      },
+      "patternProperties":{
+        "^(?!__compat)(?!__import)[a-zA-Z_0-9-$@]*$" : { "$ref": "#/definitions/identifier" }
       },
       "additionalProperties": false
     },

--- a/test/sample-data.json
+++ b/test/sample-data.json
@@ -242,6 +242,94 @@
             }
           }
         }
+      },
+      "featureWithImports": {
+        "__compat": {
+          "description": "This sub-feature has imports",
+          "support": {
+            "webview_android": {
+              "version_added": "4",
+              "notes": [
+                "First note",
+                "Second note"
+              ]
+            },
+            "chrome": {
+              "version_added": "1",
+              "notes": [
+                "A note"
+              ],
+              "version_removed": "3"
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "A note but no array"
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": false
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4",
+              "version_removed": true
+            },
+            "firefox_android": {
+              "version_added": "14"
+            },
+            "ie": {
+              "version_added": "9",
+              "version_removed": null
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "3",
+              "notes": "The same note twice should only be displayed once and have one anchor number"
+            },
+            "safari_ios": {
+              "version_added": true,
+              "notes": "The same note twice should only be displayed once and have one anchor number"
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "__import": {
+          "sample.api.onlyBasicSupport": {},
+          "sample.api.featureWithSubfeatures.chocoCookie": {
+            "__as": "superChocoCookie"
+          }
+        },
+        "recursiveImport": {
+          "__import": {
+            "sample.api.featureWithImports.recursiveImport": {}
+          }
+        },
+        "cyclicalImport": {
+          "a": {
+            "__import": {
+              "sample.api.featureWithImports.cyclicalImport.b": {}
+            }
+          },
+          "b": {
+            "__import": {
+              "sample.api.featureWithImports.cyclicalImport.a": {}
+            }
+          }
+        }
       }
     }
   }

--- a/test/test-imports.js
+++ b/test/test-imports.js
@@ -1,0 +1,50 @@
+const fs = require('fs'),
+      path = require('path'),
+      extend = require('extend'),
+      {resolveImports} = require('../process-imports');
+
+// TODO: Consider extracting this function into a separate file too.
+function load(...directories) {
+  // Recursively load one or more directories passed as arguments.
+  var dir, result = {};
+
+  function processFilename(fn) {
+    let fp = path.join(dir, fn);
+    let extra;
+
+    // If the given filename is a directory, recursively load it.
+    if (fs.statSync(fp).isDirectory()) {
+      extra = load(fp);
+    } else if (path.extname(fp) === '.json') {
+      extra = require(fp);
+    }
+
+    // The JSON data is independent of the actual file
+    // hierarchy, so it is essential to extend "deeply".
+    result = extend(true, result, extra);
+  }
+
+  for (dir of directories) {
+    dir = path.resolve(__dirname, '..', dir);
+    if (fs.statSync(dir).isDirectory()) {
+      fs.readdirSync(dir).forEach(processFilename);
+    } else {
+      processFilename('');
+    }
+  }
+
+  return result;
+}
+
+function testImports(...files) {
+  const data = load(...files);
+  try {
+    resolveImports(data);
+  } catch (e) {
+    console.error(e);
+    return true;
+  }
+  return false;
+}
+
+module.exports.testImports = testImports;


### PR DESCRIPTION
Fixes #813
Closes #1681

This works by having an extra `__import` block, which contains the features you wish to import and the optional `__as` key, which is used to rename the imported feature and optional entries which override the imported data.

Cycles and infinite recursion are currently allowed if imported data isn’t overriden. They might also work if imported data is overriden depending on how [the `extend` package](https://www.npmjs.com/package/extend) deals with cycles and infinite recursion.

```json5
"__import": {
  "<ref_to_import>": {
    // Override stuff here when necessary.
  }
}
```

## To do:
- [x] Implement global tests
- [ ] Implement per-file tests
- [ ] Update documentation
