### PR TITLE
Add notes for page and browser actions

### DIFF
--- a/webextensions/manifest/browser_action.json
+++ b/webextensions/manifest/browser_action.json
@@ -6,7 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": true,
+              "notes": [
+                "If an extension defines a browser action, it is not allowed to define a page action as well."
+              ]
             },
             "edge": {
               "version_added": "14"
@@ -18,7 +21,10 @@
               "version_added": "55"
             },
             "opera": {
-              "version_added": true
+              "version_added": true,
+              "notes": [
+                "If an extension defines a browser action, it is not allowed to define a page action as well."
+              ]
             }
           }
         },
@@ -87,7 +93,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "notes": [
+                  "SVG icons are not supported."
+                ]
               }
             }
           }

--- a/webextensions/manifest/page_action.json
+++ b/webextensions/manifest/page_action.json
@@ -8,7 +8,8 @@
             "chrome": {
               "version_added": true,
               "notes": [
-                "SVG icons are not supported."
+                "SVG icons are not supported.",
+                "If an extension defines a page action, it is not allowed to define a browser action as well."
               ]
             },
             "edge": {
@@ -25,7 +26,11 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": true,
+              "notes": [
+                "SVG icons are not supported.",
+                "If an extension defines a page action, it is not allowed to define a browser action as well."
+              ]
             }
           }
         },


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1415132 - in Chrome and Opera extensions are not allowed to have a page action and a browser action.

I also made the "SVG icons are not supported" note apply for Opera as well as Chrome.