### PR TITLE
Bug 1442385 onremovestream gone in Firefox 60

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1749,10 +1749,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "22",
+              "version_removed": "60"
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "44",
+              "version_removed": "60"
             },
             "ie": {
               "version_added": null
@@ -1788,7 +1790,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": true
           }


### PR DESCRIPTION
Noted that onremovestream in RTCPeerConnection is
removed in Firefox 60.