### PR TITLE
nth-child and nth-last-child support data update

### DIFF
--- a/css/selectors/nth-child.json
+++ b/css/selectors/nth-child.json
@@ -91,10 +91,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/selectors/nth-last-child.json
+++ b/css/selectors/nth-last-child.json
@@ -51,6 +51,59 @@
             "standard_track": true,
             "deprecated": false
           }
+        },,
+        "of_syntax": {
+          "__compat": {
+            "description": "<code>of &lt;selector&gt;</code> syntax",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/854148'>bug 854148</a>."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/854148'>bug 854148</a>."
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         },
         "no_parent_required": {
           "__compat": {

--- a/css/selectors/nth-last-child.json
+++ b/css/selectors/nth-last-child.json
@@ -51,7 +51,7 @@
             "standard_track": true,
             "deprecated": false
           }
-        },,
+        },
         "of_syntax": {
           "__compat": {
             "description": "<code>of &lt;selector&gt;</code> syntax",


### PR DESCRIPTION
Both `:nth-child` and `:nth-last-child` pseudo classes support `of <selector>` syntax in Selectors Level 4, and this is supported in Safari since version 9.