### PR TITLE
fix `<legend>` IE compat data

### DIFF
--- a/html/elements/legend.json
+++ b/html/elements/legend.json
@@ -27,7 +27,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": 6
             },
             "ie_mobile": {
               "version_added": false

--- a/html/elements/legend.json
+++ b/html/elements/legend.json
@@ -27,7 +27,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": 6
+              "version_added": "6"
             },
             "ie_mobile": {
               "version_added": false


### PR DESCRIPTION
According to [can I use](https://caniuse.com/#search=legend), `<legend>` has been supported (along with all other HTML4 elements) since IE6.