### PR TITLE
Correct `‑moz‑appearance` and `‑webkit‑appearance`

### DIFF
--- a/css/properties/-moz-appearance.json
+++ b/css/properties/-moz-appearance.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-appearance",
           "support": {
-            "webview_android": {
-              "version_added": false
-            },
             "chrome": {
               "version_added": false
             },
@@ -25,12 +22,15 @@
                 "version_added": "54"
               },
               {
+                "version_added": "1",
                 "partial_implementation": true,
-                "version_added": "1"
+                "notes": "<code>-moz-appearance: none;</code> doesn’t work with &lt;input type=\"checkbox\"&gt; and &lt;input type=\"radio\"&gt;"
               }
             ],
             "firefox_android": {
-              "version_added": true
+              "version_added": "4",
+              "partial_implementation": true,
+              "notes": "<code>-moz-appearance: none;</code> doesn’t work with &lt;input type=\"checkbox\"&gt; and &lt;input type=\"radio\"&gt;"
             },
             "ie": {
               "version_added": false
@@ -41,6 +41,9 @@
             "opera_android": {
               "version_added": false
             },
+            "qq_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
@@ -48,6 +51,15 @@
               "version_added": false
             },
             "samsunginternet_android": {
+              "version_added": false
+            },
+            "uc_android": {
+              "version_added": false
+            },
+            "uc_chinese_android": {
+              "version_added": false
+            },
+            "webview_android": {
               "version_added": false
             }
           },

--- a/css/properties/-webkit-appearance.json
+++ b/css/properties/-webkit-appearance.json
@@ -5,20 +5,17 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-appearance",
           "support": {
-            "webview_android": {
-              "version_added": true
-            },
             "chrome": {
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "1"
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": false
@@ -33,7 +30,7 @@
               "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "3"
@@ -43,12 +40,15 @@
             },
             "samsunginternet_android": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": "1"
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": false,
-            "deprecated": true
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
This corrects the browser compatibility table data for the [`‑moz‑appearance`](https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-appearance#-moz-appearance) and [`‑webkit‑appearance`](https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-appearance#-webkit-appearance) CSS properties.

See also #1827