### PR TITLE
Add `appearance`

### DIFF
--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -36,7 +36,7 @@
               "prefix": "-moz-"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "15",
@@ -59,7 +59,9 @@
               "prefix": "-webkit-"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "4.0",
+              "partial_implementation": true,
+              "prefix": "-webkit-"
             },
             "webview_android": {
               "version_added": "1",
@@ -77,10 +79,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "1"
               },
               "edge": {
                 "version_added": "12"
@@ -104,25 +106,25 @@
                 "notes": "Doesn’t work with &lt;input type=\"checkbox\"&gt; and &lt;input type=\"radio\"&gt;"
               },
               "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "samsunginternet_android": {
                 "version_added": false
               },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": {
+                "version_added": "3"
+              },
+              "samsunginternet_android": {
+                "version_added": "4.0"
+              },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -136,43 +138,43 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -1,0 +1,188 @@
+{
+  "css": {
+    "properties": {
+      "appearance": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/appearance",
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "partial_implementation": true,
+              "prefix": "-webkit-"
+            },
+            "chrome_android": {
+              "version_added": "1",
+              "partial_implementation": true,
+              "prefix": "-webkit-"
+            },
+            "edge": {
+              "version_added": "12",
+              "partial_implementation": true,
+              "prefix": "-webkit-"
+            },
+            "edge_mobile": {
+              "version_added": "12",
+              "partial_implementation": true,
+              "prefix": "-webkit-"
+            },
+            "firefox": {
+              "version_added": "1",
+              "partial_implementation": true,
+              "prefix": "-moz-"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "partial_implementation": true,
+              "prefix": "-moz-"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "partial_implementation": true,
+              "prefix": "-webkit-"
+            },
+            "opera_android": {
+              "version_added": "14",
+              "partial_implementation": true,
+              "prefix": "-webkit-"
+            },
+            "safari": {
+              "version_added": "3",
+              "partial_implementation": true,
+              "prefix": "-webkit-"
+            },
+            "safari_ios": {
+              "version_added": "3",
+              "partial_implementation": true,
+              "prefix": "-webkit-"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "1",
+              "partial_implementation": true,
+              "prefix": "-webkit-"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "none": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": "12"
+              },
+              "firefox": [
+                {
+                  "version_added": "54"
+                },
+                {
+                  "version_added": "1",
+                  "partial_implementation": true,
+                  "notes": "Doesn’t work with &lt;input type=\"checkbox\"&gt; and &lt;input type=\"radio\"&gt;"
+                }
+              ],
+              "firefox_android": {
+                "version_added": "4",
+                "partial_implementation": true,
+                "notes": "Doesn’t work with &lt;input type=\"checkbox\"&gt; and &lt;input type=\"radio\"&gt;"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "auto": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds the browser compatibility table data for the [`appearance` CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-appearance#Specifications), which is being specified in the [CSS Basic User Interface Module Level 4](https://drafts.csswg.org/css-ui-4/#appearance-switching).

See also #1826