### PR TITLE
Update Edge support for WebAssembly streaming API

### DIFF
--- a/javascript/builtins/WebAssembly.json
+++ b/javascript/builtins/WebAssembly.json
@@ -1440,7 +1440,7 @@
                 "version_added": "61"
               },
               "edge": {
-                "version_added": false
+                "version_added": "16"
               },
               "edge_mobile": {
                 "version_added": false
@@ -1556,7 +1556,7 @@
                 "version_added": "61"
               },
               "edge": {
-                "version_added": false
+                "version_added": "16"
               },
               "edge_mobile": {
                 "version_added": false


### PR DESCRIPTION
Support for `compileStreaming` and `instantiateStreaming` was added in Chakra in Pull Request https://github.com/Microsoft/ChakraCore/pull/3233 which is part of ChakraCore release 1.6.
That release is included in Windows 1709 (OS Build 16299.371) that corresponds to Edge version 16