### PR TITLE
Bug 1173851 - Rename DataChannel to RTCDataChannel

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -25,7 +25,8 @@
             },
             {
               "alternative_name": "DataChannel",
-              "version_added": "22"
+              "version_added": "22",
+              "version_removed": "60"
             }
           ],
           "firefox_android": [
@@ -34,7 +35,8 @@
             },
             {
               "alternative_name": "DataChannel",
-              "version_added": "22"
+              "version_added": "22",
+              "version_removed": "60"
             }
           ],
           "ie": {


### PR DESCRIPTION
This updates the compat data for RTCDataChannel to
note that support for the name `DataChannel` has
been removed.