### PR TITLE
fix(api.Node.getRootNode): fix IE/Edge compat

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -275,10 +275,10 @@
               "version_added": "54"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "53"
@@ -287,7 +287,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "41"


### PR DESCRIPTION
Explicitly define lack of IE/Edge support for `Node.getRootNode()`

* [Web API Confluence (`Node.getRootNode()`)](https://web-confluence.appspot.com/#!/catalog?releaseKeys=%5B%22Firefox_59.0_Windows_10.0%22,%22Chrome_65.0.3325.146_Windows_10.0%22,%22Edge_16.16299_Windows_10.0%22,%22Safari_11.0.3_OSX_10.13.3%22%5D&releaseOptions=null&numAvailable=null&currentPage=0&gap=5&itemPerPage=15&searchKey=%22getRootNode%22)