### PR TITLE
update compat data for Safari iOS

### DIFF
--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -78,10 +78,10 @@
           "status": "retired"
         },
         "11": {
-          "status": "current"
+          "status": "retired"
         },
         "11.1": {
-          "status": "beta"
+          "status": "current"
         }
       }
     }


### PR DESCRIPTION
Forgot this one yesterday...

Looks like macOs and iOs Safari releases go hand in hand