### PR TITLE
Update `‑webkit‑appearance.json` support to match `appearance.json`

### DIFF
--- a/css/properties/-webkit-appearance.json
+++ b/css/properties/-webkit-appearance.json
@@ -36,10 +36,10 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "1"


### PR DESCRIPTION
Copy `safari_ios` and `samsunginternet_android` version information from [`appearance.json`](https://github.com/mdn/browser-compat-data/blob/master/css/properties/appearance.json) to [`‑webkit‑appearance.json`](https://github.com/mdn/browser-compat-data/blob/master/css/properties/-webkit-appearance.json).

---

I had just made this correction when #1826 was merged.