### PR TITLE
Make `prefix` and `alternative_name` mutually exclusive

### DIFF
--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -237,6 +237,8 @@ In some cases features are named entirely differently and not just prefixed. Exa
 }
 ```
 
+Note that you can’t have both `prefix` and `alternative_name`.
+
 #### `flags`
 An optional array of objects indicating what kind of flags must be set for this feature to work. Usually this array will have one item, but there are cases where two or more flags can be required to activate a feature.
 An object in the `flags` array consists of three properties:

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -40,6 +40,17 @@
         }
       },
       "required": ["version_added"],
+      "anyOf": [
+        {
+          "not": {"required": ["prefix","alternative_name"]}
+        },
+        {
+          "oneOf": [
+            {"required": ["prefix"]},
+            {"required": ["alternative_name"]}
+          ]
+        }
+      ],
       "additionalProperties": false
     },
 


### PR DESCRIPTION
It doesn’t make sense to allow both, and it doesn’t seem *reasonably*[<sup>1</sup>](#user-content-ft-1) used.

<dl><h3>Edit:</h3><dt id="ft-1">Footnote 1</dt><dd>Apparently, <a href="https://developer.mozilla.org/docs/Web/CSS/user-select#Browser_compatibility"><code>user‑select</code></a> uses this for some very odd reason, but in a way that makes no sense, and it seems more like a footgun.</dd></dl>

---

Depends on #1837