### PR TITLE
Correct SyncManager

### DIFF
--- a/api/SyncManager.json
+++ b/api/SyncManager.json
@@ -4,9 +4,6 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SyncManager",
         "support": {
-          "webview_android": {
-            "version_added": null
-          },
           "chrome": {
             "version_added": "49"
           },
@@ -29,10 +26,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
           },
           "opera_android": {
-            "version_added": null
+            "version_added": false
           },
           "safari": {
             "version_added": false
@@ -42,6 +39,9 @@
           },
           "samsunginternet_android": {
             "version_added": false
+          },
+          "webview_android": {
+            "version_added": "49"
           }
         },
         "status": {
@@ -50,13 +50,82 @@
           "deprecated": false
         }
       },
+      "available_on_workers": {
+        "__compat": {
+          "description": "Available on Workers",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "49",
+                "partial_implementation": true,
+                "notes": "Only available in the <code>Window</code> and <code>ServiceWorker</code> global scopes."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "49",
+                "partial_implementation": true,
+                "notes": "Only available in the <code>Window</code> and <code>ServiceWorker</code> global scopes."
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "49",
+                "partial_implementation": true,
+                "notes": "Only available in the <code>Window</code> and <code>ServiceWorker</code> global scopes."
+              }
+            ]
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "register": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SyncManager/register",
           "support": {
-            "webview_android": {
-              "version_added": null
-            },
             "chrome": {
               "version_added": "49"
             },
@@ -79,10 +148,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -92,6 +161,9 @@
             },
             "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "49"
             }
           },
           "status": {
@@ -105,9 +177,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SyncManager/getTags",
           "support": {
-            "webview_android": {
-              "version_added": null
-            },
             "chrome": {
               "version_added": "49"
             },
@@ -143,6 +212,9 @@
             },
             "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "49"
             }
           },
           "status": {


### PR DESCRIPTION
This corrects the browser compatibility data for the [`SyncManager` API](https://developer.mozilla.org/docs/Web/API/SyncManager).

## Sources:
- https://bugzil.la/1217544
- https://www.chromestatus.com/feature/6170807885627392
- https://www.chromestatus.com/feature/5703688089763840

---

Follow-up to #1716