### PR TITLE
Chrome supports filter attribute on SVG

### DIFF
--- a/css/properties/filter.json
+++ b/css/properties/filter.json
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": false
+                "version_added": true
               },
               "chrome_android": {
                 "version_added": false


### PR DESCRIPTION
At least since version 65. I didn't find a source for the earliest version.