### PR TITLE
Add compat data to api.MouseEvent

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -1829,16 +1829,16 @@
         },
         "accel_support": {
           "__compat": {
-            "description": "<code>\"Accel\"</code> support.",
+            "description": "<code>\"Accel\"</code> as a valid parameter.",
             "support": {
               "webview_android": {
-                "version_added": "47"
+                "version_added": false
               },
               "chrome": {
                 "version_added": false
               },
               "chrome_android": {
-                "version_added": "47"
+                "version_added": false
               },
               "edge": {
                 "version_added": null
@@ -1873,8 +1873,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent",
         "support": {
           "webview_android": {
-            "version_added": null
+            "version_added": true
           },
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
-            "version_added": null
+            "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": true
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -50,18 +50,19 @@
           "deprecated": false
         }
       },
-      "altKey": {
+      "MouseEvent": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/altKey",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/MouseEvent",
+          "description": "<code>MouseEvent()</code> constructor",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "edge": {
               "version_added": null
@@ -70,22 +71,183 @@
               "version_added": null
             },
             "firefox": {
+              "version_added": "11"
+            },
+            "firefox_android": {
+              "version_added": "14"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "region_support": {
+          "__compat": {
+            "description": "Support for <code>mouseEventInit</code> optional <code>region</code> field.",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": "51",
+                "notes": "Flag needed to retrieve value from <code>MouseEvent.region</code>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "ExperimentalCanvasFeatures",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "32"
+              },
+              "firefox_android": {
+                "version_added": "32"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "long_to_double": {
+          "__compat": {
+            "description": "Redefined <code>mouseEventInit</code> fields from <code>long</code> to <code>double</code>.",
+            "support": {
+              "webview_android": {
+                "version_added": "56"
+              },
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": "56"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "altKey": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/altKey",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
@@ -109,34 +271,40 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": null
             },
-            "ie": {
-              "version_added": null
-            },
+            "ie": [
+              {
+                "version_added": "9"
+              },
+              {
+                "version_added": true,
+                "notes": "<a href='https://www.quirksmode.org/js/events_properties.html#button'>Different convention</a> used prior to version 9."
+              }
+            ],
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": null
@@ -157,40 +325,41 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/buttons",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Resrictions apply depending on OS."
             },
             "firefox_android": {
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -208,40 +377,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/clientX",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "6"
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -252,6 +421,57 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "long_to_double": {
+          "__compat": {
+            "description": "Value type converted from <code>long</code> to <code>double</code>.",
+            "support": {
+              "webview_android": {
+                "version_added": "56"
+              },
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": "56"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "clientY": {
@@ -259,40 +479,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/clientY",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "6"
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -302,6 +522,57 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "long_to_double": {
+          "__compat": {
+            "description": "Value type converted from <code>long</code> to <code>double</code>.",
+            "support": {
+              "webview_android": {
+                "version_added": "56"
+              },
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": "56"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },
@@ -313,34 +584,34 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
@@ -364,25 +635,104 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
             },
             "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
               "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "movementX": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/movementX",
+          "support": {
+            "webview_android": {
+              "version_added": "37"
+            },
+            "chrome": [
+              {
+                "version_added": "37"
+              },
+              {
+                "version_added": "22",
+                "version_removed": "37",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "37"
+              },
+              {
+                "version_added": true,
+                "version_removed": "37",
+                "prefix": "webkit"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "41",
+                "prefix": "moz"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "4",
+                "version_removed": "41",
+                "prefix": "moz"
+              }
+            ],
+            "ie": {
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -391,10 +741,569 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "movementY": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/movementY",
+          "support": {
+            "webview_android": {
+              "version_added": "37"
+            },
+            "chrome": [
+              {
+                "version_added": "37"
+              },
+              {
+                "version_added": "22",
+                "version_removed": "37",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "37"
+              },
+              {
+                "version_added": true,
+                "version_removed": "37",
+                "prefix": "webkit"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "41",
+                "prefix": "moz"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "4",
+                "version_removed": "41",
+                "prefix": "moz"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "offsetX": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/offsetX",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "43"
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "long_to_double": {
+          "__compat": {
+            "description": "Value type converted from <code>long</code> to <code>double</code>.",
+            "support": {
+              "webview_android": {
+                "version_added": "56"
+              },
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": "56"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "offsetY": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/offsetY",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "43"
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "long_to_double": {
+          "__compat": {
+            "description": "Value type converted from <code>long</code> to <code>double</code>.",
+            "support": {
+              "webview_android": {
+                "version_added": "56"
+              },
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": "56"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "pageX": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/pageX",
+          "support": {
+            "webview_android": {
+              "version_added": "45"
+            },
+            "chrome": {
+              "version_added": "45"
+            },
+            "chrome_android": {
+              "version_added": "45"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "long_to_double": {
+          "__compat": {
+            "description": "Value type converted from <code>long</code> to <code>double</code>.",
+            "support": {
+              "webview_android": {
+                "version_added": "56"
+              },
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": "56"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "pageY": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/pageY",
+          "support": {
+            "webview_android": {
+              "version_added": "45"
+            },
+            "chrome": {
+              "version_added": "45"
+            },
+            "chrome_android": {
+              "version_added": "45"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "long_to_double": {
+          "__compat": {
+            "description": "Value type converted from <code>long</code> to <code>double</code>.",
+            "support": {
+              "webview_android": {
+                "version_added": "56"
+              },
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": "56"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "region": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/region",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "ExperimentalCanvasFeatures",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "30",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "canvas.hitregions.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "30",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "canvas.hitregions.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -415,34 +1324,34 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "48"
             },
             "firefox_android": {
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
@@ -463,40 +1372,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/screenX",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "6"
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -507,6 +1416,57 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "long_to_double": {
+          "__compat": {
+            "description": "Value type converted from <code>long</code> to <code>double</code>.",
+            "support": {
+              "webview_android": {
+                "version_added": "56"
+              },
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": "56"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "screenY": {
@@ -514,40 +1474,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/screenY",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "6"
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -557,6 +1517,57 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "long_to_double": {
+          "__compat": {
+            "description": "Value type converted from <code>long</code> to <code>double</code>.",
+            "support": {
+              "webview_android": {
+                "version_added": "56"
+              },
+              "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
+                "version_added": "56"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },
@@ -568,16 +1579,222 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
               "version_added": null
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "which": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/which",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "On <code>mousemove</code> events, the <code>which</code> property is incorrectly always set to <code>1</code>."
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "notes": "On <code>mousemove</code> events, the <code>which</code> property is incorrectly always set to <code>1</code>."
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "x": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/x",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "y": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/y",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": "6"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getModifierState": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/getModifierState",
+          "support": {
+            "webview_android": {
+              "version_added": "47"
+            },
+            "chrome": {
+              "version_added": "47"
+            },
+            "chrome_android": {
+              "version_added": "47"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
             },
             "firefox": {
               "version_added": null
@@ -609,41 +1826,92 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "accel_support": {
+          "__compat": {
+            "description": "<code>\"Accel\"</code> support.",
+            "support": {
+              "webview_android": {
+                "version_added": "47"
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": "47"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
-      "getModifierState": {
+      "initMouseEvent": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/getModifierState",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/initMouseEvent",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -657,8 +1925,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -103,7 +103,7 @@
         },
         "region_support": {
           "__compat": {
-            "description": "Support for <code>mouseEventInit</code> optional <code>region</code> field.",
+            "description": "Support for <code>mouseEventInit</code> optional <code>region</code> field",
             "support": {
               "webview_android": {
                 "version_added": false
@@ -162,7 +162,7 @@
         },
         "long_to_double": {
           "__compat": {
-            "description": "Redefined <code>mouseEventInit</code> fields from <code>long</code> to <code>double</code>.",
+            "description": "Redefined <code>mouseEventInit</code> fields from <code>long</code> to <code>double</code>",
             "support": {
               "webview_android": {
                 "version_added": "56"
@@ -424,7 +424,7 @@
         },
         "long_to_double": {
           "__compat": {
-            "description": "Value type converted from <code>long</code> to <code>double</code>.",
+            "description": "Value type changed from <code>long</code> to <code>double</code>",
             "support": {
               "webview_android": {
                 "version_added": "56"
@@ -526,7 +526,7 @@
         },
         "long_to_double": {
           "__compat": {
-            "description": "Value type converted from <code>long</code> to <code>double</code>.",
+            "description": "Value type changed from <code>long</code> to <code>double</code>",
             "support": {
               "webview_android": {
                 "version_added": "56"
@@ -624,6 +624,159 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        }
+      },
+      "getModifierState": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/getModifierState",
+          "support": {
+            "webview_android": {
+              "version_added": "47"
+            },
+            "chrome": {
+              "version_added": "47"
+            },
+            "chrome_android": {
+              "version_added": "47"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "accel_support": {
+          "__compat": {
+            "description": "<code>\"Accel\"</code> parameter",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        }
+      },
+      "initMouseEvent": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/initMouseEvent",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -888,7 +1041,7 @@
         },
         "long_to_double": {
           "__compat": {
-            "description": "Value type converted from <code>long</code> to <code>double</code>.",
+            "description": "Value type changed from <code>long</code> to <code>double</code>",
             "support": {
               "webview_android": {
                 "version_added": "56"
@@ -990,7 +1143,7 @@
         },
         "long_to_double": {
           "__compat": {
-            "description": "Value type converted from <code>long</code> to <code>double</code>.",
+            "description": "Value type changed from <code>long</code> to <code>double</code>",
             "support": {
               "webview_android": {
                 "version_added": "56"
@@ -1092,7 +1245,7 @@
         },
         "long_to_double": {
           "__compat": {
-            "description": "Value type converted from <code>long</code> to <code>double</code>.",
+            "description": "Value type changed from <code>long</code> to <code>double</code>",
             "support": {
               "webview_android": {
                 "version_added": "56"
@@ -1194,7 +1347,7 @@
         },
         "long_to_double": {
           "__compat": {
-            "description": "Value type converted from <code>long</code> to <code>double</code>.",
+            "description": "Value type changed from <code>long</code> to <code>double</code>",
             "support": {
               "webview_android": {
                 "version_added": "56"
@@ -1419,7 +1572,7 @@
         },
         "long_to_double": {
           "__compat": {
-            "description": "Value type converted from <code>long</code> to <code>double</code>.",
+            "description": "Value type changed from <code>long</code> to <code>double</code>",
             "support": {
               "webview_android": {
                 "version_added": "56"
@@ -1521,7 +1674,7 @@
         },
         "long_to_double": {
           "__compat": {
-            "description": "Value type converted from <code>long</code> to <code>double</code>.",
+            "description": "Value type changed from <code>long</code> to <code>double</code>",
             "support": {
               "webview_android": {
                 "version_added": "56"
@@ -1774,159 +1927,6 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }
-        }
-      },
-      "getModifierState": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/getModifierState",
-          "support": {
-            "webview_android": {
-              "version_added": "47"
-            },
-            "chrome": {
-              "version_added": "47"
-            },
-            "chrome_android": {
-              "version_added": "47"
-            },
-            "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        },
-        "accel_support": {
-          "__compat": {
-            "description": "<code>\"Accel\"</code> as a valid parameter.",
-            "support": {
-              "webview_android": {
-                "version_added": false
-              },
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
-        }
-      },
-      "initMouseEvent": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/initMouseEvent",
-          "support": {
-            "webview_android": {
-              "version_added": true
-            },
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": true
-            },
-            "firefox_android": {
-              "version_added": true
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
[MouseEvent](https://developer.mozilla.org/docs/Web/API/MouseEvent)
The tables are missing quite a bit of data so I used my best judgement to make what was available somewhat consistent.
One question: how can I add the notes from [`buttons`](https://developer.mozilla.org/docs/Web/API/MouseEvent/buttons#Browser_compatibility) for Firefox? Do I add the huge paragraph in a note?