### PR TITLE
Fill in compat data for api.BaseAudioContext

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -5,40 +5,47 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext",
         "support": {
           "webview_android": {
-            "version_added": null
+            "version_added": true
           },
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
-            "version_added": null
+            "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
-          "opera": {
-            "version_added": null
-          },
+          "opera": [
+            {
+              "version_added": "22"
+            },
+            {
+              "version_added": "15",
+              "prefix": "webkit"
+            }
+          ],
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": "6",
+            "prefix": "webkit"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": null
@@ -95,7 +102,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -106,40 +113,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/currentTime",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -157,40 +172,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/destination",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -208,40 +231,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/listener",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -262,7 +293,7 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": null
+              "version_added": "43"
             },
             "chrome_android": {
               "version_added": null
@@ -274,13 +305,13 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "40"
             },
             "firefox_android": {
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -310,40 +341,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/sampleRate",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -364,7 +403,7 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": null
+              "version_added": "43"
             },
             "chrome_android": {
               "version_added": null
@@ -376,13 +415,13 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "40"
             },
             "firefox_android": {
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -412,40 +451,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createAnalyser",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -463,40 +510,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createBiquadFilter",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -514,40 +569,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createBuffer",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -565,40 +628,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createBufferSource",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -616,40 +687,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createChannelMerger",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -667,40 +746,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createChannelSplitter",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -718,13 +805,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createConstantSource",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "56"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "56"
             },
             "edge": {
               "version_added": null
@@ -733,25 +820,25 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": null
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -762,6 +849,65 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "implemented_on_audio_context": {
+          "__compat": {
+            "description": "Implemented on <code>AudioContext</code>",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "10",
+                "prefix": "webkit"
+              },
+              "chrome_android": {
+                "version_added": "33"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "26"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": [
+                {
+                  "version_added": "22"
+                },
+                {
+                  "version_added": "15",
+                  "prefix": "webkit"
+                }
+              ],
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "6",
+                "prefix": "webkit"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "createConvolver": {
@@ -769,40 +915,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createConvolver",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -820,40 +974,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createDelay",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -871,40 +1033,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createDynamicsCompressor",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -922,40 +1092,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createGain",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -973,25 +1151,25 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createIIRFilter",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "49"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "50"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "50"
             },
             "ie": {
               "version_added": null
@@ -1024,40 +1202,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createOscillator",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1075,40 +1261,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createPanner",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1125,41 +1319,78 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createPeriodicWave",
           "support": {
-            "webview_android": {
-              "version_added": null
-            },
-            "chrome": {
-              "version_added": null
-            },
-            "chrome_android": {
-              "version_added": null
-            },
+            "webview_android": [
+              {
+                "version_added": "59",
+                "notes": "Default values supported"
+              },
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "33",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "59",
+                "notes": "Default values supported"
+              },
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "59",
+                "notes": "Default values supported"
+              },
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "33",
+                "prefix": "webkit"
+              }
+            ],
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1170,6 +1401,57 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "disable_normalisation": {
+          "__compat": {
+            "description": "Possible to disable normalisation",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "createScriptProcessor": {
@@ -1177,40 +1459,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createScriptProcessor",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1228,40 +1518,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createStereoPanner",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "42"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "37"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "37"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1279,40 +1569,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createWaveShaper",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1330,40 +1628,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/decodeAudioData",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "10",
+              "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1374,6 +1680,57 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "promise_syntax": {
+          "__compat": {
+            "description": "Promise-based syntax",
+            "support": {
+              "webview_android": {
+                "version_added": "49"
+              },
+              "chrome": {
+                "version_added": "49"
+              },
+              "chrome_android": {
+                "version_added": "49"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "resume": {
@@ -1381,13 +1738,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/resume",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "41"
             },
             "edge": {
               "version_added": null
@@ -1396,13 +1753,13 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "40"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -108,344 +108,6 @@
           }
         }
       },
-      "currentTime": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/currentTime",
-          "support": {
-            "webview_android": {
-              "version_added": true
-            },
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
-            "chrome_android": {
-              "version_added": "33"
-            },
-            "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": "25"
-            },
-            "firefox_android": {
-              "version_added": "26"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "destination": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/destination",
-          "support": {
-            "webview_android": {
-              "version_added": true
-            },
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
-            "chrome_android": {
-              "version_added": "33"
-            },
-            "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": "25"
-            },
-            "firefox_android": {
-              "version_added": "26"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "listener": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/listener",
-          "support": {
-            "webview_android": {
-              "version_added": true
-            },
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
-            "chrome_android": {
-              "version_added": "33"
-            },
-            "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": "25"
-            },
-            "firefox_android": {
-              "version_added": "26"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onstatechange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/onstatechange",
-          "support": {
-            "webview_android": {
-              "version_added": null
-            },
-            "chrome": {
-              "version_added": "43"
-            },
-            "chrome_android": {
-              "version_added": null
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "40"
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "sampleRate": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/sampleRate",
-          "support": {
-            "webview_android": {
-              "version_added": true
-            },
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
-            "chrome_android": {
-              "version_added": "33"
-            },
-            "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": "25"
-            },
-            "firefox_android": {
-              "version_added": "26"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "state": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/state",
-          "support": {
-            "webview_android": {
-              "version_added": null
-            },
-            "chrome": {
-              "version_added": "43"
-            },
-            "chrome_android": {
-              "version_added": null
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "40"
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "createAnalyser": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createAnalyser",
@@ -1623,6 +1285,65 @@
           }
         }
       },
+      "currentTime": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/currentTime",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "10",
+              "prefix": "webkit"
+            },
+            "chrome_android": {
+              "version_added": "33"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "25"
+            },
+            "firefox_android": {
+              "version_added": "26"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "6",
+              "prefix": "webkit"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "decodeAudioData": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/decodeAudioData",
@@ -1733,6 +1454,175 @@
           }
         }
       },
+      "destination": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/destination",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "10",
+              "prefix": "webkit"
+            },
+            "chrome_android": {
+              "version_added": "33"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "25"
+            },
+            "firefox_android": {
+              "version_added": "26"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "6",
+              "prefix": "webkit"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "listener": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/listener",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "10",
+              "prefix": "webkit"
+            },
+            "chrome_android": {
+              "version_added": "33"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "25"
+            },
+            "firefox_android": {
+              "version_added": "26"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "6",
+              "prefix": "webkit"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onstatechange": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/onstatechange",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "40"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "resume": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/resume",
@@ -1757,6 +1647,116 @@
             },
             "firefox_android": {
               "version_added": true
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sampleRate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/sampleRate",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "10",
+              "prefix": "webkit"
+            },
+            "chrome_android": {
+              "version_added": "33"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "25"
+            },
+            "firefox_android": {
+              "version_added": "26"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "6",
+              "prefix": "webkit"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "state": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/state",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "40"
+            },
+            "firefox_android": {
+              "version_added": null
             },
             "ie": {
               "version_added": false

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -1402,7 +1402,7 @@
             "deprecated": false
           }
         },
-        "disable_normalisation": {
+        "disableNormalisation_supported": {
           "__compat": {
             "description": "Possible to disable normalisation",
             "support": {


### PR DESCRIPTION
[BaseAudioContext](https://developer.mozilla.org/docs/Web/API/BaseAudioContext)
**Question**: in [createPeriodicWave](https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createPeriodicWave#Browser_compatibility) the data about Chrome on android and Webview is more complete. Can we use it to infer about the other sub-features? (I mean to infer that all sub-features and basic support had prefix at v33, then no prefix at v57). 
Also, I forgot to add `baseLatency` and `suspend()`. Will come back to it later.