### PR TITLE
Correct alternatives for `border-radius` longhand properties

### DIFF
--- a/css/properties/border-bottom-left-radius.json
+++ b/css/properties/border-bottom-left-radius.json
@@ -53,7 +53,7 @@
                 ]
               },
               {
-                "alternative_name": "-moz-border-radius-topright",
+                "alternative_name": "-moz-border-radius-bottomleft",
                 "version_added": "1",
                 "version_removed": "12"
               }
@@ -103,7 +103,7 @@
                 },
                 {
                   "version_added": "1",
-                  "notes": "Before Firefox 4, the <a href='https://developer.mozilla.org/docs/Web/CSS/percentage'><code>&lt;percentage&gt;</code></a> was relative to the width of the box even when specifying the radius for a height. This implied that <code>-moz-border-radius-topright</code> was always drawing an arc of circle, and never an ellipse, when followed by a single value."
+                  "notes": "Before Firefox 4, the <a href='https://developer.mozilla.org/docs/Web/CSS/percentage'><code>&lt;percentage&gt;</code></a> was relative to the width of the box even when specifying the radius for a height. This implied that <code>-moz-border-radius-bottomleft</code> was always drawing an arc of circle, and never an ellipse, when followed by a single value."
                 }
               ],
               "firefox_android": {

--- a/css/properties/border-bottom-right-radius.json
+++ b/css/properties/border-bottom-right-radius.json
@@ -53,7 +53,7 @@
                 ]
               },
               {
-                "alternative_name": "-moz-border-radius-topright",
+                "alternative_name": "-moz-border-radius-bottomright",
                 "version_added": "1",
                 "version_removed": "12"
               }
@@ -103,7 +103,7 @@
                 },
                 {
                   "version_added": "1",
-                  "notes": "Before Firefox 4, the <a href='https://developer.mozilla.org/docs/Web/CSS/percentage'><code>&lt;percentage&gt;</code></a> was relative to the width of the box even when specifying the radius for a height. This implied that <code>-moz-border-radius-topright</code> was always drawing an arc of circle, and never an ellipse, when followed by a single value."
+                  "notes": "Before Firefox 4, the <a href='https://developer.mozilla.org/docs/Web/CSS/percentage'><code>&lt;percentage&gt;</code></a> was relative to the width of the box even when specifying the radius for a height. This implied that <code>-moz-border-radius-bottomright</code> was always drawing an arc of circle, and never an ellipse, when followed by a single value."
                 }
               ],
               "firefox_android": {

--- a/css/properties/border-top-left-radius.json
+++ b/css/properties/border-top-left-radius.json
@@ -53,7 +53,7 @@
                 ]
               },
               {
-                "alternative_name": "-moz-border-radius-topright",
+                "alternative_name": "-moz-border-radius-topleft",
                 "version_added": "1",
                 "version_removed": "12"
               }
@@ -103,7 +103,7 @@
                 },
                 {
                   "version_added": "1",
-                  "notes": "Before Firefox 4, the <a href='https://developer.mozilla.org/docs/Web/CSS/percentage'><code>&lt;percentage&gt;</code></a> was relative to the width of the box even when specifying the radius for a height. This implied that <code>-moz-border-radius-topright</code> was always drawing an arc of circle, and never an ellipse, when followed by a single value."
+                  "notes": "Before Firefox 4, the <a href='https://developer.mozilla.org/docs/Web/CSS/percentage'><code>&lt;percentage&gt;</code></a> was relative to the width of the box even when specifying the radius for a height. This implied that <code>-moz-border-radius-topleft</code> was always drawing an arc of circle, and never an ellipse, when followed by a single value."
                 }
               ],
               "firefox_android": {


### PR DESCRIPTION
Seems to be due to some copy pastin' of `border-top-right-radius`.