### PR TITLE
Correct alternatives for `[margin|padding]-inline-[end|start]`

### DIFF
--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "chrome": {
-              "alternative_name": "-webkit-padding-end",
+              "alternative_name": "-webkit-margin-end",
               "version_added": "2"
             },
             "chrome_android": {
@@ -26,7 +26,7 @@
                 "version_added": "41"
               },
               {
-                "alternative_name": "-moz-padding-end",
+                "alternative_name": "-moz-margin-end",
                 "version_added": "3"
               },
               {
@@ -46,7 +46,7 @@
                 "version_added": "41"
               },
               {
-                "alternative_name": "-moz-padding-end",
+                "alternative_name": "-moz-margin-end",
                 "version_added": "4"
               },
               {
@@ -71,7 +71,7 @@
               "version_added": null
             },
             "safari": {
-              "alternative_name": "-webkit-padding-end",
+              "alternative_name": "-webkit-margin-end",
               "version_added": "3"
             },
             "safari_ios": {

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "chrome": {
-              "alternative_name": "-webkit-padding-start",
+              "alternative_name": "-webkit-margin-start",
               "version_added": "2"
             },
             "chrome_android": {
@@ -26,7 +26,7 @@
                 "version_added": "41"
               },
               {
-                "alternative_name": "-moz-padding-start",
+                "alternative_name": "-moz-margin-start",
                 "version_added": "3"
               },
               {
@@ -46,7 +46,7 @@
                 "version_added": "41"
               },
               {
-                "alternative_name": "-moz-padding-start",
+                "alternative_name": "-moz-margin-start",
                 "version_added": "4"
               },
               {
@@ -71,7 +71,7 @@
               "version_added": null
             },
             "safari": {
-              "alternative_name": "-webkit-padding-start",
+              "alternative_name": "-webkit-margin-start",
               "version_added": "3"
             },
             "safari_ios": {

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-inline-start",
           "support": {
             "webview_android": {
-              "alternative_name": "-webkit-padding-end",
+              "alternative_name": "-webkit-padding-start",
               "version_added": true
             },
             "chrome": {
@@ -14,7 +14,7 @@
               "version_added": "2"
             },
             "chrome_android": {
-              "alternative_name": "-webkit-padding-end",
+              "alternative_name": "-webkit-padding-start",
               "version_added": true
             },
             "edge": {
@@ -67,11 +67,11 @@
               "version_added": false
             },
             "opera": {
-              "alternative_name": "-webkit-padding-end",
+              "alternative_name": "-webkit-padding-start",
               "version_added": true
             },
             "opera_android": {
-              "alternative_name": "-webkit-padding-end",
+              "alternative_name": "-webkit-padding-start",
               "version_added": true
             },
             "safari": {
@@ -79,7 +79,7 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "alternative_name": "-webkit-padding-end",
+              "alternative_name": "-webkit-padding-start",
               "version_added": true
             },
             "samsunginternet_android": {


### PR DESCRIPTION
Same thing here as for #1895 I guess.