### PR TITLE
Chrome no longer supports caretPositionFromPoint

### DIFF
--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -310,14 +310,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/caretPositionFromPoint",
           "support": {
             "webview_android": {
-              "version_added": "53"
+              "version_added": false
             },
             "chrome": {
-              "version_added": "53"
-              ,"version_removed": "65"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -335,10 +334,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": "40"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": false
             },
             "safari": {
               "version_added": true
@@ -347,7 +346,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             }
           },
           "status": {

--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -314,6 +314,7 @@
             },
             "chrome": {
               "version_added": "53"
+              ,"version_removed" : "65"
             },
             "chrome_android": {
               "version_added": "53"

--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -314,7 +314,7 @@
             },
             "chrome": {
               "version_added": "53"
-              ,"version_removed" : "65"
+              ,"version_removed": "65"
             },
             "chrome_android": {
               "version_added": "53"


### PR DESCRIPTION
Attempting to run document.caretPositionFromPoint in Chrome 65.0x gives the error "Uncaught TypeError: document.caretPositionFromPoint is not a function"