### PR TITLE
Add compat data for api.TextEncoder

### DIFF
--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextEncoder",
         "support": {
           "webview_android": {
-            "version_added": null
+            "version_added": "38"
           },
           "chrome": {
-            "version_added": null
+            "version_added": "38"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "38"
           },
           "edge": {
             "version_added": null
@@ -19,49 +19,61 @@
           "edge_mobile": {
             "version_added": null
           },
-          "firefox": {
-            "version_added": null
-          },
-          "firefox_android": {
-            "version_added": null
-          },
+          "firefox": [
+            {
+              "version_added": "19"
+            },
+            {
+              "version_added": "18",
+              "notes": "Slightly different version of the spec"
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "19"
+            },
+            {
+              "version_added": "18",
+              "notes": "Slightly different version of the spec"
+            }
+          ],
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "25"
           },
           "opera_android": {
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": null
           }
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
       },
-      "encoding": {
+      "worker_support": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextEncoder/encoding",
+          "description": "Available in Web Workers",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "38"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "38"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "38"
             },
             "edge": {
               "version_added": null
@@ -70,34 +82,290 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "20"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "20"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "25"
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        }
+      },
+      "TextEncoder": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextEncoder/TextEncoder",
+          "description": "<code>TextEncoder()</code> constructor",
+          "support": {
+            "webview_android": {
+              "version_added": "38"
+            },
+            "chrome": [
+              {
+                "version_added": "53"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "53",
+                "notes": "Throws <code>RangeError</code> exception for unknown encoding type"
+              }
+            ],
+            "chrome_android": {
+              "version_added": "38"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "48"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "48",
+                "notes": "Invalid parameter leads to the standard <code>RangeError</code> exception."
+              },
+              {
+                "version_added": "19",
+                "version_removed": "38",
+                "notes": "<code>utf-16</code> not supported. Invalid parameter leads to a <code>TypeError</code> exception."
+              },
+              {
+                "version_added": "18",
+                "notes": "Slightly different version of the spec"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "48"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "48",
+                "notes": "Invalid parameter leads to the standard <code>RangeError</code> exception."
+              },
+              {
+                "version_added": "19",
+                "version_removed": "38",
+                "notes": "<code>utf-16</code> not supported. Invalid parameter leads to a <code>TypeError</code> exception."
+              },
+              {
+                "version_added": "18",
+                "notes": "Slightly different version of the spec"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "25"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "worker_support": {
+          "__compat": {
+            "description": "Available in Web Workers",
+            "support": {
+              "webview_android": {
+                "version_added": "38"
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": "38"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "20"
+              },
+              "firefox_android": {
+                "version_added": "20"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "encoding": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextEncoder/encoding",
+          "support": {
+            "webview_android": {
+              "version_added": "38"
+            },
+            "chrome": {
+              "version_added": "38"
+            },
+            "chrome_android": {
+              "version_added": "38"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "19"
+              },
+              {
+                "version_added": "18",
+                "notes": "Slightly different version of the spec"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "19"
+              },
+              {
+                "version_added": "18",
+                "notes": "Slightly different version of the spec"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "25"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "worker_support": {
+          "__compat": {
+            "description": "Available in Web Workers",
+            "support": {
+              "webview_android": {
+                "version_added": "38"
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": "38"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "20"
+              },
+              "firefox_android": {
+                "version_added": "20"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },
@@ -106,13 +374,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextEncoder/encode",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "38"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "38"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "38"
             },
             "edge": {
               "version_added": null
@@ -120,35 +388,98 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
+            "firefox": [
+              {
+                "version_added": "19"
+              },
+              {
+                "version_added": "18",
+                "notes": "Slightly different version of the spec"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "19"
+              },
+              {
+                "version_added": "18",
+                "notes": "Slightly different version of the spec"
+              }
+            ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "25"
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "worker_support": {
+          "__compat": {
+            "description": "Available in Web Workers",
+            "support": {
+              "webview_android": {
+                "version_added": "38"
+              },
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": "38"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "20"
+              },
+              "firefox_android": {
+                "version_added": "20"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -25,7 +25,7 @@
             },
             {
               "version_added": "18",
-              "notes": "Slightly different version of the spec"
+              "notes": "Firefox 18 implemented an earlier and slightly different version of the specification."
             }
           ],
           "firefox_android": [
@@ -34,7 +34,7 @@
             },
             {
               "version_added": "18",
-              "notes": "Slightly different version of the spec"
+              "notes": "Firefox 18 implemented an earlier and slightly different version of the specification."
             }
           ],
           "ie": {
@@ -124,12 +124,12 @@
             "chrome": [
               {
                 "version_added": "53",
-                "notes": "Does not accept parameters. Supports only <code>uft-8</code> encoding."
+                "notes": "Does not accept parameters. Supports only <code>utf-8</code> encoding."
               },
               {
                 "version_added": "38",
                 "version_removed": "53",
-                "notes": "Throws <code>RangeError</code> exception for unknown encoding type"
+                "notes": "Throws <code>RangeError</code> exception for unknown encoding types."
               }
             ],
             "chrome_android": {
@@ -144,41 +144,41 @@
             "firefox": [
               {
                 "version_added": "48",
-                "notes": "Does not accept parameters. Supports only <code>uft-8</code> encoding."
+                "notes": "The constructor accepts an encoding type label argument, but the value is ignored. Only <code>utf-8</code> encoding is supported."
               },
               {
                 "version_added": "38",
                 "version_removed": "48",
-                "notes": "Invalid parameter leads to the standard <code>RangeError</code> exception."
+                "notes": "If the encoding type label argument is invalid, then a <code>RangeError</code> exception is thrown."
               },
               {
                 "version_added": "19",
                 "version_removed": "38",
-                "notes": "Invalid parameter leads to a <code>TypeError</code> exception."
+                "notes": "If the encoding type label argument is invalid, then a <code>TypeError</code> exception is thrown."
               },
               {
                 "version_added": "18",
-                "notes": "Slightly different version of the spec"
+                "notes": "Firefox 18 implemented an earlier and slightly different version of the specification."
               }
             ],
             "firefox_android": [
               {
                 "version_added": "48",
-                "notes": "Does not accept parameters. Supports only <code>uft-8</code> encoding."
+                "notes": "The constructor accepts an encoding type label argument, but the value is ignored. Only <code>utf-8</code> encoding is supported."
               },
               {
                 "version_added": "38",
                 "version_removed": "48",
-                "notes": "Invalid parameter leads to the standard <code>RangeError</code> exception."
+                "notes": "If the encoding type label argument is invalid, then a <code>RangeError</code> exception is thrown."
               },
               {
                 "version_added": "19",
                 "version_removed": "38",
-                "notes": "Invalid parameter leads to a <code>TypeError</code> exception."
+                "notes": "If the encoding type label argument is invalid, then a <code>TypeError</code> exception is thrown."
               },
               {
                 "version_added": "18",
-                "notes": "Slightly different version of the spec"
+                "notes": "Firefox 18 implemented an earlier and slightly different version of the specification."
               }
             ],
             "ie": {
@@ -204,57 +204,6 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "worker_support": {
-          "__compat": {
-            "description": "Available in Web Workers",
-            "support": {
-              "webview_android": {
-                "version_added": "38"
-              },
-              "chrome": {
-                "version_added": "38"
-              },
-              "chrome_android": {
-                "version_added": "38"
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "20"
-              },
-              "firefox_android": {
-                "version_added": "20"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "25"
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -283,7 +232,7 @@
               },
               {
                 "version_added": "18",
-                "notes": "Slightly different version of the spec"
+                "notes": "Firefox 18 implemented an earlier and slightly different version of the specification."
               }
             ],
             "firefox_android": [
@@ -292,7 +241,7 @@
               },
               {
                 "version_added": "18",
-                "notes": "Slightly different version of the spec"
+                "notes": "Firefox 18 implemented an earlier and slightly different version of the specification."
               }
             ],
             "ie": {
@@ -318,57 +267,6 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "worker_support": {
-          "__compat": {
-            "description": "Available in Web Workers",
-            "support": {
-              "webview_android": {
-                "version_added": "38"
-              },
-              "chrome": {
-                "version_added": "38"
-              },
-              "chrome_android": {
-                "version_added": "38"
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "20"
-              },
-              "firefox_android": {
-                "version_added": "20"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "25"
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -397,7 +295,7 @@
               },
               {
                 "version_added": "18",
-                "notes": "Slightly different version of the spec"
+                "notes": "Firefox 18 implemented an earlier and slightly different version of the specification."
               }
             ],
             "firefox_android": [
@@ -406,7 +304,7 @@
               },
               {
                 "version_added": "18",
-                "notes": "Slightly different version of the spec"
+                "notes": "Firefox 18 implemented an earlier and slightly different version of the specification."
               }
             ],
             "ie": {
@@ -432,57 +330,6 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "worker_support": {
-          "__compat": {
-            "description": "Available in Web Workers",
-            "support": {
-              "webview_android": {
-                "version_added": "38"
-              },
-              "chrome": {
-                "version_added": "38"
-              },
-              "chrome_android": {
-                "version_added": "38"
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "20"
-              },
-              "firefox_android": {
-                "version_added": "20"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "25"
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       }

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -123,7 +123,8 @@
             },
             "chrome": [
               {
-                "version_added": "53"
+                "version_added": "53",
+                "notes": "Does not accept parameters. Supports only <code>uft-8</code> encoding."
               },
               {
                 "version_added": "38",
@@ -142,12 +143,13 @@
             },
             "firefox": [
               {
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "Does not accept parameters. Supports only <code>uft-8</code> encoding."
               },
               {
                 "version_added": "38",
                 "version_removed": "48",
-                "notes": "Invalid parameter leads to the standard <code>RangeError</code> exception."
+                "notes": "<code>utf-16</code> not supported. Invalid parameter leads to the standard <code>RangeError</code> exception."
               },
               {
                 "version_added": "19",
@@ -161,12 +163,13 @@
             ],
             "firefox_android": [
               {
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "Does not accept parameters. Supports only <code>uft-8</code> encoding."
               },
               {
                 "version_added": "38",
                 "version_removed": "48",
-                "notes": "Invalid parameter leads to the standard <code>RangeError</code> exception."
+                "notes": "<code>utf-16</code> not supported. Invalid parameter leads to the standard <code>RangeError</code> exception."
               },
               {
                 "version_added": "19",

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -149,12 +149,12 @@
               {
                 "version_added": "38",
                 "version_removed": "48",
-                "notes": "<code>utf-16</code> not supported. Invalid parameter leads to the standard <code>RangeError</code> exception."
+                "notes": "Invalid parameter leads to the standard <code>RangeError</code> exception."
               },
               {
                 "version_added": "19",
                 "version_removed": "38",
-                "notes": "<code>utf-16</code> not supported. Invalid parameter leads to a <code>TypeError</code> exception."
+                "notes": "Invalid parameter leads to a <code>TypeError</code> exception."
               },
               {
                 "version_added": "18",
@@ -169,12 +169,12 @@
               {
                 "version_added": "38",
                 "version_removed": "48",
-                "notes": "<code>utf-16</code> not supported. Invalid parameter leads to the standard <code>RangeError</code> exception."
+                "notes": "Invalid parameter leads to the standard <code>RangeError</code> exception."
               },
               {
                 "version_added": "19",
                 "version_removed": "38",
-                "notes": "<code>utf-16</code> not supported. Invalid parameter leads to a <code>TypeError</code> exception."
+                "notes": "Invalid parameter leads to a <code>TypeError</code> exception."
               },
               {
                 "version_added": "18",


### PR DESCRIPTION
[TextEncoder](https://developer.mozilla.org/docs/Web/API/TextEncoder)
Overkill on the constructor Firefox versions?