### PR TITLE
Update/data channel edge safari

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2299,10 +2299,10 @@
               }
             ],
             "safari": {
-              "version_added": 11
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": 11
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2264,10 +2264,10 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": {
               "version_added": "22"
@@ -2299,10 +2299,10 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": 11
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": 11
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
Updated `api/RTCPeerConnection/createDataChannel`. 

Edge support was incorrect. It does not support data channels:
https://developer.microsoft.com/en-us/microsoft-edge/platform/status/rtcdatachannels/?q=rtcdata

Safari released WebRTC (with data channel support) in version 11:
https://webkit.org/blog/7726/announcing-webrtc-and-media-capture/