### PR TITLE
Update nodejs version information

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -12,7 +12,7 @@
         },
         "4": {
           "release_date": "2015-09-08",
-          "status": "current"
+          "status": "retired"
         },
         "5": {
           "release_date": "2015-10-29",
@@ -32,9 +32,13 @@
         },
         "9": {
           "release_date": "2017-10-31",
-          "status": "current"
+          "status": "retired"
         },
         "10": {
+          "release_date": "2018-04-24",
+          "status": "current"
+        },
+        "11": {
           "status": "planned"
         }
       }


### PR DESCRIPTION
See https://medium.com/the-node-js-collection/april-2018-release-updates-from-the-node-js-project-71687e1f7742

- node 4.x is dead
- node 9.x is dead
- node 10.x is out
- node 11.x will be out next