### PR TITLE
Update MSE for EventHandlers attributes support

### DIFF
--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -459,11 +459,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/onsourceclose",
           "support": {
-            "chrome": [
-              {
-                "version_added": "53"
-              }
-            ],
+            "chrome": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": true
             },
@@ -530,11 +528,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/onsourceended",
           "support": {
-            "chrome": [
-              {
-                "version_added": "53"
-              }
-            ],
+            "chrome": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": true
             },
@@ -601,11 +597,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/onsourceopen",
           "support": {
-            "chrome": [
-              {
-                "version_added": "53"
-              }
-            ],
+            "chrome": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": true
             },

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -461,12 +461,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "31"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "31",
-                "prefix": "-webkit-"
+                "version_added": "53"
               }
             ],
             "edge": {
@@ -537,12 +532,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "31"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "31",
-                "prefix": "-webkit-"
+                "version_added": "53"
               }
             ],
             "edge": {
@@ -613,12 +603,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "31"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "31",
-                "prefix": "-webkit-"
+                "version_added": "53"
               }
             ],
             "edge": {

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -463,7 +463,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": [
               {
@@ -532,7 +532,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": [
               {
@@ -601,7 +601,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": [
               {

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -728,7 +728,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": [
               {
@@ -791,7 +791,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": [
               {
@@ -854,7 +854,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": [
               {
@@ -917,7 +917,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": [
               {
@@ -980,7 +980,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": [
               {

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -724,11 +724,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBuffer/onabort",
           "support": {
-            "chrome": [
-              {
-                "version_added": "53"
-              }
-            ],
+            "chrome": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": true
             },
@@ -789,11 +787,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBuffer/onerror",
           "support": {
-            "chrome": [
-              {
-                "version_added": "53"
-              }
-            ],
+            "chrome": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": true
             },
@@ -854,11 +850,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBuffer/onupdate",
           "support": {
-            "chrome": [
-              {
-                "version_added": "53"
-              }
-            ],
+            "chrome": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": true
             },
@@ -919,11 +913,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBuffer/onupdatestart",
           "support": {
-            "chrome": [
-              {
-                "version_added": "53"
-              }
-            ],
+            "chrome": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": true
             },
@@ -984,11 +976,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBuffer/onupdateend",
           "support": {
-            "chrome": [
-              {
-                "version_added": "53"
-              }
-            ],
+            "chrome": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": true
             },

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -726,12 +726,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "31"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "31",
-                "prefix": "-webkit-"
+                "version_added": "53"
               }
             ],
             "edge": {
@@ -796,12 +791,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "31"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "31",
-                "prefix": "-webkit-"
+                "version_added": "53"
               }
             ],
             "edge": {
@@ -866,12 +856,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "31"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "31",
-                "prefix": "-webkit-"
+                "version_added": "53"
               }
             ],
             "edge": {
@@ -936,12 +921,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "31"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "31",
-                "prefix": "-webkit-"
+                "version_added": "53"
               }
             ],
             "edge": {
@@ -1006,12 +986,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "31"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "31",
-                "prefix": "-webkit-"
+                "version_added": "53"
               }
             ],
             "edge": {

--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -145,12 +145,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "31"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "31",
-                "prefix": "-webkit-"
+                "version_added": "53"
               }
             ],
             "edge": {
@@ -215,12 +210,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "31"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "31",
-                "prefix": "-webkit-"
+                "version_added": "53"
               }
             ],
             "edge": {

--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -143,11 +143,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBufferList/onaddsourcebuffer",
           "support": {
-            "chrome": [
-              {
-                "version_added": "53"
-              }
-            ],
+            "chrome": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": true
             },
@@ -208,11 +206,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBufferList/onremovesourcebuffer",
           "support": {
-            "chrome": [
-              {
-                "version_added": "53"
-              }
-            ],
+            "chrome": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": true
             },

--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -147,7 +147,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": [
               {
@@ -210,7 +210,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": [
               {


### PR DESCRIPTION
The informations about MSE's EventHandler attributes was wrong.
These attributes were added after the MSE implementation: https://www.chromestatus.com/feature/5696773133697024

I have no information for other browsers.