### PR TITLE
Add NodeJS release notes

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -4,38 +4,47 @@
       "releases": {
         "0.10": {
           "release_date": "2013-03-11",
+          "release_notes": "https://nodejs.org/en/blog/release/v0.10.0/",
           "status": "retired"
         },
         "0.12": {
           "release_date": "2015-02-06",
+          "release_notes": "https://nodejs.org/en/blog/release/v0.12.0/",
           "status": "retired"
         },
         "4": {
           "release_date": "2015-09-08",
+          "release_notes": "https://nodejs.org/en/blog/release/v4.0.0/",
           "status": "retired"
         },
         "5": {
           "release_date": "2015-10-29",
+          "release_notes": "https://nodejs.org/en/blog/release/v5.0.0/",
           "status": "retired"
         },
         "6": {
           "release_date": "2016-04-26",
+          "release_notes": "https://nodejs.org/en/blog/release/v6.0.0/",
           "status": "current"
         },
         "7": {
           "release_date": "2016-10-25",
+          "release_notes": "https://nodejs.org/en/blog/release/v7.0.0/",
           "status": "retired"
         },
         "8": {
           "release_date": "2017-05-30",
+          "release_notes": "https://nodejs.org/en/blog/release/v8.0.0/",
           "status": "current"
         },
         "9": {
           "release_date": "2017-10-31",
+          "release_notes": "https://nodejs.org/en/blog/release/v9.0.0/",
           "status": "retired"
         },
         "10": {
           "release_date": "2018-04-24",
+          "release_notes": "https://nodejs.org/en/blog/release/v10.0.0/",
           "status": "current"
         },
         "11": {


### PR DESCRIPTION
All of these can be found on the NodeJS blog, e.g. https://nodejs.org/en/blog/release/v0.10.0/, https://nodejs.org/en/blog/release/v0.12.0/, https://nodejs.org/en/blog/release/v4.0.0/, etc.