### PR TITLE
Add missing note to `Element.createShadowRoot(…)`

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -704,7 +704,8 @@
           "support": {
             "chrome": [
               {
-                "version_added": "35"
+                "version_added": "35",
+                "notes": "In Chrome 45, the ability to have multiple shadow roots was deprecated."
               },
               {
                 "version_added": "25",
@@ -714,7 +715,8 @@
             ],
             "chrome_android": [
               {
-                "version_added": "35"
+                "version_added": "35",
+                "notes": "In Chrome 45, the ability to have multiple shadow roots was deprecated."
               },
               {
                 "version_added": "25",
@@ -781,7 +783,8 @@
             },
             "opera": [
               {
-                "version_added": "22"
+                "version_added": "22",
+                "notes": "In Opera 32, the ability to have multiple shadow roots was deprecated."
               },
               {
                 "version_added": "15",
@@ -791,7 +794,8 @@
             ],
             "opera_android": [
               {
-                "version_added": "22"
+                "version_added": "22",
+                "notes": "In Opera 32, the ability to have multiple shadow roots was deprecated."
               },
               {
                 "version_added": "14",
@@ -817,7 +821,8 @@
             ],
             "webview_android": [
               {
-                "version_added": "35"
+                "version_added": "35",
+                "notes": "In Chrome 45, the ability to have multiple shadow roots was deprecated."
               },
               {
                 "version_added": "25",


### PR DESCRIPTION
This adds the missing Chrome 45 deprecation note to the [`Element.createShadowRoot(…)` API](https://developer.mozilla.org/en-US/docs/Web/API/Element/createShadowRoot#Browser_compatibility).