### PR TITLE
Compat data for multi-keyword syntax in CSS overflow

### DIFF
--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -53,9 +53,9 @@
             "deprecated": false
           }
         },
-        "Multi-keyword": {
+        "multiple_keywords": {
           "__compat": {
-            "description": "Multi-keyword syntax for <code>overflow-x</code> and <code>overflow-y</code>.",
+            "description": "Multiple keyword syntax for <code>overflow-x</code> and <code>overflow-y</code>",
             "support": {
               "webview_android": {
                 "version_added": "68"

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -52,6 +52,52 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "Multi-keyword": {
+          "__compat": {
+            "description": "Multi-keyword syntax for <code>overflow-x</code> and <code>overflow-y</code>.",
+            "support": {
+              "webview_android": {
+                "version_added": "68"
+              },
+              "chrome": {
+                "version_added": "68"
+              },
+              "chrome_android": {
+                "version_added": "68"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "61"
+              },
+              "firefox_android": {
+                "version_added": "61"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "55"
+              },
+              "opera_android": {
+                "version_added": "55"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Firefox 61 accepts two keywords in `overflow`:

https://bugzilla.mozilla.org/show_bug.cgi?id=1453148
https://groups.google.com/forum/#!topic/mozilla.dev.platform/4vy-a5_a35o
https://github.com/mdn/data/commit/5f28d73672718f555e2cfd76d06ec29c904cc828