### PR TITLE
Record that timeZone works

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -830,7 +830,7 @@
                     "version_added": "35"
                   },
                   "chrome_android": {
-                    "version_added": null
+                    "version_added": "<66"
                   },
                   "edge": {
                     "version_added": "14"

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -830,7 +830,7 @@
                     "version_added": "35"
                   },
                   "chrome_android": {
-                    "version_added": "<66"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"


### PR DESCRIPTION
I don't know exactly which version it was first supported in, but it definitely DOES work in Chrome for Android 66.