### PR TITLE
th: mark the `scope` attribute as not deprecated

### DIFF
--- a/html/elements/th.json
+++ b/html/elements/th.json
@@ -604,7 +604,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },


### PR DESCRIPTION
The `th` `scope` attribute is part of the HTML5 standard: https://www.w3.org/TR/html50/tabular-data.html#attr-th-scope