### PR TITLE
th: mark the `abbr` attribute as not deprecated

### DIFF
--- a/html/elements/th.json
+++ b/html/elements/th.json
@@ -97,7 +97,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },


### PR DESCRIPTION
The `th` `abbr` attribute is part of the HTML5 standard: https://www.w3.org/TR/html50/tabular-data.html#attr-th-abbr