### PR TITLE
Fix Chrome/Opera versions RTCPeerConnection.addTrack/removeTrack (#1288)

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2093,13 +2093,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/addTrack",
           "support": {
             "webview_android": {
-              "version_added": "56"
+              "version_added": "64"
             },
             "chrome": {
-              "version_added": "56"
+              "version_added": "64"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "64"
             },
             "edge": {
               "version_added": true
@@ -2116,26 +2116,12 @@
             "ie": {
               "version_added": null
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "51"
+            },
+            "opera_android": {
+              "version_added": "51"
+            },
             "safari": {
               "version_added": null
             },
@@ -2974,13 +2960,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/removeTrack",
           "support": {
             "webview_android": {
-              "version_added": "56"
+              "version_added": "64"
             },
             "chrome": {
-              "version_added": "56"
+              "version_added": "64"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "64"
             },
             "edge": {
               "version_added": true
@@ -2997,26 +2983,12 @@
             "ie": {
               "version_added": null
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "51"
+            },
+            "opera_android": {
+              "version_added": "51"
+            },
             "safari": {
               "version_added": null
             },


### PR DESCRIPTION
Fixes the same problem as https://github.com/mdn/browser-compat-data/pull/1713 but for `RTCPeerConnection.addTrack()` and `RTCPeerConnection.removeTrack()`. The information about a promise-based version probably was a copy-paste error here.

References:

https://www.chromestatus.com/feature/5644723490390016
https://bugs.chromium.org/p/chromium/issues/detail?id=705901&desc=2
https://dev.opera.com/blog/opera-51/