### PR TITLE
Update source element and its attributes for Safari desktop/iOS

### DIFF
--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -41,7 +41,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -90,7 +90,7 @@
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -164,7 +164,7 @@
                 "version_added": null
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "9.2"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -214,7 +214,7 @@
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -288,7 +288,7 @@
                 "version_added": null
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "9.2"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -338,7 +338,7 @@
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -165,7 +165,7 @@
                   "version_added": "9"
                 },
                 {
-                  "version_added": "7.1",
+                  "version_added": "7",
                   "partial_implementation": true
                 }
               ],
@@ -301,7 +301,7 @@
                   "version_added": "9"
                 },
                 {
-                  "version_added": "7.1",
+                  "version_added": "7",
                   "partial_implementation": true
                 }
               ],

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -163,13 +163,15 @@
               "safari": {
                 "version_added": null
               },
-              "safari_ios": {
-                "version_added": "9.2",
+              "safari_ios": [
+                {
+                  "version_added": "9.2"
+                },
                 {
                   "version_added": "8",
                   "partial_implementation": true
                 }
-              },
+              ],
               "samsunginternet_android": {
                 "version_added": true
               }
@@ -291,13 +293,15 @@
               "safari": {
                 "version_added": null
               },
-              "safari_ios": {
-                "version_added": "9.2",
+              "safari_ios": [
+                {
+                  "version_added": "9.2"
+                },
                 {
                   "version_added": "8",
                   "partial_implementation": true
                 }
-              },
+              ],
               "samsunginternet_android": {
                 "version_added": true
               }

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -164,7 +164,11 @@
                 "version_added": null
               },
               "safari_ios": {
-                "version_added": "9.2"
+                "version_added": "9.2",
+                {
+                  "version_added": "8",
+                  "partial_implementation": true
+                }
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -288,7 +292,11 @@
                 "version_added": null
               },
               "safari_ios": {
-                "version_added": "9.2"
+                "version_added": "9.2",
+                {
+                  "version_added": "8",
+                  "partial_implementation": true
+                }
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -160,9 +160,15 @@
               "opera_android": {
                 "version_added": null
               },
-              "safari": {
-                "version_added": null
-              },
+              "safari": [
+                {
+                  "version_added": "9"
+                },
+                {
+                  "version_added": "7.1",
+                  "partial_implementation": true
+                }
+              ],
               "safari_ios": [
                 {
                   "version_added": "9.2"
@@ -290,9 +296,15 @@
               "opera_android": {
                 "version_added": null
               },
-              "safari": {
-                "version_added": null
-              },
+              "safari": [
+                {
+                  "version_added": "9"
+                },
+                {
+                  "version_added": "7.1",
+                  "partial_implementation": true
+                }
+              ],
               "safari_ios": [
                 {
                   "version_added": "9.2"


### PR DESCRIPTION
[Apple developer guide](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/HTMLTags.html#//apple_ref/doc/uid/30001262-SW5) and [caniuse](https://caniuse.com/#feat=srcset) suggest that the `<source>` element and `srcset`, `sizes`, `media`, `src`, and `type` attributes are all supported by iOS Safari by v9.2 and desktop Safari by v9.