### PR TITLE
Correct bcd for api.KeyboardEvent

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1030,7 +1030,7 @@
         },
         "accel_support": {
           "__compat": {
-            "description": "<code>\"Accel\"</code> support",
+            "description": "<code>\"Accel\"</code> is a valid parameter",
             "support": {
               "webview_android": {
                 "version_added": "48"
@@ -1074,8 +1074,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
The `"Accel"` parameter to `getModifierState()` is [deprecated](https://developer.mozilla.org/docs/Web/API/KeyboardEvent/getModifierState#Accel_virtual_modifier). Also made the description clearer. Props to @connorshea for catching the mistake.