### PR TITLE
Update compatibility information for new color syntax in Chrome/Opera

### DIFF
--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -540,13 +540,13 @@
             "description": "Space-separated functional color notations",
             "support": {
               "webview_android": {
-                "version_added": null
+                "version_added": "65"
               },
               "chrome": {
                 "version_added": "65"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "65"
               },
               "edge": {
                 "version_added": null
@@ -567,7 +567,7 @@
                 "version_added": "52"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "52"
               },
               "safari": {
                 "version_added": null
@@ -591,13 +591,13 @@
             "description": "Allow floats in <code>rgb()</code> and <code>rgba()</code>",
             "support": {
               "webview_android": {
-                "version_added": "67"
+                "version_added": "66"
               },
               "chrome": {
-                "version_added": "67"
+                "version_added": "66"
               },
               "chrome_android": {
-                "version_added": "67"
+                "version_added": "66"
               },
               "edge": {
                 "version_added": null
@@ -615,10 +615,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": "53"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "53"
               },
               "safari": {
                 "version_added": null


### PR DESCRIPTION
https://crrev.com/532032, which landed support for decimal numbers in rgb/rgba, actually landed in Chrome 66 instead of 67 per https://storage.googleapis.com/chromium-find-releases-static/f8e.html#f8e89bb9a450bca698c8c522aded1030ea1cd681.

Also add compatibility information for Android versions and Opera based off of these base Chrome version numbers.