### PR TITLE
Change MDN page for chrome support of AnimationEvent.pseudoElement

### DIFF
--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -338,13 +338,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEvent/pseudoElement",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "chrome": {
-              "version_added": false
+              "version_added": "68"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "edge": {
               "version_added": false


### PR DESCRIPTION
The AnimationEvent.pseudoElement is implemented and shipped in chromium here:
https://chromium-review.googlesource.com/c/chromium/src/+/1019383

It will hit chrome stable in M68. This updates the MDN page.

@birtles @flackr