### PR TITLE
Update WebExtensions `notifications` API on Chrome/Opera

### DIFF
--- a/webextensions/api/notifications.json
+++ b/webextensions/api/notifications.json
@@ -358,7 +358,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/clear",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "28"
               },
               "edge": {
                 "version_added": "17"
@@ -370,7 +370,7 @@
                 "version_added": "48"
               },
               "opera": {
-                "version_added": true
+                "version_added": "25"
               }
             }
           }
@@ -380,7 +380,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/create",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "28"
               },
               "edge": {
                 "version_added": "17"
@@ -392,7 +392,7 @@
                 "version_added": "48"
               },
               "opera": {
-                "version_added": true
+                "version_added": "25"
               }
             }
           }
@@ -402,7 +402,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/getAll",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "29"
               },
               "edge": {
                 "version_added": "17"
@@ -414,7 +414,7 @@
                 "version_added": "48"
               },
               "opera": {
-                "version_added": true
+                "version_added": "25"
               }
             }
           }
@@ -424,7 +424,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/onButtonClicked",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "28"
               },
               "edge": {
                 "version_added": "17"
@@ -436,7 +436,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "25"
               }
             }
           }
@@ -446,7 +446,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/onClicked",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "28"
               },
               "edge": {
                 "version_added": "17"
@@ -458,7 +458,7 @@
                 "version_added": "48"
               },
               "opera": {
-                "version_added": true
+                "version_added": "25"
               }
             }
           }
@@ -468,7 +468,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/onClosed",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "28"
               },
               "edge": {
                 "version_added": "17"
@@ -480,7 +480,7 @@
                 "version_added": "48"
               },
               "opera": {
-                "version_added": true
+                "version_added": "25"
               }
             }
           },
@@ -533,7 +533,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/update",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "28"
               },
               "edge": {
                 "version_added": "17"
@@ -548,7 +548,7 @@
                 "notes": [
                   "Not supported on Macs."
                 ],
-                "version_added": true
+                "version_added": "25"
               }
             }
           }

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -558,7 +558,7 @@
             "description": "<code>notifications</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "5"
               },
               "edge": {
                 "version_added": false
@@ -570,7 +570,7 @@
                 "version_added": "48"
               },
               "opera": {
-                "version_added": true
+                "version_added": "25"
               }
             }
           }


### PR DESCRIPTION
Self-tested and verified with sources

Chrome 28 started supporting it
Chrome 27 is bugged, the functions are available and exposed, but calling them does nothing(!)
https://developer.chrome.com/extensions/notifications

Opera only supports notifications starting from v25
https://dev.opera.com/blog/opera-25/#notifications-api
https://caniuse.com/#feat=notifications