### PR TITLE
Fix support of `background` on WebExtensions permissions

### DIFF
--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -71,7 +71,7 @@
             "description": "<code>background</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "10"
               },
               "edge": {
                 "version_added": false
@@ -83,7 +83,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": false
               }
             }
           }


### PR DESCRIPTION
Not to be confused with background/event pages: https://developer.chrome.com/extensions/background_pages

It refers to this:
![](https://user-images.githubusercontent.com/6135313/39748126-e14339ce-52e1-11e8-91bb-b42bcecbc25e.png)

According to sources/blog posts, Chrome supported this since v10. My old Chrome collection only goes back to v12, I can't easily confirm this 😅

https://blog.chromium.org/2011/02/amping-up-chromes-background-feature.html
https://web.archive.org/web/20110426141831/http://code.google.com/chrome/apps/docs/background.html

Opera does **not** support the `background` permission. Developers can use this code to check for support instead of user-agent sniffing:

```js
chrome.permissions.contains({permissions: ['background']}, function(result) {
    console.log(JSON.stringify(chrome.runtime.lastError)); // {"message":"'background' is not a recognized permission."}
    console.log(result === undefined); // true
});
````