### PR TITLE
Add Edge browser release note links

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -4,22 +4,27 @@
       "releases": {
         "12": {
           "release_date": "2015-07-28",
+          "release_notes": "https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-12",
           "status": "retired"
         },
         "13": {
           "release_date": "2015-11-12",
+          "release_notes": "https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-13",
           "status": "retired"
         },
         "14": {
           "release_date": "2016-08-02",
+          "release_notes": "https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-14",
           "status": "retired"
         },
         "15": {
           "release_date": "2017-04-05",
+          "release_notes": "https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-15",
           "status": "retired"
         },
         "16": {
           "release_date": "2017-10-17",
+          "release_notes": "https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-16",
           "status": "current"
         },
         "17": {


### PR DESCRIPTION
Part of #1951, [a comment from kypflug recommends using the Edge Dev Guide](https://github.com/mdn/browser-compat-data/issues/1951#issuecomment-386496648).

I didn't include Edge 17 because the current "permalink" is `https://aka.ms/devguide_edgehtml_17`, which is a shortlink. I'm not sure if we should use that or not? The normal format (`https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-VERSION`) doesn't work for the latest release (prior to the release of 17, the same was true of 16).

@kypflug any opinion on this? :)