### PR TITLE
Add Chrome release notes and fix a few incorrect release dates.

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -5,270 +5,337 @@
       "releases": {
         "1": {
           "release_date": "2008-12-11",
+          "release_notes": "https://chromereleases.googleblog.com/2008/12/stable-release-google-chrome-is-out-of.html",
           "status": "retired"
         },
         "2": {
-          "release_date": "2009-05-24",
+          "release_date": "2009-05-21",
+          "release_notes": "https://chromereleases.googleblog.com/2009/05/stable-update-google-chrome-2017228.html",
           "status": "retired"
         },
         "3": {
-          "release_date": "2009-10-12",
+          "release_date": "2009-09-15",
+          "release_notes": "https://chromereleases.googleblog.com/2009/09/stable-channel-update.html",
           "status": "retired"
         },
         "4": {
           "release_date": "2010-01-25",
+          "release_notes": "https://chromereleases.googleblog.com/2010/01/stable-channel-update_25.html",
           "status": "retired"
         },
         "5": {
-          "release_date": "2010-05-21",
+          "release_date": "2010-05-25",
+          "release_notes": "https://chromereleases.googleblog.com/2010/05/stable-channel-update.html",
           "status": "retired"
         },
         "6": {
           "release_date": "2010-09-02",
+          "release_notes": "https://chromereleases.googleblog.com/2010/09/stable-and-beta-channel-updates.html",
           "status": "retired"
         },
         "7": {
-          "release_date": "2010-10-21",
+          "release_date": "2010-10-19",
+          "release_notes": "https://chromereleases.googleblog.com/2010/10/stable-channel-update.html",
           "status": "retired"
         },
         "8": {
           "release_date": "2010-12-02",
+          "release_notes": "https://chromereleases.googleblog.com/2010/12/stable-beta-channel-updates.html",
           "status": "retired"
         },
         "9": {
           "release_date": "2011-02-03",
+          "release_notes": "https://chromereleases.googleblog.com/2011/02/stable-channel-update.html",
           "status": "retired"
         },
         "10": {
           "release_date": "2011-03-08",
+          "release_notes": "https://chromereleases.googleblog.com/2011/03/chrome-stable-release.html",
           "status": "retired"
         },
         "11": {
           "release_date": "2011-04-27",
+          "release_notes": "https://chromereleases.googleblog.com/2011/04/chrome-stable-update.html",
           "status": "retired"
         },
         "12": {
           "release_date": "2011-06-07",
+          "release_notes": "https://chromereleases.googleblog.com/2011/06/chrome-stable-release.html",
           "status": "retired"
         },
         "13": {
           "release_date": "2011-08-02",
+          "release_notes": "https://chromereleases.googleblog.com/2011/08/stable-channel-update.html",
           "status": "retired"
         },
         "14": {
           "release_date": "2011-09-16",
+          "release_notes": "https://chromereleases.googleblog.com/2011/09/stable-channel-update_16.html",
           "status": "retired"
         },
         "15": {
           "release_date": "2011-10-25",
+          "release_notes": "https://chromereleases.googleblog.com/2011/10/chrome-stable-release.html",
           "status": "retired"
         },
         "16": {
           "release_date": "2011-12-13",
+          "release_notes": "https://chromereleases.googleblog.com/2011/12/stable-channel-update.html",
           "status": "retired"
         },
         "17": {
           "release_date": "2012-02-08",
+          "release_notes": "https://chromereleases.googleblog.com/2012/02/stable-channel-update.html",
           "status": "retired"
         },
         "18": {
           "release_date": "2012-03-28",
+          "release_notes": "https://chromereleases.googleblog.com/2012/03/stable-channel-release-and-beta-channel.html",
           "status": "retired"
         },
         "19": {
           "release_date": "2012-05-15",
+          "release_notes": "https://chromereleases.googleblog.com/2012/05/stable-channel-update.html",
           "status": "retired"
         },
         "20": {
           "release_date": "2012-06-26",
+          "release_notes": "https://chromereleases.googleblog.com/2012/06/stable-channel-update_26.html",
           "status": "retired"
         },
         "21": {
           "release_date": "2012-07-31",
+          "release_notes": "https://chromereleases.googleblog.com/2012/07/stable-channel-release.html",
           "status": "retired"
         },
         "22": {
           "release_date": "2012-09-25",
+          "release_notes": "https://chromereleases.googleblog.com/2012/09/stable-channel-update_25.html",
           "status": "retired"
         },
         "23": {
           "release_date": "2012-11-06",
+          "release_notes": "https://chromereleases.googleblog.com/2012/11/stable-channel-release-and-beta-channel.html",
           "status": "retired"
         },
         "24": {
           "release_date": "2013-01-10",
+          "release_notes": "https://chromereleases.googleblog.com/2013/01/stable-channel-update.html",
           "status": "retired"
         },
         "25": {
           "release_date": "2013-02-21",
+          "release_notes": "https://chromereleases.googleblog.com/2013/02/stable-channel-update_21.html",
           "status": "retired"
         },
         "26": {
           "release_date": "2013-03-26",
+          "release_notes": "https://chromereleases.googleblog.com/2013/03/stable-channel-update_26.html",
           "status": "retired"
         },
         "27": {
           "release_date": "2013-05-21",
+          "release_notes": "https://chromereleases.googleblog.com/2013/05/stable-channel-release.html",
           "status": "retired"
         },
         "28": {
           "release_date": "2013-07-09",
+          "release_notes": "https://chromereleases.googleblog.com/2013/07/stable-channel-update.html",
           "status": "retired"
         },
         "29": {
           "release_date": "2013-08-20",
+          "release_notes": "https://chromereleases.googleblog.com/2013/08/stable-channel-update.html",
           "status": "retired"
         },
         "30": {
           "release_date": "2013-10-01",
+          "release_notes": "https://chromereleases.googleblog.com/2013/10/stable-channel-update.html",
           "status": "retired"
         },
         "31": {
           "release_date": "2013-11-12",
+          "release_notes": "https://chromereleases.googleblog.com/2013/11/stable-channel-update.html",
           "status": "retired"
         },
         "32": {
           "release_date": "2014-01-14",
+          "release_notes": "https://chromereleases.googleblog.com/2014/01/stable-channel-update.html",
           "status": "retired"
         },
         "33": {
           "release_date": "2014-02-20",
+          "release_notes": "https://chromereleases.googleblog.com/2014/02/stable-channel-update_20.html",
           "status": "retired"
         },
         "34": {
           "release_date": "2014-04-08",
+          "release_notes": "https://chromereleases.googleblog.com/2014/04/stable-channel-update.html",
           "status": "retired"
         },
         "35": {
           "release_date": "2014-05-20",
+          "release_notes": "https://chromereleases.googleblog.com/2014/05/stable-channel-update_20.html",
           "status": "retired"
         },
         "36": {
           "release_date": "2014-07-16",
+          "release_notes": "https://chromereleases.googleblog.com/2014/07/stable-channel-update.html",
           "status": "retired"
         },
         "37": {
           "release_date": "2014-08-26",
+          "release_notes": "https://chromereleases.googleblog.com/2014/08/stable-channel-update_26.html",
           "status": "retired"
         },
         "38": {
           "release_date": "2014-10-07",
+          "release_notes": "https://chromereleases.googleblog.com/2014/10/stable-channel-update.html",
           "status": "retired"
         },
         "39": {
           "release_date": "2014-11-18",
+          "release_notes": "https://chromereleases.googleblog.com/2014/11/stable-channel-update_18.html",
           "status": "retired"
         },
         "40": {
           "release_date": "2015-01-21",
+          "release_notes": "https://chromereleases.googleblog.com/2015/01/stable-update.html",
           "status": "retired"
         },
         "41": {
           "release_date": "2015-03-03",
+          "release_notes": "https://chromereleases.googleblog.com/2015/03/stable-channel-update.html",
           "status": "retired"
         },
         "42": {
           "release_date": "2015-04-14",
+          "release_notes": "https://chromereleases.googleblog.com/2015/04/stable-channel-update_14.html",
           "status": "retired"
         },
         "43": {
           "release_date": "2015-05-19",
+          "release_notes": "https://chromereleases.googleblog.com/2015/05/stable-channel-update_19.html",
           "status": "retired"
         },
         "44": {
           "release_date": "2015-07-21",
+          "release_notes": "https://chromereleases.googleblog.com/2015/07/stable-channel-update_21.html",
           "status": "retired"
         },
         "45": {
           "release_date": "2015-09-01",
+          "release_notes": "https://chromereleases.googleblog.com/2015/09/stable-channel-update.html",
           "status": "retired"
         },
         "46": {
           "release_date": "2015-10-13",
+          "release_notes": "https://chromereleases.googleblog.com/2015/10/stable-channel-update.html",
           "status": "retired"
         },
         "47": {
           "release_date": "2015-12-01",
+          "release_notes": "https://chromereleases.googleblog.com/2015/12/stable-channel-update.html",
           "status": "retired"
         },
         "48": {
           "release_date": "2016-01-20",
+          "release_notes": "https://chromereleases.googleblog.com/2016/01/stable-channel-update_20.html",
           "status": "retired"
         },
         "49": {
           "release_date": "2016-03-02",
+          "release_notes": "https://chromereleases.googleblog.com/2016/03/stable-channel-update.html",
           "status": "retired"
         },
         "50": {
           "release_date": "2016-04-13",
+          "release_notes": "https://chromereleases.googleblog.com/2016/04/stable-channel-update_13.html",
           "status": "retired"
         },
         "51": {
           "release_date": "2016-05-25",
+          "release_notes": "https://chromereleases.googleblog.com/2016/05/stable-channel-update_25.html",
           "status": "retired"
         },
         "52": {
           "release_date": "2016-07-20",
+          "release_notes": "https://chromereleases.googleblog.com/2016/07/stable-channel-update.html",
           "status": "retired"
         },
         "53": {
           "release_date": "2016-08-31",
+          "release_notes": "https://chromereleases.googleblog.com/2016/08/stable-channel-update-for-desktop_31.html",
           "status": "retired"
         },
         "54": {
           "release_date": "2016-10-12",
+          "release_notes": "https://chromereleases.googleblog.com/2016/10/stable-channel-update-for-desktop.html",
           "status": "retired"
         },
         "55": {
           "release_date": "2016-12-01",
+          "release_notes": "https://chromereleases.googleblog.com/2016/12/stable-channel-update-for-desktop.html",
           "status": "retired"
         },
         "56": {
           "release_date": "2017-01-25",
+          "release_notes": "https://chromereleases.googleblog.com/2017/01/stable-channel-update-for-desktop.html",
           "status": "retired"
         },
         "57": {
           "release_date": "2017-03-09",
+          "release_notes": "https://chromereleases.googleblog.com/2017/03/stable-channel-update-for-desktop.html",
           "status": "retired"
         },
         "58": {
           "release_date": "2017-04-19",
+          "release_notes": "https://chromereleases.googleblog.com/2017/04/stable-channel-update-for-desktop.html",
           "status": "retired"
         },
         "59": {
           "release_date": "2017-06-05",
+          "release_notes": "https://chromereleases.googleblog.com/2017/06/stable-channel-update-for-desktop.html",
           "status": "retired"
         },
         "60": {
           "release_date": "2017-07-25",
+          "release_notes": "https://chromereleases.googleblog.com/2017/07/stable-channel-update-for-desktop.html",
           "status": "retired"
         },
         "61": {
           "release_date": "2017-09-05",
+          "release_notes": "https://chromereleases.googleblog.com/2017/09/stable-channel-update-for-desktop.html",
           "status": "retired"
         },
         "62": {
           "release_date": "2017-10-17",
+          "release_notes": "https://chromereleases.googleblog.com/2017/10/stable-channel-update-for-desktop.html",
           "status": "retired"
         },
         "63": {
           "release_date": "2017-12-06",
+          "release_notes": "https://chromereleases.googleblog.com/2017/12/stable-channel-update-for-desktop.html",
           "status": "retired"
         },
         "64": {
           "release_date": "2018-01-23",
+          "release_notes": "https://chromereleases.googleblog.com/2018/01/stable-channel-update-for-desktop_24.html",
           "status": "retired"
         },
         "65": {
           "release_date": "2018-03-06",
+          "release_notes": "https://chromereleases.googleblog.com/2018/03/stable-channel-update-for-desktop.html",
           "status": "retired"
         },
         "66": {
           "release_date": "2018-04-17",
+          "release_notes": "https://chromereleases.googleblog.com/2018/04/stable-channel-update-for-desktop.html",
           "status": "retired"
         },
         "67": {
           "release_date": "2018-05-29",
+          "release_notes": "https://chromereleases.googleblog.com/2018/05/stable-channel-update-for-desktop_58.html",
           "status": "current"
         },
         "68": {


### PR DESCRIPTION
This adds release notes to the Chrome JSON. Part of #1951. The Chrome Releases blog was suggested as the source in [this comment by jpmedley](https://github.com/mdn/browser-compat-data/issues/1951#issuecomment-384789076).

I also made some corrections to dates, I'm not sure where the original dates were sourced from?

Corrections:

- Originally for v2, May 24, 2009 was listed, but I only see a post on [the 21st](https://chromereleases.googleblog.com/2009/05/stable-update-google-chrome-2017228.html).
- Originally for v3, October 12, 2009 was listed, presumably because of [this post](https://chromereleases.googleblog.com/2009/10/betastable-channel-update.html), but there's an [earlier post about Chrome 3 being made stable in September](https://chromereleases.googleblog.com/2009/09/stable-channel-update.html).
- For v5, I see [no blog post on the original date](https://chromereleases.googleblog.com/search/label/Stable%20updates?updated-max=2010-06-08T14:00:00-07:00&max-results=20&start=446&by-date=false).
- For v7, I see [no blog post on the original date](https://chromereleases.googleblog.com/search/label/Stable%20updates?updated-max=2010-12-02T11:47:00-08:00&max-results=20&start=434&by-date=false).

The rest of the release notes matched their listed release dates, and for all those above ~30, were distinguishable by "The Chrome team is [excited, delighted, etc.] to announce the promotion of Chrome [version] to the Stable channel." Prior major release posts didn't have this same intro, so I pretty much just matched the date.

In the cases where no post matched the date, I found the earliest blog post that mentioned releasing the version to stable. All these cases are mentioned above with their release dates updated.