### PR TITLE
Update WebAuthentication MDN URL

### DIFF
--- a/api/WebAuthentication.json
+++ b/api/WebAuthentication.json
@@ -2,7 +2,7 @@
   "api": {
     "WebAuthentication": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebAuthentication",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Web_Authentication_API",
         "support": {
           "chrome": {
             "version_added": "67",
@@ -67,7 +67,7 @@
       },
       "getAssertion": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebAuthentication/getAssertion",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Web_Authentication_API/getAssertion",
           "support": {
             "chrome": {
               "version_added": "67",
@@ -133,7 +133,7 @@
       },
       "makeCredential": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebAuthentication/makeCredential",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Web_Authentication_API/makeCredential",
           "support": {
             "chrome": {
               "version_added": "67",


### PR DESCRIPTION
The WebAuthentication MDN URL was incorrect, should link to [Web_Authentication_API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API).

Originally introduced in #1742 