### PR TITLE
Bug 509958 – Remove the `-moz-` prefix from `::selection`

### DIFF
--- a/css/selectors/selection.json
+++ b/css/selectors/selection.json
@@ -27,7 +27,6 @@
               },
               {
                 "version_added": "1",
-                "version_removed": "62",
                 "prefix": "-moz-"
               }
             ],


### PR DESCRIPTION
## External links:
- [Bug 509958](https://bugzil.la/509958 "509958 - Remove the -moz prefix from ::selection")