### PR TITLE
Add release dates for some Safari iOS releases, remove non-existant releases

### DIFF
--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -39,12 +39,14 @@
           "status": "retired"
         },
         "7": {
+          "release_date": "2013-09-18",
           "status": "retired"
         },
         "7.1": {
           "status": "retired"
         },
         "8": {
+          "release_date": "2014-09-17",
           "status": "retired"
         },
         "8.1": {
@@ -54,33 +56,27 @@
           "status": "retired"
         },
         "9": {
+          "release_date": "2015-09-16",
           "status": "retired"
         },
         "9.1": {
-          "status": "retired"
-        },
-        "9.2": {
-          "status": "retired"
-        },
-        "9.3": {
+          "release_date": "2016-03-21",
           "status": "retired"
         },
         "10": {
+          "release_date": "2016-09-13",
           "status": "retired"
         },
         "10.1": {
-          "status": "retired"
-        },
-        "10.2": {
-          "status": "retired"
-        },
-        "10.3": {
+          "release_date": "2017-03-27",
           "status": "retired"
         },
         "11": {
+          "release_date": "2017-09-19",
           "status": "retired"
         },
         "11.1": {
+          "release_date": "2018-03-29",
           "status": "current"
         }
       }


### PR DESCRIPTION
This fixes some problems mentioned in #2006 and adds release dates for versions which I can ensure match up with an iOS release.