### PR TITLE
Add CDATASection

### DIFF
--- a/api/CDATASection.json
+++ b/api/CDATASection.json
@@ -1,0 +1,46 @@
+{
+  "api": {
+    "CDATASection": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CDATASection",
+        "support": {
+          "chrome": {
+            "version_added": "1"
+          },
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "ie": {
+            "version_added": true
+          },
+          "opera": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds the browser compatibility table data for the [`CDATASection` API](https://developer.mozilla.org/docs/Web/API/CDATASection).