### PR TITLE
Add String trimStart/trimEnd

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -3124,42 +3124,63 @@
             }
           }
         },
-        "trimLeft": {
+        "trimEnd": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trimLeft",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd",
             "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": null
-              },
+              "chrome": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "alternative_name": "trimRight"
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "alternative_name": "trimRight"
+                }
+              ],
               "edge": {
-                "version_added": true
+                "version_added": null
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
-              "firefox": {
-                "version_added": "3.5"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
+              "firefox": [
+                {
+                  "version_added": "61"
+                },
+                {
+                  "version_added": "3.5",
+                  "alternative_name": "trimRight"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "61"
+                },
+                {
+                  "version_added": "4",
+                  "alternative_name": "trimRight"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "4"
+                "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": "53"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "53"
               },
               "safari": {
                 "version_added": null
@@ -3169,51 +3190,81 @@
               },
               "samsunginternet_android": {
                 "version_added": null
-              }
+              },
+              "webview_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "alternative_name": "trimRight"
+                }
+              ]
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }
         },
-        "trimRight": {
+        "trimStart": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trimRight",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart",
             "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": null
-              },
+              "chrome": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "alternative_name": "trimLeft"
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "alternative_name": "trimLeft"
+                }
+              ],
               "edge": {
-                "version_added": true
+                "version_added": null
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
-              "firefox": {
-                "version_added": "3.5"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
+              "firefox": [
+                {
+                  "version_added": "61"
+                },
+                {
+                  "version_added": "3.5",
+                  "alternative_name": "trimLeft"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "61"
+                },
+                {
+                  "version_added": "4",
+                  "alternative_name": "trimLeft"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "4"
+                "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": "53"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "53"
               },
               "safari": {
                 "version_added": null
@@ -3223,11 +3274,20 @@
               },
               "samsunginternet_android": {
                 "version_added": null
-              }
+              },
+              "webview_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "alternative_name": "trimLeft"
+                }
+              ]
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }


### PR DESCRIPTION
Renames trimLeft/trimRight to trimStart/trimEnd. Legacy names are recorded as alternative names.

References:

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd
- https://bugzilla.mozilla.org/show_bug.cgi?id=1434007
- https://www.chromestatus.com/features/4790066333351936