### PR TITLE
Firefox removed SVGSVGElement.{pixel,screenPixel}UnitToMillimeter{X,Y}

### DIFF
--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -1204,10 +1204,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "61"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "61"
             },
             "ie": {
               "version_added": null
@@ -1256,10 +1258,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "61"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "61"
             },
             "ie": {
               "version_added": null
@@ -1308,10 +1312,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "61"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "61"
             },
             "ie": {
               "version_added": null
@@ -1360,10 +1366,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "61"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "61"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1133172
https://developer.mozilla.org/en-US/docs/Web/API/SVGSVGElement#Browser_compatibility

r? @JeremiePat 
