### PR TITLE
Added extraParameters argument to tabs.onUpdated

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -2069,6 +2069,27 @@
                 }
               }
             }
+          },
+          "extraParameters": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "61"
+                },
+                "firefox_android": {
+                  "version_added": "61"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "onZoomChange": {


### PR DESCRIPTION
Firefox 61 added a new argument to `tabs.onUpdated`, called `extraParameters`:
https://bugzilla.mozilla.org/show_bug.cgi?id=1329507
