### PR TITLE
Add data for browserSettings.overrideDocumentColors

### DIFF
--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -178,6 +178,28 @@
             }
           }
         },
+        "overrideDocumentColors": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/overrideDocumentColors",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "61"
+              },
+              "firefox_android": {
+                "version_added": "61"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "proxyConfig": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/proxyConfig",


### PR DESCRIPTION
New browser setting exposing a Firefox pref:

https://bugzilla.mozilla.org/show_bug.cgi?id=1417810
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browserSettings/overrideDocumentColors