### PR TITLE
Update WEBGL_debug_renderer_info

### DIFF
--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -4,11 +4,8 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_debug_renderer_info",
         "support": {
-          "webview_android": {
-            "version_added": null
-          },
           "chrome": {
-            "version_added": null
+            "version_added": "33"
           },
           "chrome_android": {
             "version_added": null
@@ -21,6 +18,9 @@
           },
           "firefox": [
             {
+              "version_added": "53"
+            },
+            {
               "version_added": true,
               "version_removed": "53",
               "flags": [
@@ -30,30 +30,30 @@
                   "value_to_set": "true"
                 }
               ]
-            },
-            {
-              "version_added": "53"
             }
           ],
           "firefox_android": {
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
             "version_added": null
           },
           "samsunginternet_android": {
+            "version_added": null
+          },
+          "webview_android": {
             "version_added": null
           }
         },


### PR DESCRIPTION
Some minor fixes here:

- Firefox ordering to show 53 without flag first.
- Chrome has this enabled in 33, too: https://bugs.chromium.org/p/chromium/issues/detail?id=335373
- Safari has this enabled sometime, too: https://bugs.webkit.org/show_bug.cgi?id=149735 
- Sort browsers alphabetically