### PR TITLE
Add compat data for Window event handlers

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -251,7 +251,7 @@
             },
             "firefox": {
               "version_added": "22",
-              "notes": "Works on Mac OSX. Support for Windows 7 <a href='https://bugzil.la/754199'in progress</a>."
+              "version_removed": "60"
             },
             "firefox_android": {
               "version_added": "15"

--- a/api/Window.json
+++ b/api/Window.json
@@ -3231,10 +3231,24 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "49",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.manifest.onappinstall",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "49",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.manifest.onappinstall",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": null
@@ -3255,7 +3269,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -600,7 +600,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -665,7 +665,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Window.json
+++ b/api/Window.json
@@ -742,7 +742,8 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": "15"
+              "version_added": "15",
+              "version_removed": "60"
             },
             "ie": {
               "version_added": false

--- a/api/Window.json
+++ b/api/Window.json
@@ -779,7 +779,13 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "API Available on all platforms behind a flag, but currently only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getVRDisplays'><code>Navigator.getVRDisplays()</code></a> is invoked)."
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": true,
@@ -834,11 +840,20 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "API Available on all platforms behind a flag, but currently only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getVRDisplays'><code>Navigator.getVRDisplays()</code></a> is invoked)."
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Currently only supported by Google Daydream."
+              "version_added": "56",
+              "notes": [
+                "Chrome for Android 56 supports only Google Daydream View.",
+                "Chrome for Android 57 adds support for Google Cardboard."
+              ]
             },
             "edge": {
               "version_added": null
@@ -1092,8 +1107,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplaypresentchange",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "API Available on all platforms behind a flag, but currently only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getVRDisplays'><code>Navigator.getVRDisplays()</code></a> is invoked)."
+              "version_added": "65",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": true,

--- a/api/Window.json
+++ b/api/Window.json
@@ -3263,7 +3263,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": null
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -233,6 +233,57 @@
           }
         }
       },
+      "ondevicelight": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ondevicelight",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "convertPointFromNodeToPage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/convertPointFromNodeToPage",
@@ -333,6 +384,771 @@
           "status": {
             "experimental": false,
             "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "ondeviceorientationabsolute": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ondeviceorientationabsolute",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ondeviceproximity": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ondeviceproximity",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ongamepadconnected": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ongamepadconnected",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ongamepaddisconnected": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ongamepaddisconnected",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "oninput": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/oninput",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onmozbeforepaint": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onmozbeforepaint",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onpaint": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onpaint",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onuserproximity": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onuserproximity",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onvrdisplayconnect": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplayconnect",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onvrdisplaydisconnect": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplaydisconnect",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onvrdisplayactivate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplayactivate",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onvrdisplaydeactivate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplaydeactivate",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onvrdisplayblur": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplayblur",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onvrdisplayfocus": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplayfocus",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onvrdisplaypresentchange": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplaypresentchange",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/Window.json
+++ b/api/Window.json
@@ -290,12 +290,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/convertPointFromNodeToPage",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Constructor supported. ------------- lucian95: What does that mean? See reference page. ------------"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Constructor supported. ------------- lucian95: What does that mean? See reference page. ------------"
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -329,8 +327,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "Constructor supported. ------------- lucian95: What does that mean? See reference page. ------------"
+              "version_added": true
             }
           },
           "status": {
@@ -347,10 +344,7 @@
             "chrome": [
               {
                 "version_added": "50",
-                "notes": [
-                  "For absolute values, use <code>ondeviceorientationabsolute</code>",
-                  "Constructor supported. ------------- lucian95: What does that mean? See reference page. ------------"
-                ]
+                "notes": "For absolute values, use <code>ondeviceorientationabsolute</code>."
               },
               {
                 "version_added": "7",
@@ -361,10 +355,7 @@
             "chrome_android": [
               {
                 "version_added": "50",
-                "notes": [
-                  "For absolute values, use <code>ondeviceorientationabsolute</code>",
-                  "Constructor supported. ------------- lucian95: What does that mean? See reference page. ------------"
-                ]
+                "notes": "For absolute values, use <code>ondeviceorientationabsolute</code>."
               },
               {
                 "version_added": true,
@@ -420,10 +411,7 @@
             "webview_android": [
               {
                 "version_added": "50",
-                "notes": [
-                  "For absolute values, use <code>ondeviceorientationabsolute</code>",
-                  "Constructor supported. ------------- lucian95: What does that mean? See reference page. ------------"
-                ]
+                "notes": "For absolute values, use <code>ondeviceorientationabsolute</code>."
               },
               {
                 "version_added": true,

--- a/api/Window.json
+++ b/api/Window.json
@@ -778,10 +778,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplayconnect",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false,
+              "notes": "API Available on all platforms behind a flag, but currently only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <a href='https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getVRDisplays'><code>Navigator.getVRDisplays()</code></a> is invoked)."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Currently only supported by Google Daydream."
             },
             "edge": {
               "version_added": null
@@ -790,35 +792,37 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is available in <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>Firefox Nigthly</a>."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Supported on Samsung Internet for GearVR."
             },
             "webview_android": {
               "version_added": null
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -829,10 +833,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplaydisconnect",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false,
+              "notes": "API Available on all platforms behind a flag, but currently only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <a href='https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getVRDisplays'><code>Navigator.getVRDisplays()</code></a> is invoked)."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Currently only supported by Google Daydream."
             },
             "edge": {
               "version_added": null
@@ -841,35 +847,37 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is available in <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>Firefox Nigthly</a>."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Supported on Samsung Internet for GearVR."
             },
             "webview_android": {
               "version_added": null
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -880,47 +888,47 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplayactivate",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -931,47 +939,47 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplaydeactivate",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -982,47 +990,47 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplayblur",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -1033,47 +1041,47 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplayfocus",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -1084,10 +1092,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplaypresentchange",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false,
+              "notes": "API Available on all platforms behind a flag, but currently only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <a href='https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getVRDisplays'><code>Navigator.getVRDisplays()</code></a> is invoked)."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Currently only supported by Google Daydream."
             },
             "edge": {
               "version_added": null
@@ -1096,35 +1106,37 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "55",
+              "notes": "Currently only Windows support is enabled by default. Mac support is available in <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>Firefox Nigthly</a>."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Supported on Samsung Internet for GearVR."
             },
             "webview_android": {
               "version_added": null
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Window.json
+++ b/api/Window.json
@@ -881,7 +881,10 @@
             },
             "chrome_android": {
               "version_added": true,
-              "notes": "Currently only supported by Google Daydream."
+              "notes": [
+                "Chrome for Android 56 supports only Google Daydream View.",
+                "Chrome for Android 57 adds support for Google Cardboard."
+              ]
             },
             "edge": {
               "version_added": null
@@ -1119,8 +1122,11 @@
               ]
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Currently only supported by Google Daydream."
+              "version_added": "56",
+              "notes": [
+                "Chrome for Android 56 supports only Google Daydream View.",
+                "Chrome for Android 57 adds support for Google Cardboard."
+              ]
             },
             "edge": {
               "version_added": null

--- a/api/Window.json
+++ b/api/Window.json
@@ -773,197 +773,9 @@
           }
         }
       },
-      "onvrdisplayconnect": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplayconnect",
-          "support": {
-            "chrome": {
-              "version_added": false,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "WebVR",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": true,
-              "notes": "Currently only supported by Google Daydream."
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": [
-              {
-                "version_added": "63",
-                "notes": "Only Windows and macOS support is enabled."
-              },
-              {
-                "version_added": "55",
-                "notes": "Only Windows support is enabled."
-              }
-            ],
-            "firefox_android": {
-              "version_added": "55"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Supported on Samsung Internet for GearVR."
-            },
-            "webview_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onvrdisplaydisconnect": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplaydisconnect",
-          "support": {
-            "chrome": {
-              "version_added": false,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "WebVR",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "56",
-              "notes": [
-                "Chrome for Android 56 supports only Google Daydream View.",
-                "Chrome for Android 57 adds support for Google Cardboard."
-              ]
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": [
-              {
-                "version_added": "63",
-                "notes": "Only Windows and macOS support is enabled."
-              },
-              {
-                "version_added": "55",
-                "notes": "Only Windows support is enabled."
-              }
-            ],
-            "firefox_android": {
-              "version_added": "55"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Supported on Samsung Internet for GearVR."
-            },
-            "webview_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "onvrdisplayactivate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplayactivate",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "edge_mobile": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "55"
-            },
-            "firefox_android": {
-              "version_added": "55"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onvrdisplaydeactivate": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplaydeactivate",
           "support": {
             "chrome": {
               "version_added": false
@@ -1054,6 +866,194 @@
             },
             "webview_android": {
               "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onvrdisplayconnect": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplayconnect",
+          "support": {
+            "chrome": {
+              "version_added": false,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": "Currently only supported by Google Daydream."
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "63",
+                "notes": "Only Windows and macOS support is enabled."
+              },
+              {
+                "version_added": "55",
+                "notes": "Only Windows support is enabled."
+              }
+            ],
+            "firefox_android": {
+              "version_added": "55"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Supported on Samsung Internet for GearVR."
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onvrdisplaydeactivate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplaydeactivate",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onvrdisplaydisconnect": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplaydisconnect",
+          "support": {
+            "chrome": {
+              "version_added": false,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": "56",
+              "notes": [
+                "Chrome for Android 56 supports only Google Daydream View.",
+                "Chrome for Android 57 adds support for Google Cardboard."
+              ]
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "63",
+                "notes": "Only Windows and macOS support is enabled."
+              },
+              {
+                "version_added": "55",
+                "notes": "Only Windows support is enabled."
+              }
+            ],
+            "firefox_android": {
+              "version_added": "55"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Supported on Samsung Internet for GearVR."
+            },
+            "webview_android": {
+              "version_added": null
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -779,7 +779,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "API Available on all platforms behind a flag, but currently only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <a href='https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getVRDisplays'><code>Navigator.getVRDisplays()</code></a> is invoked)."
+              "notes": "API Available on all platforms behind a flag, but currently only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getVRDisplays'><code>Navigator.getVRDisplays()</code></a> is invoked)."
             },
             "chrome_android": {
               "version_added": true,
@@ -834,7 +834,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "API Available on all platforms behind a flag, but currently only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <a href='https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getVRDisplays'><code>Navigator.getVRDisplays()</code></a> is invoked)."
+              "notes": "API Available on all platforms behind a flag, but currently only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getVRDisplays'><code>Navigator.getVRDisplays()</code></a> is invoked)."
             },
             "chrome_android": {
               "version_added": true,
@@ -1093,7 +1093,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "API Available on all platforms behind a flag, but currently only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <a href='https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getVRDisplays'><code>Navigator.getVRDisplays()</code></a> is invoked)."
+              "notes": "API Available on all platforms behind a flag, but currently only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getVRDisplays'><code>Navigator.getVRDisplays()</code></a> is invoked)."
             },
             "chrome_android": {
               "version_added": true,

--- a/api/Window.json
+++ b/api/Window.json
@@ -797,10 +797,16 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is available in <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>Firefox Nigthly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "63",
+                "notes": "Only Windows and macOS support is enabled."
+              },
+              {
+                "version_added": "55",
+                "notes": "Only Windows support is enabled."
+              }
+            ],
             "firefox_android": {
               "version_added": "55"
             },
@@ -861,10 +867,16 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is available in <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>Firefox Nigthly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "63",
+                "notes": "Only Windows and macOS support is enabled."
+              },
+              {
+                "version_added": "55",
+                "notes": "Only Windows support is enabled."
+              }
+            ],
             "firefox_android": {
               "version_added": "55"
             },
@@ -1126,10 +1138,16 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is available in <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>Firefox Nigthly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "63",
+                "notes": "Only Windows and macOS support is enabled."
+              },
+              {
+                "version_added": "55",
+                "notes": "Only Windows support is enabled."
+              }
+            ],
             "firefox_android": {
               "version_added": "55"
             },

--- a/api/Window.json
+++ b/api/Window.json
@@ -507,7 +507,8 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "60"
             },
             "firefox_android": {
               "version_added": "15"

--- a/api/Window.json
+++ b/api/Window.json
@@ -495,10 +495,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ondeviceproximity",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -507,31 +507,31 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -545,48 +545,62 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ongamepadconnected",
           "support": {
-            "chrome": {
-              "version_added": null
-            },
+            "chrome": [
+              {
+                "version_added": "35"
+              },
+              {
+                "version_added": "21",
+                "version_removed": "35",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "29"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "32"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "22",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -596,150 +610,62 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ongamepaddisconnected",
           "support": {
-            "chrome": {
-              "version_added": null
-            },
+            "chrome": [
+              {
+                "version_added": "35"
+              },
+              {
+                "version_added": "21",
+                "version_removed": "35",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "29"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "32"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "22",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "oninput": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/oninput",
-          "support": {
-            "chrome": {
-              "version_added": null
-            },
-            "chrome_android": {
-              "version_added": null
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onmozbeforepaint": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onmozbeforepaint",
-          "support": {
-            "chrome": {
-              "version_added": null
-            },
-            "chrome_android": {
-              "version_added": null
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -762,10 +688,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null
@@ -791,7 +717,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -801,10 +727,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onuserproximity",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -813,31 +739,31 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -456,10 +456,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null
@@ -676,10 +676,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onpaint",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -712,7 +712,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -1184,7 +1184,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -3178,10 +3178,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onappinstalled",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null

--- a/api/Window.json
+++ b/api/Window.json
@@ -238,43 +238,44 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ondevicelight",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "22",
+              "notes": "Works on Mac OSX. Support for Windows 7 <a href='https://bugzil.la/754199'in progress</a>."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -289,22 +290,24 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/convertPointFromNodeToPage",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Constructor supported. ------------- lucian95: What does that mean? See reference page. ------------"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Constructor supported. ------------- lucian95: What does that mean? See reference page. ------------"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "6"
             },
             "ie": {
               "version_added": null
@@ -313,7 +316,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": true,
@@ -326,7 +329,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Constructor supported. ------------- lucian95: What does that mean? See reference page. ------------"
             }
           },
           "status": {
@@ -340,24 +344,60 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/convertPointFromPageToNode",
           "support": {
-            "chrome": {
-              "version_added": null
-            },
-            "chrome_android": {
-              "version_added": null
-            },
+            "chrome": [
+              {
+                "version_added": "50",
+                "notes": [
+                  "For absolute values, use <code>ondeviceorientationabsolute</code>",
+                  "Constructor supported. ------------- lucian95: What does that mean? See reference page. ------------"
+                ]
+              },
+              {
+                "version_added": "7",
+                "version_removed": "50",
+                "notes": "Provided absolute values, not relative."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "50",
+                "notes": [
+                  "For absolute values, use <code>ondeviceorientationabsolute</code>",
+                  "Constructor supported. ------------- lucian95: What does that mean? See reference page. ------------"
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "50",
+                "notes": "Provided absolute values, not relative."
+              }
+            ],
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
+            "firefox": [
+              {
+                "version_added": "6"
+              },
+              {
+                "version_added": "3.6",
+                "version_removed": "6",
+                "alternative_name": "onmozorientation"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "6"
+              },
+              {
+                "version_added": "4",
+                "version_removed": "6",
+                "alternative_name": "onmozorientation"
+              }
+            ],
             "ie": {
               "version_added": null
             },
@@ -365,7 +405,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": true,
@@ -377,9 +417,20 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": {
-              "version_added": null
-            }
+            "webview_android": [
+              {
+                "version_added": "50",
+                "notes": [
+                  "For absolute values, use <code>ondeviceorientationabsolute</code>",
+                  "Constructor supported. ------------- lucian95: What does that mean? See reference page. ------------"
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "50",
+                "notes": "Provided absolute values, not relative."
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -393,10 +444,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ondeviceorientationabsolute",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "50"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "50"
             },
             "edge": {
               "version_added": null
@@ -429,12 +480,12 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "50"
             }
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
[Window event handlers](https://developer.mozilla.org/en-US/docs/Web/API/Window#Event_handlers)
Only included event handlers defined on `Window`, not `GlobalEventHandlers` or `WindowEventHandlers`.