### PR TITLE
Move proxy settings property from browserSettings to proxy

### DIFF
--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -200,28 +200,6 @@
             }
           }
         },
-        "proxyConfig": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/proxyConfig",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "59"
-              },
-              "firefox_android": {
-                "version_added": "59"
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
-        },
         "webNotificationsDisabled": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/webNotificationsDisabled",

--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -136,6 +136,34 @@
             }
           }
         },
+        "settings": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/proxy/settings",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "notes": [
+                  "In version 59, this property was listed as <code>proxyConfig</code> in the <code>browserSettings</code> namespace, but had a bug that made it mostly unusable."
+                ],
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "notes": [
+                  "In version 59, this property was listed as <code>proxyConfig</code> in the <code>browserSettings</code> namespace, but had a bug that made it mostly unusable."
+                ],
+                "version_added": "60"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "unregister": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/proxy/unregister",


### PR DESCRIPTION
In Firefox 59 `proxyConfig` was added to the `browserSettings` namespace, but contained a serious bug that made it basically unusable. In Firefox 60 the bug was fixed and the property was renamed and moved to become `proxy.settings`.

This PR moves the data for it. I decided to capture the history in a note rather than using `alternative_name`, since it was never actually usable under the old name.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1455755 for a bit more context.