### PR TITLE
Add a name property to the browser schema.

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -1,6 +1,7 @@
 {
   "browsers": {
     "chrome": {
+      "name": "Chrome",
       "releases": {
         "1": {
           "release_date": "2008-12-11",

--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -1,6 +1,7 @@
 {
   "browsers": {
     "edge": {
+      "name": "Edge",
       "releases": {
         "12": {
           "release_date": "2015-07-28",

--- a/browsers/edge_mobile.json
+++ b/browsers/edge_mobile.json
@@ -1,6 +1,7 @@
 {
   "browsers": {
     "edge_mobile": {
+      "name": "Edge Mobile",
       "releases": {
         "12": {
           "release_date": "2015-07-15",

--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -1,6 +1,7 @@
 {
   "browsers": {
     "firefox": {
+      "name": "Firefox",
       "releases": {
         "1": {
           "release_date": "2004-11-09",

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -1,6 +1,7 @@
 {
   "browsers": {
     "firefox_android": {
+      "name": "Firefox Android",
       "releases": {
         "4": {
           "release_date": "2011-03-29",

--- a/browsers/ie.json
+++ b/browsers/ie.json
@@ -1,6 +1,7 @@
 {
   "browsers": {
     "ie": {
+      "name": "Internet Explorer",
       "releases": {
         "1": {
           "release_date": "1995-08-16",

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -1,6 +1,7 @@
 {
   "browsers": {
     "nodejs": {
+      "name": "Node.js",
       "releases": {
         "0.10": {
           "release_date": "2013-03-11",

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -1,6 +1,7 @@
 {
   "browsers": {
     "opera": {
+      "name": "Opera",
       "releases": {
         "2": {
           "release_date": "1996-07-14",

--- a/browsers/qq_android.json
+++ b/browsers/qq_android.json
@@ -1,6 +1,7 @@
 {
   "browsers": {
     "qq_android": {
+      "name": "QQ Browser",
       "releases": {
         "7.2.1": {
           "release_date": "2017-01-18",

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -1,6 +1,7 @@
 {
   "browsers": {
     "safari": {
+      "name": "Safari",
       "releases": {
         "1": {
           "release_date": "2003-06-23",

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -1,6 +1,7 @@
 {
   "browsers": {
     "safari_ios": {
+      "name": "iOS Safari",
       "releases": {
         "1": {
           "status": "retired"

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -1,6 +1,7 @@
 {
   "browsers": {
     "samsunginternet_android": {
+      "name": "Samsung Internet",
       "releases": {
         "1.0": {
           "release_date": "2013-04-27",

--- a/browsers/uc_android.json
+++ b/browsers/uc_android.json
@@ -1,6 +1,7 @@
 {
   "browsers": {
     "uc_android": {
+      "name": "UC Browser",
       "releases": {
         "8.6.1.262": {
           "release_date": "2013-01-31",

--- a/browsers/uc_chinese_android.json
+++ b/browsers/uc_chinese_android.json
@@ -1,6 +1,7 @@
 {
   "browsers": {
     "uc_chinese_android": {
+      "name": "Chinese UC Browser",
       "releases": {
         "10.10.0.800": {
           "release_date": "2016-05-26",

--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -16,6 +16,7 @@ The file `firefox.json` is structured like this:
 {
   "browsers": {
     "firefox": {
+      "name": "Firefox",
       "releases": {
         "1.5": {
           "release_date": "2005-11-29",
@@ -30,6 +31,10 @@ The file `firefox.json` is structured like this:
 It contains an object with the property `browsers` which then contains an object with the browser identifier as the property name (`firefox`).
 
 Underneath, there is a `releases` object which will hold the various releases of a given browser by their release version number (`"1.5"`).
+
+### `name`
+
+The `name` string is an optional property which should use the browser brand name and avoid English words if possible, for example `"Firefox"`, `"Firefox Android"`, `"Safari"`, `"iOS Safari"`, etc.
 
 ### Release objects
 The release objects consist of the following properties:

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -30,13 +30,13 @@
     "browser_statement": {
       "type": "object",
       "properties": {
+        "name": { "type": "string" },
         "releases": {
           "type": "object",
           "additionalProperties": { "$ref": "#/definitions/release_statement" }
-        },
-        "name": { "type": "string" }
+        }
       },
-      "required": ["releases"],
+      "required": ["name", "releases"],
       "additionalProperties": false
     },
 

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -33,7 +33,8 @@
         "releases": {
           "type": "object",
           "additionalProperties": { "$ref": "#/definitions/release_statement" }
-        }
+        },
+        "name": { "type": "string" }
       },
       "required": ["releases"],
       "additionalProperties": false


### PR DESCRIPTION
Resolves #1791.

This adds a `name` property to the browser schema and adds names for all the browser JSON files except a few that I wasn't sure about.

Right now the property is optional, I'd argue we should probably make it required if we can decide on names for the remaining browser files.