### PR TITLE
Add data for browserSettings.useDocumentFonts

### DIFF
--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -222,6 +222,28 @@
             }
           }
         },
+        "useDocumentFonts": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/useDocumentFonts",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "61"
+              },
+              "firefox_android": {
+                "version_added": "61"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "webNotificationsDisabled": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/webNotificationsDisabled",


### PR DESCRIPTION
New browser setting in Firefox 61:

https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browserSettings/useDocumentFonts
https://bugzilla.mozilla.org/show_bug.cgi?id=1400805