### PR TITLE
tabs.hide is enabled by default now

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1448,16 +1448,22 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "extensions.webextensions.tabhide.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "61"
+                },
+                {
+                  "version_added": "59",
+                  "version_removed": "61",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "extensions.webextensions.tabhide.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": false
               },


### PR DESCRIPTION
-> https://bugzilla.mozilla.org/show_bug.cgi?id=1455040

The data is trying to say: it was behind a pref in 59 and 60, then from 61 it's not behind a pref any more.