### PR TITLE
Update onRequestFinished note for Firefox 61

### DIFF
--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -191,12 +191,18 @@
                 "edge": {
                   "version_added": false
                 },
-                "firefox": {
-                  "notes": [
-                    "This event will only start firing after the user has activated the browser's network panel at least once."
-                  ],
-                  "version_added": "60"
-                },
+                "firefox": [
+                  {
+                    "version_added": "61"
+                  },
+                  {
+                    "notes": [
+                      "This event will only start firing after the user has activated the browser's network panel at least once."
+                    ],
+                    "version_added": "60",
+                    "version_removed": "61"
+                  }
+                ],
                 "firefox_android": {
                   "version_added": false
                 },


### PR DESCRIPTION
Now that https://bugzilla.mozilla.org/show_bug.cgi?id=1436665 has landed (in Firefox 61), the condition noted for devtools.network.onRequestFinished isn't applicable any more.

See also https://bugzilla.mozilla.org/show_bug.cgi?id=1311171#c82.