### PR TITLE
Note permissions.request issues

### DIFF
--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -144,18 +144,38 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "55",
-                "notes": [
-                  "The user will be prompted again for permissions that have been previously granted and then removed."
-                ]
-              },
-              "firefox_android": {
-                "version_added": "55",
-                "notes": [
-                  "The user will be prompted again for permissions that have been previously granted and then removed."
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "55",
+                  "notes": [
+                    "The user will be prompted again for permissions that have been previously granted and then removed.",
+                    "It's not possible to request permissions from a popup or a sidebar document."
+                  ]
+                },
+                {
+                  "version_added": "56",
+                  "version_removed": "61",
+                  "notes": [
+                    "It's not possible to request permissions from an options page that's embedded in about:addons. To request permissions from an options page, set the <code>open_in_tab</code> property in the <code>options_ui</code> manifest key, so the options page opens in its own tab."
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "55",
+                  "notes": [
+                    "The user will be prompted again for permissions that have been previously granted and then removed.",
+                    "It's not possible to request permissions from a popup or a sidebar document."
+                  ]
+                },
+                {
+                  "version_added": "56",
+                  "version_removed": "61",
+                  "notes": [
+                    "It's not possible to request permissions from an options page that's embedded in about:addons. To request permissions from an options page, set the <code>open_in_tab</code> property in the <code>options_ui</code> manifest key, so the options page opens in its own tab."
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": true
               }


### PR DESCRIPTION
What this tries to say:

* from Firefox 55 onwards, code running inside popups and sidebar documents aren't able to request optional permissions
* from Firefox 56-61, code running inside options pages aren't able to request optional permissions, *only when they are embedded in about:addons* (which is the default). The workaround is to specify `open_in_tab` in the [`options_ui` manifest key](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/options_ui), which means the options page gets its own tab and the request will work.
* from Firefox 61 onwards this is fixed.

See also: https://bugzilla.mozilla.org/show_bug.cgi?id=1382953