### PR TITLE
Added notes about clearing tab-specific data

### DIFF
--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -254,9 +254,18 @@
               "edge": {
                 "version_added": "14"
               },
-              "firefox": {
-                "version_added": "45"
-              },
+              "firefox": [
+                {
+                  "version_added": "45"
+                },
+                {
+                  "version_added": "45",
+                  "version_removed": "58",
+                  "notes": [
+                    "Tab-specific badge background color is not cleared when a new page is loaded."
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": false
               },
@@ -323,12 +332,18 @@
               "edge": {
                 "version_added": "14"
               },
-              "firefox": {
-                "version_added": "45",
-                "notes": [
-                  "On Firefox, the badge text is not cleared on navigation, see <a href='https://bugzil.la/1395074'>bug 1395074</a>."
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "45"
+                },
+                {
+                  "version_added": "45",
+                  "version_removed": "58",
+                  "notes": [
+                    "Tab-specific badge text is not cleared when a new page is loaded."
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": false
               },
@@ -373,9 +388,18 @@
               "edge": {
                 "version_added": "14"
               },
-              "firefox": {
-                "version_added": "45"
-              },
+              "firefox": [
+                {
+                  "version_added": "45"
+                },
+                {
+                  "version_added": "45",
+                  "version_removed": "58",
+                  "notes": [
+                    "Tab-specific icons are not cleared when a new page is loaded."
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": false
               },
@@ -438,12 +462,30 @@
               "edge": {
                 "version_added": "14"
               },
-              "firefox": {
-                "version_added": "45"
-              },
-              "firefox_android": {
-                "version_added": "57"
-              },
+              "firefox": [
+                {
+                  "version_added": "45"
+                },
+                {
+                  "version_added": "45",
+                  "version_removed": "58",
+                  "notes": [
+                    "Tab-specific popups are not cleared when a new page is loaded."
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "57"
+                },
+                {
+                  "version_added": "57",
+                  "version_removed": "58",
+                  "notes": [
+                    "Tab-specific popups are not cleared when a new page is loaded."
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": true
               }
@@ -482,12 +524,30 @@
               "edge": {
                 "version_added": "15"
               },
-              "firefox": {
-                "version_added": "45"
-              },
-              "firefox_android": {
-                "version_added": "55"
-              },
+              "firefox": [
+                {
+                  "version_added": "45"
+                },
+                {
+                  "version_added": "45",
+                  "version_removed": "58",
+                  "notes": [
+                    "Tab-specific titles are not cleared when a new page is loaded."
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "55"
+                },
+                {
+                  "version_added": "55",
+                  "version_removed": "58",
+                  "notes": [
+                    "Tab-specific titles are not cleared when a new page is loaded."
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": true
               }


### PR DESCRIPTION
The [browserAction API](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browserAction) lets you set various properties of a browser action: badge text, badge background color, icon, title, popup. You can set these for just a single tab or globally. If you set them for a single tab, the browser is supposed to reset them when the user navigates.

Firefox did not do this until version 58.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1395074 for more details.