### PR TITLE
Update theme data for Firefox 61

### DIFF
--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -590,7 +590,8 @@
                 "firefox": {
                   "version_added": "57",
                   "notes": [
-                    "Before version 59, the RGB array form was not supported for this property."
+                    "Before version 59, the RGB array form was not supported for this property.",
+                    "Before version 61, this did not set the \"find\" bar's color."
                   ]
                 },
                 "firefox_android": {
@@ -638,7 +639,8 @@
                 "firefox": {
                   "version_added": "57",
                   "notes": [
-                    "Before version 59, the RGB array form was not supported for this property."
+                    "Before version 59, the RGB array form was not supported for this property.",
+                    "Before version 61, this did not set the \"find\" field's background color."
                   ]
                 },
                 "firefox_android": {
@@ -660,7 +662,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "59"
+                  "version_added": "59",
+                  "notes": [
+                    "Before version 61, this did not set the \"find\" bar's border color."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": false
@@ -756,7 +761,8 @@
                 "firefox": {
                   "version_added": "57",
                   "notes": [
-                    "Before version 59, the RGB array form was not supported for this property."
+                    "Before version 59, the RGB array form was not supported for this property.",
+                    "Before version 61, this did not set the \"find\" bar's field text color."
                   ]
                 },
                 "firefox_android": {
@@ -801,7 +807,8 @@
                 "firefox": {
                   "version_added": "57",
                   "notes": [
-                    "Before version 59, the RGB array form was not supported for this property."
+                    "Before version 59, the RGB array form was not supported for this property.",
+                    "Before version 61, this did not set the \"find\" bar's text color."
                   ]
                 },
                 "firefox_android": {

--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -591,7 +591,7 @@
                   "version_added": "57",
                   "notes": [
                     "Before version 59, the RGB array form was not supported for this property.",
-                    "Before version 61, this did not set the \"find\" bar's color."
+                    "Before version 61, this did not set the \"Find\" bar's color."
                   ]
                 },
                 "firefox_android": {
@@ -640,7 +640,7 @@
                   "version_added": "57",
                   "notes": [
                     "Before version 59, the RGB array form was not supported for this property.",
-                    "Before version 61, this did not set the \"find\" field's background color."
+                    "Before version 61, this did not set the \"Find\" field's background color."
                   ]
                 },
                 "firefox_android": {
@@ -664,7 +664,7 @@
                 "firefox": {
                   "version_added": "59",
                   "notes": [
-                    "Before version 61, this did not set the \"find\" bar's border color."
+                    "Before version 61, this did not set the \"Find\" field's border color."
                   ]
                 },
                 "firefox_android": {
@@ -762,7 +762,7 @@
                   "version_added": "57",
                   "notes": [
                     "Before version 59, the RGB array form was not supported for this property.",
-                    "Before version 61, this did not set the \"find\" bar's field text color."
+                    "Before version 61, this did not set the \"Find\" field's text color."
                   ]
                 },
                 "firefox_android": {
@@ -808,7 +808,7 @@
                   "version_added": "57",
                   "notes": [
                     "Before version 59, the RGB array form was not supported for this property.",
-                    "Before version 61, this did not set the \"find\" bar's text color."
+                    "Before version 61, this did not set the \"Find\" bar's text color."
                   ]
                 },
                 "firefox_android": {


### PR DESCRIPTION
Firefox 61 updated the following sub-properties of [`theme.colors`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/theme#colors) to make them set colors of the "Find" bar as well as the browser toolbar.

```
toolbar
toolbar_text
toolbar_field
toolbar_field_text
toolbar_field_border
```

More details: https://bugzilla.mozilla.org/show_bug.cgi?id=1418605

I wasn't really sure about the best way to capture this. Up till now I've just done this kind of stuff in `"notes"`, e.g.

```
"notes" : [
  "Before version 61, it usually exploded."
]
```

But in the most recent PRs I've made here I've used explicit version ranges for this, like:

```
[
  {
    "version_added": "55"
  },
  {
    "version_added": "55",
    "version_removed": "61"
    "notes": "It usually exploded."
  }
]
```
I hadn't thought before about using version ranges for notes. I guess maybe this is better since it is more structured, although it makes the data more complex. 

But then in this file there were already a lot of notes about versions, so I just went with what was there, rather than rewrite everything.




