### PR TITLE
Update toLocaleString compat in Firefox Android

### DIFF
--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2616,7 +2616,7 @@
                   "version_added": "29"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "ie": {
                   "version_added": "11"
@@ -2669,7 +2669,7 @@
                   "version_added": "29"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "ie": {
                   "version_added": "11"
@@ -2886,7 +2886,7 @@
                   "version_added": "29"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "ie": {
                   "version_added": "11"
@@ -2939,7 +2939,7 @@
                   "version_added": "29"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "ie": {
                   "version_added": "11"
@@ -3100,7 +3100,7 @@
                   "version_added": "29"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "ie": {
                   "version_added": "11"
@@ -3153,7 +3153,7 @@
                   "version_added": "29"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "ie": {
                   "version_added": "11"


### PR DESCRIPTION
Fixes #2039 

Updates the version of Firefox Android that added support for `locales` and `options` in the `Date.prototype.toLocale(Date/Time)String` methods.