### PR TITLE
Update tabs.show as well

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -2791,16 +2791,22 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "extensions.webextensions.tabhide.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "61"
+                },
+                {
+                  "version_added": "59",
+                  "version_removed": "61",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "extensions.webextensions.tabhide.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": false
               },


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1455040, I updated [tabs.hide()](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/hide), but missed the corresponding [tabs.show()](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/show). Sigh.