### PR TITLE
 Update BackgroundSync

### DIFF
--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -382,46 +382,34 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/periodicSync",
           "support": {
             "webview_android": {
-              "version_added": "40"
+              "version_added": false
             },
             "chrome": {
-              "version_added": "40"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": false
             },
-            "edge": [
-              {
-                "version_added": "16",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable service workers"
-                  }
-                ]
-              },
-              {
-                "version_added": "17"
-              }
-            ],
+            "edge": {
+              "version_added": false
+            },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "Service workers (and Push) have been disabled in the Firefox 45 and 52 Extended Support Releases (ESR)."
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "27"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "27"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -430,7 +418,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": false
             }
           },
           "status": {
@@ -516,29 +504,17 @@
             "chrome_android": {
               "version_added": "49"
             },
-            "edge": [
-              {
-                "version_added": "16",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable service workers"
-                  }
-                ]
-              },
-              {
-                "version_added": "17"
-              }
-            ],
+            "edge": {
+              "version_added": null
+            },
             "edge_mobile": {
               "version_added": null
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "Service workers (and Push) have been disabled in the Firefox 45 and 52 Extended Support Releases (ESR)."
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Only chrome partial(one-off background sync) support.

https://github.com/WICG/BackgroundSync/blob/master/explainer.md#periodic-synchronization-in-design
https://www.chromestatus.com/feature/6170807885627392
https://bugzilla.mozilla.org/show_bug.cgi?id=1217544
