### PR TITLE
Correct Opera WebExtension `sidebarAction` API support information

### DIFF
--- a/webextensions/api/sidebarAction.json
+++ b/webextensions/api/sidebarAction.json
@@ -19,7 +19,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "30"
               }
             }
           }
@@ -63,7 +63,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "30"
               }
             }
           },
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "30"
               }
             }
           },
@@ -197,7 +197,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "30"
               }
             }
           },
@@ -264,7 +264,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "30"
               }
             }
           },
@@ -331,7 +331,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "30"
               }
             }
           },

--- a/webextensions/manifest/sidebar_action.json
+++ b/webextensions/manifest/sidebar_action.json
@@ -18,7 +18,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "30"
             }
           }
         },


### PR DESCRIPTION
Opera added support for the [`sidebarAction` API](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/sidebarAction) in [version 30](https://dev.opera.com/extensions/sidebar-action-api/).