### PR TITLE
Migrate data for interaction @media features

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -421,6 +421,57 @@
               "deprecated": false
             }
           }
+        },
+        "pointer": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/pointer",
+            "description": "<code>pointer</code> media feature",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "41"
+              },
+              "chrome_android": {
+                "version_added": "50"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "28"
+              },
+              "opera_android": {
+                "version_added": "28"
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9.2"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -205,6 +205,58 @@
             }
           }
         },
+        "hover": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/hover",
+            "description": "<code>hover</code> media feature",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "38",
+                "notes": "Before Chrome 41, the implementation was buggy and reported <code>(hover: none)</code> on non-touch-based computers with a mouse/trackpad. See <a href='https://crbug.com/441613'>bug 441613</a>."
+              },
+              "chrome_android": {
+                "version_added": "50"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "28"
+              },
+              "opera_android": {
+                "version_added": "28"
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9.2"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "resolution_media_feature": {
           "__compat": {
             "description": "<code>resolution</code> media feature",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -154,6 +154,57 @@
             }
           }
         },
+        "any-pointer": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/any-pointer",
+            "description": "<code>any-pointer</code> media feature",
+            "support": {
+              "webview_android": {
+                "version_added": "41"
+              },
+              "chrome": {
+                "version_added": "41"
+              },
+              "chrome_android": {
+                "version_added": "41"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "28"
+              },
+              "opera_android": {
+                "version_added": "28"
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9.2"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "resolution_media_feature": {
           "__compat": {
             "description": "<code>resolution</code> media feature",


### PR DESCRIPTION
This PR adds data for interaction `@media` features:

- [`any-pointer`](https://developer.mozilla.org/docs/Web/CSS/@media/any-pointer)
- [`hover`](https://developer.mozilla.org/docs/Web/CSS/@media/hover)
- [`pointer`](https://developer.mozilla.org/docs/Web/CSS/@media/pointer)

There is already an open PR, #1977, for `any-hover`.

This is the first of several changes I have queued up to address #2009. I've broken them up by topic to keep the PR size manageable.

Finally, there are going to be some oddities with sorting and name consistency. I figured it'd be easier to fix those when there's not any open PRs on this file. I'll open a PR for that as soon as practical.