### PR TITLE
SameSite supported in Firefox 60.

### DIFF
--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -224,12 +224,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/795346'>bug 795346</a> on Bugzilla."
+                "version_added": "60"
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/795346'>bug 795346</a> on Bugzilla."
+                "version_added": "60"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Hope I got this right :)

https://blog.mozilla.org/security/2018/04/24/same-site-cookies-in-firefox-60/