### PR TITLE
Add compat data for WritableStreamDefaultWriter.

### DIFF
--- a/api/WritableStreamDefaultWriter.json
+++ b/api/WritableStreamDefaultWriter.json
@@ -1,0 +1,437 @@
+{
+  "api": {
+    "WritableStreamDefaultWriter": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter",
+        "support": {
+          "chrome": {
+            "version_added": "59"
+          },
+          "chrome_android": {
+            "version_added": "59"
+          },
+          "edge": {
+            "version_added": "16"
+          },
+          "edge_mobile": {
+            "version_added": "16"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "46"
+          },
+          "opera_android": {
+            "version_added": "46"
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          },
+          "webview_android": {
+            "version_added": "59"
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "WritableStreamDefaultWriter": {
+        "__compat": {
+          "description": "<code>WritableStreamDefaultWriter()</code> constructor.",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/WritableStreamDefaultWriter",
+          "support": {
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "46"
+            },
+            "opera_android": {
+              "version_added": "46"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "59"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "closed": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/closed",
+          "support": {
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "46"
+            },
+            "opera_android": {
+              "version_added": "46"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "59"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "desiredSize": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/desiredSize",
+          "support": {
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "46"
+            },
+            "opera_android": {
+              "version_added": "46"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "59"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ready": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/ready",
+          "support": {
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "46"
+            },
+            "opera_android": {
+              "version_added": "46"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "59"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "abort": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/abort",
+          "support": {
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "46"
+            },
+            "opera_android": {
+              "version_added": "46"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "59"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "close": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/close",
+          "support": {
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "46"
+            },
+            "opera_android": {
+              "version_added": "46"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "59"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "releaseLock": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/releaseLock",
+          "support": {
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "46"
+            },
+            "opera_android": {
+              "version_added": "46"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "59"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "write": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/write",
+          "support": {
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "46"
+            },
+            "opera_android": {
+              "version_added": "46"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "59"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
`WritableStream` compat data was added in #862, this adds data for `WritableStreamDefaultWriter` and its constructor, methods, and properties.

- [`WritableStreamDefaultWriter`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter)
- [Constructor](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter/WritableStreamDefaultWriter)
- [`closed` property](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter/closed)
- [`desiredSize` property](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter/desiredSize)
- [`ready` property](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter/ready)
- [`abort` method](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter/abort)
- [`close` method](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter/close)
- [`releaseLock` method](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter/releaseLock)
- [`write` method](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter/write)

Some of the support info is from `WritableStream.json` and other data is from [Chrome Status](https://www.chromestatus.com/feature/5928498656968704). The original compat table for [`WritableStreamDefaultWriter`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter#Browser_Compatibility) is a bit off for Chrome and Android versions, compared to the data on Chrome Status. I chose to use Chrome Status' version info instead, where possible.