### PR TITLE
Fix a few feature hierarchy mistakes.

### DIFF
--- a/api/SpeechRecognitionAlternative.json
+++ b/api/SpeechRecognitionAlternative.json
@@ -52,113 +52,113 @@
           "standard_track": true,
           "deprecated": false
         }
-      }
-    },
-    "confidence": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionAlternative/confidence",
-        "support": {
-          "chrome": {
-            "prefix": "webkit",
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+      },
+      "confidence": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionAlternative/confidence",
+          "support": {
+            "chrome": {
+              "prefix": "webkit",
+              "version_added": "33",
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "chrome_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            }
           },
-          "chrome_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
-          },
-          "edge": {
-            "version_added": null
-          },
-          "edge_mobile": {
-            "version_added": null
-          },
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": false
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
-          },
-          "webview_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "transcript": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionAlternative/transcript",
-        "support": {
-          "chrome": {
-            "prefix": "webkit",
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+      },
+      "transcript": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionAlternative/transcript",
+          "support": {
+            "chrome": {
+              "prefix": "webkit",
+              "version_added": "33",
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "chrome_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            }
           },
-          "chrome_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
-          },
-          "edge": {
-            "version_added": null
-          },
-          "edge_mobile": {
-            "version_added": null
-          },
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": false
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
-          },
-          "webview_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
         }
       }
     }

--- a/api/SpeechRecognitionError.json
+++ b/api/SpeechRecognitionError.json
@@ -52,113 +52,113 @@
           "standard_track": true,
           "deprecated": false
         }
-      }
-    },
-    "error": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionError/error",
-        "support": {
-          "chrome": {
-            "prefix": "webkit",
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+      },
+      "error": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionError/error",
+          "support": {
+            "chrome": {
+              "prefix": "webkit",
+              "version_added": "33",
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "chrome_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            }
           },
-          "chrome_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
-          },
-          "edge": {
-            "version_added": null
-          },
-          "edge_mobile": {
-            "version_added": null
-          },
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": false
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
-          },
-          "webview_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "message": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionError/message",
-        "support": {
-          "chrome": {
-            "prefix": "webkit",
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+      },
+      "message": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionError/message",
+          "support": {
+            "chrome": {
+              "prefix": "webkit",
+              "version_added": "33",
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "chrome_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            }
           },
-          "chrome_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
-          },
-          "edge": {
-            "version_added": null
-          },
-          "edge_mobile": {
-            "version_added": null
-          },
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": false
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
-          },
-          "webview_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
         }
       }
     }

--- a/api/SpeechRecognitionEvent.json
+++ b/api/SpeechRecognitionEvent.json
@@ -52,221 +52,221 @@
           "standard_track": true,
           "deprecated": false
         }
-      }
-    },
-    "emma": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/emma",
-        "support": {
-          "chrome": {
-            "prefix": "webkit",
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+      },
+      "emma": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/emma",
+          "support": {
+            "chrome": {
+              "prefix": "webkit",
+              "version_added": "33",
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "chrome_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            }
           },
-          "chrome_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
-          },
-          "edge": {
-            "version_added": null
-          },
-          "edge_mobile": {
-            "version_added": null
-          },
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": false
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
-          },
-          "webview_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "interpretation": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/interpretation",
-        "support": {
-          "chrome": {
-            "prefix": "webkit",
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+      },
+      "interpretation": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/interpretation",
+          "support": {
+            "chrome": {
+              "prefix": "webkit",
+              "version_added": "33",
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "chrome_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            }
           },
-          "chrome_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
-          },
-          "edge": {
-            "version_added": null
-          },
-          "edge_mobile": {
-            "version_added": null
-          },
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": false
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
-          },
-          "webview_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "resultIndex": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/resultIndex",
-        "support": {
-          "chrome": {
-            "prefix": "webkit",
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+      },
+      "resultIndex": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/resultIndex",
+          "support": {
+            "chrome": {
+              "prefix": "webkit",
+              "version_added": "33",
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "chrome_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            }
           },
-          "chrome_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
-          },
-          "edge": {
-            "version_added": null
-          },
-          "edge_mobile": {
-            "version_added": null
-          },
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": false
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
-          },
-          "webview_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "results": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/results",
-        "support": {
-          "chrome": {
-            "prefix": "webkit",
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+      },
+      "results": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/results",
+          "support": {
+            "chrome": {
+              "prefix": "webkit",
+              "version_added": "33",
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "chrome_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            }
           },
-          "chrome_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
-          },
-          "edge": {
-            "version_added": null
-          },
-          "edge_mobile": {
-            "version_added": null
-          },
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": false
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
-          },
-          "webview_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
         }
       }
     }

--- a/api/SpeechRecognitionResult.json
+++ b/api/SpeechRecognitionResult.json
@@ -52,167 +52,167 @@
           "standard_track": true,
           "deprecated": false
         }
-      }
-    },
-    "isFinal": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResult/isFinal",
-        "support": {
-          "chrome": {
-            "prefix": "webkit",
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+      },
+      "isFinal": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResult/isFinal",
+          "support": {
+            "chrome": {
+              "prefix": "webkit",
+              "version_added": "33",
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "chrome_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            }
           },
-          "chrome_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
-          },
-          "edge": {
-            "version_added": null
-          },
-          "edge_mobile": {
-            "version_added": null
-          },
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": false
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
-          },
-          "webview_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "length": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResult/length",
-        "support": {
-          "chrome": {
-            "prefix": "webkit",
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+      },
+      "length": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResult/length",
+          "support": {
+            "chrome": {
+              "prefix": "webkit",
+              "version_added": "33",
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "chrome_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            }
           },
-          "chrome_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
-          },
-          "edge": {
-            "version_added": null
-          },
-          "edge_mobile": {
-            "version_added": null
-          },
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": false
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
-          },
-          "webview_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "item": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResult/item",
-        "support": {
-          "chrome": {
-            "prefix": "webkit",
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+      },
+      "item": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResult/item",
+          "support": {
+            "chrome": {
+              "prefix": "webkit",
+              "version_added": "33",
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "chrome_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            }
           },
-          "chrome_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
-          },
-          "edge": {
-            "version_added": null
-          },
-          "edge_mobile": {
-            "version_added": null
-          },
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": false
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
-          },
-          "webview_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
         }
       }
     }

--- a/api/SpeechRecognitionResultList.json
+++ b/api/SpeechRecognitionResultList.json
@@ -52,113 +52,113 @@
           "standard_track": true,
           "deprecated": false
         }
-      }
-    },
-    "item": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResultList/item",
-        "support": {
-          "chrome": {
-            "prefix": "webkit",
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+      },
+      "item": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResultList/item",
+          "support": {
+            "chrome": {
+              "prefix": "webkit",
+              "version_added": "33",
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "chrome_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            }
           },
-          "chrome_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
-          },
-          "edge": {
-            "version_added": null
-          },
-          "edge_mobile": {
-            "version_added": null
-          },
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": false
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
-          },
-          "webview_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
         }
-      }
-    },
-    "length": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResultList/length",
-        "support": {
-          "chrome": {
-            "prefix": "webkit",
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+      },
+      "length": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResultList/length",
+          "support": {
+            "chrome": {
+              "prefix": "webkit",
+              "version_added": "33",
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "chrome_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            }
           },
-          "chrome_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
-          },
-          "edge": {
-            "version_added": null
-          },
-          "edge_mobile": {
-            "version_added": null
-          },
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": false
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": false
-          },
-          "opera_android": {
-            "version_added": false
-          },
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": {
-            "version_added": false
-          },
-          "webview_android": {
-            "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
         }
       }
     }


### PR DESCRIPTION
These were introduced in a few SpeechRecognition APIs with the following PRs:

- #1357
- #1358
- #1359
- #1361
- #1362

tl;dr the properties/methods for these APIs weren't formatted as children of their respective APIs which caused the MDN package to index them as `api.item`, `api.confidence`, etc.

Example:

<img width="367" alt="screen shot 2018-05-21 at 2 54 08 pm" src="https://user-images.githubusercontent.com/2977353/40330133-3840abb8-5d09-11e8-9d62-3e0dfa3be664.png">

I noticed this when I tried to update one of the MDN pages with a table for one of these properties.

cc: @maboa @Elchi3 