### PR TITLE
Bug 1387454 - Add AudioContextOptions

### DIFF
--- a/api/AudioContextOptions.json
+++ b/api/AudioContextOptions.json
@@ -1,0 +1,155 @@
+{
+  "api": {
+    "AudioContextOptions": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioContextOptions",
+        "support": {
+          "webview_android": {
+            "version_added": "60"
+          },
+          "chrome": {
+            "version_added": "60"
+          },
+          "chrome_android": {
+            "version_added": "60"
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "61"
+          },
+          "firefox_android": {
+            "version_added": "61"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "latencyHint": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioContextOptions/latencyHint",
+          "support": {
+            "webview_android": {
+              "version_added": "60"
+            },
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "61"
+            },
+            "firefox_android": {
+              "version_added": "61"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sampleRate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioContextOptions/sampleRate",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/432248' title='Issue 432248 - AudioContext needs to support optional sample rate parameter.'>issue 432248</a> for Chrome support."
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "61"
+            },
+            "firefox_android": {
+              "version_added": "61"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit adds the AudioContextOptions dictionary to
BCD. Linted and test-rendered well for me. Part of Firefox 61 DDNs.