### PR TITLE
Add compat data for Transferable

### DIFF
--- a/api/Transferable.json
+++ b/api/Transferable.json
@@ -1,0 +1,53 @@
+{
+  "api": {
+    "Transferable": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Transferable",
+        "support": {
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "4"
+          },
+          "firefox_android": {
+            "version_added": "4"
+          },
+          "ie": {
+            "version_added": "10",
+            "notes": "Internet Explorer 10 only accepts a single <code>Transferable</code> object as parameter, but not an array."
+          },
+          "opera": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/Transferable.json
+++ b/api/Transferable.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Transferable",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Transferable

Note there is mention in the table of `messagePort` but this appears to be a completely separate API and so I omitted it.