### PR TITLE
adding extra data point for replace method new return value

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -99,6 +99,57 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "boolean_value": {
+          "__compat": {
+            "description": "<code>return()</code>'s value is a boolean, not void as it used to be.",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "61"
+              },
+              "firefox_android": {
+                "version_added": "61"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "supports": {

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -105,19 +105,19 @@
             "description": "<code>return()</code>'s value is a boolean, not void as it used to be.",
             "support": {
               "webview_android": {
-                "version_added": true
+                "version_added": "67"
               },
               "chrome": {
-                "version_added": true
+                "version_added": "67"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "67"
               },
               "edge": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "18"
               },
               "firefox": {
                 "version_added": "61"
@@ -129,10 +129,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "54"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "54"
               },
               "safari": {
                 "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1444909.

I am not 100% sure this is the best way to represent this data, but it is a bit of an odd one. replace() method was implemented on DOMTokenList interface a little while ago, and they have updated the behavior so it returns a boolean rather than void.