### PR TITLE
Correct MathML Firefox support

### DIFF
--- a/mathml/elements/maction.json
+++ b/mathml/elements/maction.json
@@ -18,7 +18,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"

--- a/mathml/elements/menclose.json
+++ b/mathml/elements/menclose.json
@@ -18,7 +18,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"
@@ -64,7 +64,7 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "2"
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"

--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -64,7 +64,7 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "2"
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"

--- a/mathml/elements/mtable.json
+++ b/mathml/elements/mtable.json
@@ -18,7 +18,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"
@@ -64,7 +64,7 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "2"
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -158,7 +158,7 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "2"
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -205,7 +205,7 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "2"
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -346,7 +346,7 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "2"
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -487,7 +487,7 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "2"
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -816,7 +816,7 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "2"
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -863,7 +863,7 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "2"
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"

--- a/mathml/elements/mtd.json
+++ b/mathml/elements/mtd.json
@@ -18,7 +18,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"
@@ -64,7 +64,7 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "2"
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -111,7 +111,7 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "2"
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -252,7 +252,7 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "2"
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -299,7 +299,7 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "2"
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"

--- a/mathml/elements/mtr.json
+++ b/mathml/elements/mtr.json
@@ -18,7 +18,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"
@@ -64,7 +64,7 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "2"
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -205,7 +205,7 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "2"
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"


### PR DESCRIPTION
I missed this in the first few pull requests. 
In the old tables, the following means Firefox 1 and not Firefox 2:

> Firefox (Gecko)
> 1.0 (1.7 or earlier)