### PR TITLE
Improve media at-rule style consistency

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -257,7 +257,7 @@
             }
           }
         },
-        "resolution_media_feature": {
+        "resolution": {
           "__compat": {
             "description": "<code>resolution</code> media feature",
             "support": {
@@ -315,7 +315,7 @@
             }
           }
         },
-        "display_mode_media_feature": {
+        "display-mode": {
           "__compat": {
             "description": "<code>display-mode</code> media feature",
             "support": {

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -262,6 +262,7 @@
         "display-mode": {
           "__compat": {
             "description": "<code>display-mode</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/display-mode",
             "support": {
               "webview_android": {
                 "version_added": null

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -205,6 +205,113 @@
             }
           }
         },
+        "any-hover": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/any-hover",
+            "description": "<code>any-hover</code> media feature",
+            "support": {
+              "webview_android": {
+                "version_added": "41"
+              },
+              "chrome": {
+                "version_added": "41"
+              },
+              "chrome_android": {
+                "version_added": "41"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": "16"
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "28"
+              },
+              "opera_android": {
+                "version_added": "28"
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9.2"
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "display-mode": {
+          "__compat": {
+            "description": "<code>display-mode</code> media feature",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "47",
+                "notes": "Firefox 47 and later support <code>display-mode</code> values <code>fullscreen</code> and <code>browser</code>. Firefox 57 added support for <code>minimal-ui</code> and <code>standalone</code> values."
+              },
+              "firefox_android": {
+                "version_added": "47",
+                "notes": "Firefox 47 and later support <code>display-mode</code> values <code>fullscreen</code> and <code>browser</code>. Firefox 57 added support for <code>minimal-ui</code> and <code>standalone</code> values."
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "hover": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/hover",
@@ -306,113 +413,6 @@
               },
               "samsunginternet_android": {
                 "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "display-mode": {
-          "__compat": {
-            "description": "<code>display-mode</code> media feature",
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "47",
-                "notes": "Firefox 47 and later support <code>display-mode</code> values <code>fullscreen</code> and <code>browser</code>. Firefox 57 added support for <code>minimal-ui</code> and <code>standalone</code> values."
-              },
-              "firefox_android": {
-                "version_added": "47",
-                "notes": "Firefox 47 and later support <code>display-mode</code> values <code>fullscreen</code> and <code>browser</code>. Firefox 57 added support for <code>minimal-ui</code> and <code>standalone</code> values."
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "any-hover": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/any-hover",
-            "description": "<code>any-hover</code> media feature",
-            "support": {
-              "webview_android": {
-                "version_added": "41"
-              },
-              "chrome": {
-                "version_added": "41"
-              },
-              "chrome_android": {
-                "version_added": "41"
-              },
-              "edge": {
-                "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": "16"
-              },
-              "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
-              },
-              "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "28"
-              },
-              "opera_android": {
-                "version_added": "28"
-              },
-              "safari": {
-                "version_added": "9"
-              },
-              "safari_ios": {
-                "version_added": "9.2"
-              },
-              "samsunginternet_android": {
-                "version_added": "5.0"
               }
             },
             "status": {


### PR DESCRIPTION
This PR improves a few superficial things about the `@media` data:

* Renames the media features (Note: confusingly the actual CSS feature is a called a "media feature" which is what I'm referring to, not BCD "features" generically)
* Sorts the media features by name
* Adds missing MDN URLs

Apart from the URL, the underlying data stays the same.

Finally, this is another step forward for #2009.