### PR TITLE
Add data for viewport media features

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -469,64 +469,6 @@
             }
           }
         },
-        "resolution": {
-          "__compat": {
-            "description": "<code>resolution</code> media feature",
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": "29"
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": [
-                {
-                  "version_added": "8"
-                },
-                {
-                  "partial_implementation": true,
-                  "version_added": "3.5",
-                  "notes": "Supports <a href='https://developer.mozilla.org/docs/Web/CSS/integer'><code>&lt;integer&gt;</code></a> values only."
-                }
-              ],
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "orientation": {
           "__compat": {
             "description": "<code>orientation</code> media feature",
@@ -621,6 +563,64 @@
               },
               "safari_ios": {
                 "version_added": "9.2"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "resolution": {
+          "__compat": {
+            "description": "<code>resolution</code> media feature",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "29"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "8"
+                },
+                {
+                  "partial_implementation": true,
+                  "version_added": "3.5",
+                  "notes": "Supports <a href='https://developer.mozilla.org/docs/Web/CSS/integer'><code>&lt;integer&gt;</code></a> values only."
+                }
+              ],
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
               }
             },
             "status": {

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -527,6 +527,58 @@
             }
           }
         },
+        "orientation": {
+          "__compat": {
+            "description": "<code>orientation</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/orientation",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "pointer": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/pointer",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -259,6 +259,58 @@
             }
           }
         },
+        "aspect-ratio": {
+          "__compat": {
+            "description": "<code>aspect-ratio</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/aspect-ratio",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": {
+                "version_added": "9"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "display-mode": {
           "__compat": {
             "description": "<code>display-mode</code> media feature",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -283,10 +283,10 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "9"
+                "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": "9"
               },
               "opera": {
                 "version_added": null
@@ -487,10 +487,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": false
+                "version_added": true
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": null
               },
               "ie": {
                 "version_added": null

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -313,6 +313,58 @@
             }
           }
         },
+        "height": {
+          "__compat": {
+            "description": "<code>height</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/height",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "hover": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/hover",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -473,6 +473,58 @@
               "deprecated": false
             }
           }
+        },
+        "width": {
+          "__compat": {
+            "description": "<code>width</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/width",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This PR adds the data for the following `@media` at-rule features:

- https://developer.mozilla.org/docs/Web/CSS/@media/aspect-ratio
- https://developer.mozilla.org/docs/Web/CSS/@media/height
- https://developer.mozilla.org/docs/Web/CSS/@media/orientation
- https://developer.mozilla.org/docs/Web/CSS/@media/width

For #2009