### PR TITLE
Add WebExtension match patterns

### DIFF
--- a/webextensions/match_patterns.json
+++ b/webextensions/match_patterns.json
@@ -1,0 +1,234 @@
+{
+  "webextensions": {
+    "match_patterns": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Match_patterns",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": "14"
+          },
+          "firefox": {
+            "version_added": "48"
+          },
+          "firefox_android": {
+            "version_added": "48"
+          },
+          "opera": {
+            "version_added": true
+          }
+        }
+      },
+      "scheme": {
+        "wildcard": {
+          "__compat": {
+            "description": "Wildcard <code>*</code> scheme",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "wildcard_websocket": {
+          "__compat": {
+            "description": "<code>*</code> matches <code>ws</code> and <code>wss</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "http": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "https": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "ws": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "wss": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "ftp": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "ftps": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1463440'>bug 1463440</a>"
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1463440'>bug 1463440</a>"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "file": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "data": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "48",
+                "partial_implementation": true,
+                "notes": "Doesn’t support injection of content scripts or stylesheets."
+              },
+              "firefox_android": {
+                "version_added": "48",
+                "partial_implementation": true,
+                "notes": "Doesn’t support injection of content scripts or stylesheets."
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds the browser compatibility table data for [WebExtension match patterns](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Match_patterns).

## Notes:
- The `data:` URI scheme shows up in Firefox’s codebase since the earliest commit for the [`MatchPattern.cpp` code](https://searchfox.org/mozilla-central/rev/186924219bdca9ea87440b5cdb029efcdcf5bd59/toolkit/components/extensions/MatchPattern.cpp#245).
- The `ws:` and `wss:` schemes were later added in [bug 1367478](https://bugzil.la/1367478).
- Chrome’s documentation doesn’t indicate any sort of support for `ws:`, `wss:` or `ftps:`.
- Support for `ftps:` in Firefox depends on [bug 1463440](https://bugzil.la/1463440 "Support FTP over TLS/SSL (ftps://) URLs in MatchPattern") and [bug 85464](https://bugzil.la/85464 "Support FTP over TLS/SSL (FTPS)").

---

### Footnotes:
<dl>
<dt>ftps:</dt>
<dd><p>
FTPS is FTP over TLS/SSL.
</p><p>
Not to be confused with SFTP, which is FTP over SSH.
</p><p>
I saw people confuse the two way too much in <a href="https://bugzil.la/85464" title="Support FTP over TLS/SSL (FTPS)">bug 85464</a>’s comments.
</p></dd>
</dl>