### PR TITLE
Modify lint.js to output any errors at the end of the run.

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -4,6 +4,7 @@ var {testStyle} = require('./test-style');
 var {testSchema} = require('./test-schema');
 var {testVersions} = require('./test-versions');
 var hasErrors, hasStyleErrors, hasSchemaErrors, hasVersionErrors = false;
+var filesWithErrors = {};
 
 function load(...files) {
   for (let file of files) {
@@ -19,10 +20,12 @@ function load(...files) {
         } else {
           hasSchemaErrors = testSchema(file);
           hasStyleErrors = testStyle(file);
-          hasVersionErrors =  testVersions(file);
+          hasVersionErrors = testVersions(file);
         }
         if (hasStyleErrors || hasSchemaErrors || hasVersionErrors) {
           hasErrors = true;
+          fileName = file.replace(path.resolve(__dirname, '..') + path.sep, '');
+          filesWithErrors[fileName] = file;
         }
       }
 
@@ -56,5 +59,13 @@ if (process.argv[2]) {
 }
 
 if (hasErrors) {
+  console.log("");
+  console.log(`Problems in ${Object.keys(filesWithErrors).length} files:`);
+  for (var file in filesWithErrors) {
+    console.log(file);
+    testSchema(filesWithErrors[file]);
+    testStyle(filesWithErrors[file]);
+    testVersions(filesWithErrors[file]);
+  }
   process.exit(1);
 }

--- a/test/lint.js
+++ b/test/lint.js
@@ -61,7 +61,7 @@ if (process.argv[2]) {
 if (hasErrors) {
   console.log("");
   console.log(`Problems in ${Object.keys(filesWithErrors).length} files:`);
-  for (var file in filesWithErrors) {
+  for (let file in filesWithErrors) {
     console.log(file);
     testSchema(filesWithErrors[file]);
     testStyle(filesWithErrors[file]);


### PR DESCRIPTION
Behavior has not changed for successful runs.

This changes `test/lint.js` so any failures are also displayed at the end of the test run. Previously if there were warnings, you'd have to scroll through hundreds of lines of logs to find the file that had a problem. With this change the linter outputs the problematic files and their issues at the end of the run.

<img width="857" alt="screen shot 2018-05-23 at 12 37 19 pm" src="https://user-images.githubusercontent.com/2977353/40444457-b2cff8f6-5e86-11e8-8145-b9c09407440d.png">

This should make resolving linter failures a bit easier for contributors :)