### PR TITLE
Note that @-moz-document is now disabled by default

### DIFF
--- a/css/at-rules/document.json
+++ b/css/at-rules/document.json
@@ -21,10 +21,27 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "prefix": "-moz-",
-              "version_added": "1.5"
-            },
+            "firefox": [
+              {
+                "prefix": "-moz-",
+                "version_added": "1.5",
+                "version_removed": "61"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "61",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.moz-document.content.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": [
+                  "Disabled by default in web pages, except for an empty <code>url-prefix()</code> value, which is supported due to its <a href='https://css-tricks.com/snippets/css/css-hacks-targeting-firefox/'>use in Firefox browser detection</a>. Still supported in user stylesheets."
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": null
             },


### PR DESCRIPTION
`@-moz-document` is now behind a pref in web content, although it is still supported in user stylesheets. An empty `url-prefix()` is still parsed, because some sites rely on it for browser detection.

https://bugzilla.mozilla.org/show_bug.cgi?id=1422245
https://bugzilla.mozilla.org/show_bug.cgi?id=1446470
https://www.fxsitecompat.com/en-CA/docs/2018/moz-document-support-has-been-dropped-except-for-empty-url-prefix/

I thought including a note as well as the `preference` was worth doing to emphasise (hopefully) that this is an EOL type of preference, and to include the details.

I'm not sure what the review process is for Layout DDNs - should we ask a review from Emilio for this PR?
