### PR TITLE
Firefox supports these 2 properties by default from version 61

### DIFF
--- a/css/properties/font-optical-sizing.json
+++ b/css/properties/font-optical-sizing.json
@@ -22,10 +22,11 @@
             },
             "firefox": [
               {
-                "version_added": "62"
+                "version_added": "61"
               },
               {
                 "version_added": "60",
+                "version_removed": "61",
                 "flags": [
                   {
                     "type": "preference",
@@ -37,10 +38,11 @@
             ],
             "firefox_android": [
               {
-                "version_added": "62"
+                "version_added": "61"
               },
               {
                 "version_added": "60",
+                "version_removed": "61",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/font-variation-settings.json
+++ b/css/properties/font-variation-settings.json
@@ -22,26 +22,38 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/fontvariationpropertieswithopentypevariablefontsupport/'>In development</a>."
             },
-            "firefox": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.font-variations.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.font-variations.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "53",
+                "version_removed": "61",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-variations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "53",
+                "version_removed": "61",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-variations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
Firefox 61 flips the pref for `font-variation-settings` and `font-optical-sizing`: https://bugzilla.mozilla.org/show_bug.cgi?id=1447163

Note that the previous data, indicating that the pref for `font-optical-sizing` flipped in 62, was incorrect - I've tested this with the current Beta.