### PR TITLE
flex-basis:content is supported in Firefox 61

### DIFF
--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -212,10 +212,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": false
+                "version_added": "61"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "61"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Firefox 61 supports the `content` value for `flex-basis`:

https://bugzilla.mozilla.org/show_bug.cgi?id=1105111
https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis