### PR TITLE
Bug 1458883 - Remove File.lastModifiedDate from Firefox 61

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -187,7 +187,8 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "15"
+              "version_added": "15",
+              "version_removed": 61
             },
             "firefox_android": {
               "version_added": false

--- a/api/File.json
+++ b/api/File.json
@@ -188,7 +188,7 @@
             },
             "firefox": {
               "version_added": "15",
-              "version_removed": 61
+              "version_removed": "61"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
Added "version_removed": "61" to Firefox desktop for this property.