### PR TITLE
Update Firefox data for CSSStyleRule.selectorText

### DIFF
--- a/api/CSSStyleRule.json
+++ b/api/CSSStyleRule.json
@@ -66,14 +66,24 @@
             "edge_mobile": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": true,
-              "notes": "Read-only; setting of this property not supported"
-            },
-            "firefox_android": {
-              "version_added": true,
-              "notes": "Read-only; setting of this property not supported"
-            },
+            "firefox": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": true,
+                "notes": "Read-only; setting of this property not supported."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": true,
+                "notes": "Read-only; setting of this property not supported."
+              }
+            ],
             "ie": {
               "version_added": "9"
             },

--- a/api/CSSStyleRule.json
+++ b/api/CSSStyleRule.json
@@ -72,6 +72,7 @@
               },
               {
                 "version_added": true,
+                "version_removed": "61",
                 "notes": "Read-only; setting of this property not supported."
               }
             ],
@@ -81,6 +82,7 @@
               },
               {
                 "version_added": true,
+                "version_removed": "61",
                 "notes": "Read-only; setting of this property not supported."
               }
             ],


### PR DESCRIPTION
See 
https://bugzilla.mozilla.org/show_bug.cgi?id=37468
https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleRule/selectorText#Browser_Compatibility