### PR TITLE
Firefox supports Event.srcElement in 62

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -662,12 +662,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/453968'>bug 453968</a>."
+              "version_added": "62"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/453968'>bug 453968</a>."
+              "version_added": "62"
             },
             "ie": {
               "version_added": true


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=453968
and in particular https://bugzilla.mozilla.org/show_bug.cgi?id=453968#c40 (this didn't make 61 but 62).

https://developer.mozilla.org/en-US/docs/Web/API/Event/srcElement