### PR TITLE
Bug 1454889 - remove MediaStream support from createObjectURL

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -104,7 +104,16 @@
               "version_added": "10"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": [
+                "Support for creating an object URL from a <code>MediaStream</code> was removed in Firefox 61. See <a href='https://developer.mozilla.org/docs/Web/API/URL/createObjectURL#Using_object_URLs_for_media_streams'>Using object URLs for media streams</a> for details."
+              ]
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "notes": [
+                "Support for creating an object URL from a <code>MediaStream</code> was removed in Firefox 61. See <a href='https://developer.mozilla.org/docs/Web/API/URL/createObjectURL#Using_object_URLs_for_media_streams'>Using object URLs for media streams</a> for details."
+              ]
             },
             "opera": {
               "version_added": "15"

--- a/api/URL.json
+++ b/api/URL.json
@@ -104,16 +104,10 @@
               "version_added": "10"
             },
             "firefox": {
-              "version_added": "4",
-              "notes": [
-                "Support for creating an object URL from a <code>MediaStream</code> was removed in Firefox 62 See <a href='https://developer.mozilla.org/docs/Web/API/URL/createObjectURL#Using_object_URLs_for_media_streams'>Using object URLs for media streams</a> for details."
-              ]
+              "version_added": "4"
             },
             "firefox_android": {
-              "version_added": "4",
-              "notes": [
-                "Support for creating an object URL from a <code>MediaStream</code> was removed in Firefox 62. See <a href='https://developer.mozilla.org/docs/Web/API/URL/createObjectURL#Using_object_URLs_for_media_streams'>Using object URLs for media streams</a> for details."
-              ]
+              "version_added": "4"
             },
             "opera": {
               "version_added": "15"
@@ -132,6 +126,39 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "no_MediaStream_argument": {
+          "__compat": {
+            "description": "No longer accepts <code>MediaStream</code> object",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "62"
+              },
+              "firefox_android": {
+                "version_added": "62"
+              },
+              "opera": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/URL.json
+++ b/api/URL.json
@@ -106,13 +106,13 @@
             "firefox": {
               "version_added": "4",
               "notes": [
-                "Support for creating an object URL from a <code>MediaStream</code> was removed in Firefox 61. See <a href='https://developer.mozilla.org/docs/Web/API/URL/createObjectURL#Using_object_URLs_for_media_streams'>Using object URLs for media streams</a> for details."
+                "Support for creating an object URL from a <code>MediaStream</code> was removed in Firefox 62 See <a href='https://developer.mozilla.org/docs/Web/API/URL/createObjectURL#Using_object_URLs_for_media_streams'>Using object URLs for media streams</a> for details."
               ]
             },
             "firefox_android": {
               "version_added": "4",
               "notes": [
-                "Support for creating an object URL from a <code>MediaStream</code> was removed in Firefox 61. See <a href='https://developer.mozilla.org/docs/Web/API/URL/createObjectURL#Using_object_URLs_for_media_streams'>Using object URLs for media streams</a> for details."
+                "Support for creating an object URL from a <code>MediaStream</code> was removed in Firefox 62. See <a href='https://developer.mozilla.org/docs/Web/API/URL/createObjectURL#Using_object_URLs_for_media_streams'>Using object URLs for media streams</a> for details."
               ]
             },
             "opera": {


### PR DESCRIPTION
Added notes to Firefox on createObjectURL() noting that
MediaStream can no longer be used as an input, with a link
to new text in the wiki with details.