### PR TITLE
>> syntax is deprecated

### DIFF
--- a/css/selectors/descendant.json
+++ b/css/selectors/descendant.json
@@ -87,7 +87,8 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "10"
+                "version_added": "10",
+                "version_removed": "11.1"
               },
               "safari_ios": {
                 "version_added": "10"
@@ -97,9 +98,9 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }

--- a/css/selectors/descendant.json
+++ b/css/selectors/descendant.json
@@ -91,7 +91,8 @@
                 "version_removed": "11.1"
               },
               "safari_ios": {
-                "version_added": "10"
+                "version_added": "10",
+                "version_removed": "11.1"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
This came up from looking at https://bugzilla.mozilla.org/show_bug.cgi?id=1266283, an old bug to add support for the `>>` form for the [descendant selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Descendant_selectors).

That bug didn't get fixed because the form has been deprecated, so this PR instead updates the status to deprecated and notes that Safari has also dropped support (from https://caniuse.com/#feat=css-descendant-gtgt).

