### PR TITLE
Note about flex item sizing before Firefox 61

### DIFF
--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -50,6 +50,13 @@
                 ]
               },
               {
+                "version_added": "20",
+                "version_removed": "61",
+                "notes": [
+                  "Flex items that are sized according to their content are sized using <a href='https://drafts.csswg.org/css-sizing-3/#column-sizing'>fit-content, not max-content</a>."
+                ]
+              },
+              {
                 "prefix": "-webkit-",
                 "version_added": "49"
               },


### PR DESCRIPTION
From
https://bugzilla.mozilla.org/show_bug.cgi?id=1282821
and 
https://bugzilla.mozilla.org/show_bug.cgi?id=1374540

I'll ask in the bug if this is a correct note to use here, as I'm not sure.

