### PR TITLE
Bug 1448162 – Disable XUL overlays

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4649,13 +4649,31 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": true,
-              "notes": [
-                "Available only to <a href='https://developer.mozilla.org/docs/Mozilla/Tech/XUL'>XUL documents</a>.",
-                "See <a href='https://bugzil.la/1449791'>bug 1449791</a>"
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "61",
+                "flags": [
+                  {
+                    "type": "compile_flag",
+                    "name": "MOZ_BREAK_XUL_OVERLAYS",
+                    "value_to_set": "False"
+                  }
+                ],
+                "notes": [
+                  "Available only to <a href='https://developer.mozilla.org/docs/Mozilla/Tech/XUL'>XUL documents</a>.",
+                  "If a XUL document attempts to load an overlay without the compile flag, an error will be thrown (see <a href='https://bugzil.la/1448162'>bug 1448162</a>).",
+                  "See <a href='https://bugzil.la/1449791'>bug 1449791</a>"
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "61",
+                "notes": [
+                  "Available only to <a href='https://developer.mozilla.org/docs/Mozilla/Tech/XUL'>XUL documents</a>.",
+                  "See <a href='https://bugzil.la/1449791'>bug 1449791</a>"
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },


### PR DESCRIPTION
XUL overlays have been disabled behind the `MOZ_BREAK_XUL_OVERLAYS` compile flag, which has to be set to `False` in order to be able to use XUL overlays.

XUL overlays haven’t yet been outright removed as Thunderbird and SeaMonkey still depend on them.

## See also:
- [bug 1448162](https://bugzil.la/1448162 "Disable XUL overlays")