### PR TITLE
Bug 1394399 - Request.credentials should default to "same-origin"

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -586,8 +586,7 @@
             },
             "firefox": [
               {
-                "version_added": "39",
-                "notes": "In Firefox 61, the default value of <code>credentials</code> changed from <code>\"omit\"</code> to <code>\"same-origin\"</code>."
+                "version_added": "39"
               },
               {
                 "version_added": "34",
@@ -636,6 +635,57 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "default_same-origin": {
+          "__compat": {
+            "description": "Default value <code>same-origin</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "61"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/Request.json
+++ b/api/Request.json
@@ -586,7 +586,8 @@
             },
             "firefox": [
               {
-                "version_added": "39"
+                "version_added": "39",
+                "notes": "In Firefox 61, the default value of <code>credentials</code> changed from <code>\"omit\"</code> to <code>\"same-origin\"</code>."
               },
               {
                 "version_added": "34",


### PR DESCRIPTION
Updated to note that this change was made in Firefox 61.