### PR TITLE
Note >>> alias in Chrome

### DIFF
--- a/css/selectors/descendant.json
+++ b/css/selectors/descendant.json
@@ -9,12 +9,28 @@
             "webview_android": {
               "version_added": true
             },
-            "chrome": {
-              "version_added": "1"
-            },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": "61",
+                "notes": [
+                  "<code>&gt;&gt;&gt;</code> is aliased to this selector <a href='https://developers.google.com/web/updates/2017/06/chrome-60-deprecations#make_shadow-piercing_descendant_combinator_behave_like_descendent_combinator'>since its use as the 'shadow-piercing descendant combinator' was deprecated</a>."
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": "61",
+                "notes": [
+                  "<code>&gt;&gt;&gt;</code> is aliased to this selector <a href='https://developers.google.com/web/updates/2017/06/chrome-60-deprecations#make_shadow-piercing_descendant_combinator_behave_like_descendent_combinator'>since its use as the 'shadow-piercing descendant combinator' was deprecated</a>."
+                ]
+              }
+            ],
             "edge": {
               "version_added": "12"
             },


### PR DESCRIPTION
This came up looking at https://bugzilla.mozilla.org/show_bug.cgi?id=1117572, which was about implementing the "shadow-piercing descendant combinator". That bug was WONTFIX'd because the combinator was deprecated, but Chrome, which had already implemented it, [decided to alias it to the normal descendant combinator, to reduce breakage](https://developers.google.com/web/updates/2017/06/chrome-60-deprecations#make_shadow-piercing_descendant_combinator_behave_like_descendent_combinator). I think that is worth noting, which is what this PR does.

I decided not to use "alternative_name" here, thinking it's more useful to use a note to explain the connection to shadow DOM.

