### PR TITLE
WebVR is enabled in Firefox 61 on macOS, not 60

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -586,8 +586,7 @@
             },
             "firefox": [
               {
-                "version_added": "39",
-                "notes": "In Firefox 61, the default value of <code>credentials</code> changed from <code>\"omit\"</code> to <code>\"same-origin\"</code>."
+                "version_added": "39"
               },
               {
                 "version_added": "34",
@@ -636,6 +635,57 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "default_same-origin": {
+          "__compat": {
+            "description": "Default value <code>same-origin</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "61"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/Request.json
+++ b/api/Request.json
@@ -147,13 +147,10 @@
             "deprecated": false
           }
         },
-        "accept_readablestream": {
+        "reponse_body_readablestream": {
           "__compat": {
-            "description": "<code>body</code> can be a <code>ReadableStream</code>",
+            "description": "Consume response body as a <code>ReadableStream</code>",
             "support": {
-              "webview_android": {
-                "version_added": "43"
-              },
               "chrome": {
                 "version_added": "43"
               },
@@ -209,6 +206,55 @@
               },
               "samsunginternet_android": {
                 "version_added": "4.0"
+              },
+              "webview_android": {
+                "version_added": "43"
+              }
+            }
+          }
+        },
+        "readablestream_request_body": {
+          "__compat": {
+            "description": "Send <code>ReadableStream</code> in request body",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
               }
             }
           }

--- a/api/Request.json
+++ b/api/Request.json
@@ -586,7 +586,8 @@
             },
             "firefox": [
               {
-                "version_added": "39"
+                "version_added": "39",
+                "notes": "In Firefox 61, the default value of <code>credentials</code> changed from <code>\"omit\"</code> to <code>\"same-origin\"</code>."
               },
               {
                 "version_added": "34",

--- a/api/Request.json
+++ b/api/Request.json
@@ -147,10 +147,13 @@
             "deprecated": false
           }
         },
-        "reponse_body_readablestream": {
+        "accept_readablestream": {
           "__compat": {
-            "description": "Consume response body as a <code>ReadableStream</code>",
+            "description": "<code>body</code> can be a <code>ReadableStream</code>",
             "support": {
+              "webview_android": {
+                "version_added": "43"
+              },
               "chrome": {
                 "version_added": "43"
               },
@@ -206,55 +209,6 @@
               },
               "samsunginternet_android": {
                 "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "43"
-              }
-            }
-          }
-        },
-        "readablestream_request_body": {
-          "__compat": {
-            "description": "Send <code>ReadableStream</code> in request body",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
               }
             }
           }
@@ -635,57 +589,6 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "default_same-origin": {
-          "__compat": {
-            "description": "Default value <code>same-origin</code>",
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "61"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "60",
-              "notes": "macOS support was enabled in Firefox 60."
+              "version_added": "61",
+              "notes": "macOS support was enabled in Firefox 61."
             }
           ],
           "ie": {
@@ -86,8 +86,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -140,8 +140,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -194,8 +194,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -248,8 +248,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -302,8 +302,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -356,8 +356,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -410,8 +410,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -464,8 +464,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -518,8 +518,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -572,8 +572,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -615,8 +615,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -669,8 +669,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -759,8 +759,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -813,8 +813,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -867,8 +867,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -921,8 +921,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -975,8 +975,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -1029,8 +1029,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -1083,8 +1083,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "62",
-              "notes": "macOS support was enabled in Firefox 62."
+              "version_added": "63",
+              "notes": "macOS support was enabled in Firefox 63."
             }
           ],
           "ie": {
@@ -86,8 +86,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -140,8 +140,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -194,8 +194,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -248,8 +248,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -302,8 +302,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -356,8 +356,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -410,8 +410,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -464,8 +464,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -518,8 +518,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -572,8 +572,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -615,8 +615,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -669,8 +669,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -759,8 +759,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -813,8 +813,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -867,8 +867,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -921,8 +921,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -975,8 +975,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -1029,8 +1029,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -1083,8 +1083,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -33,7 +33,7 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "61",
+              "version_added": "62",
               "notes": "macOS support was enabled in Firefox 62."
             }
           ],
@@ -86,7 +86,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -140,7 +140,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -194,7 +194,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -248,7 +248,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -302,7 +302,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -356,7 +356,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -410,7 +410,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -464,7 +464,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -518,7 +518,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -572,7 +572,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -615,7 +615,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -669,7 +669,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -759,7 +759,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -813,7 +813,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -867,7 +867,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -921,7 +921,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -975,7 +975,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -1029,7 +1029,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -1083,7 +1083,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -34,7 +34,7 @@
             },
             {
               "version_added": "61",
-              "notes": "macOS support was enabled in Firefox 61."
+              "notes": "macOS support was enabled in Firefox 62."
             }
           ],
           "ie": {
@@ -87,7 +87,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -141,7 +141,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -195,7 +195,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -249,7 +249,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -303,7 +303,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -357,7 +357,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -411,7 +411,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -465,7 +465,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -519,7 +519,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -573,7 +573,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -616,7 +616,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -670,7 +670,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -760,7 +760,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -814,7 +814,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -868,7 +868,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -922,7 +922,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -976,7 +976,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -1030,7 +1030,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -1084,7 +1084,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -33,7 +33,7 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "61",
+              "version_added": "62",
               "notes": "macOS support was enabled in Firefox 62."
             }
           ],
@@ -86,7 +86,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -140,7 +140,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -194,7 +194,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -248,7 +248,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -302,7 +302,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "60",
-              "notes": "macOS support was enabled in Firefox 60."
+              "version_added": "61",
+              "notes": "macOS support was enabled in Firefox 61."
             }
           ],
           "ie": {
@@ -86,8 +86,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -140,8 +140,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -194,8 +194,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -248,8 +248,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -302,8 +302,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "62",
-              "notes": "macOS support was enabled in Firefox 62."
+              "version_added": "63",
+              "notes": "macOS support was enabled in Firefox 63."
             }
           ],
           "ie": {
@@ -86,8 +86,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -140,8 +140,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -194,8 +194,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -248,8 +248,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -302,8 +302,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -34,7 +34,7 @@
             },
             {
               "version_added": "61",
-              "notes": "macOS support was enabled in Firefox 61."
+              "notes": "macOS support was enabled in Firefox 62."
             }
           ],
           "ie": {
@@ -87,7 +87,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -141,7 +141,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -195,7 +195,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -249,7 +249,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -303,7 +303,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "60",
-              "notes": "macOS support was enabled in Firefox 60."
+              "version_added": "61",
+              "notes": "macOS support was enabled in Firefox 61."
             }
           ],
           "ie": {
@@ -87,8 +87,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -141,8 +141,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -195,8 +195,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -33,7 +33,7 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "61",
+              "version_added": "62",
               "notes": "macOS support was enabled in Firefox 62."
             }
           ],
@@ -87,7 +87,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -141,7 +141,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -195,7 +195,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -34,7 +34,7 @@
             },
             {
               "version_added": "61",
-              "notes": "macOS support was enabled in Firefox 61."
+              "notes": "macOS support was enabled in Firefox 62."
             }
           ],
           "ie": {
@@ -88,7 +88,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -142,7 +142,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -196,7 +196,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "62",
-              "notes": "macOS support was enabled in Firefox 62."
+              "version_added": "63",
+              "notes": "macOS support was enabled in Firefox 63."
             }
           ],
           "ie": {
@@ -87,8 +87,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -141,8 +141,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -195,8 +195,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -33,7 +33,7 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "61",
+              "version_added": "62",
               "notes": "macOS support was enabled in Firefox 62."
             }
           ],
@@ -86,7 +86,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -129,7 +129,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -172,7 +172,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -226,7 +226,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -316,7 +316,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -406,7 +406,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -34,7 +34,7 @@
             },
             {
               "version_added": "61",
-              "notes": "macOS support was enabled in Firefox 61."
+              "notes": "macOS support was enabled in Firefox 62."
             }
           ],
           "ie": {
@@ -87,7 +87,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -130,7 +130,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -173,7 +173,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -227,7 +227,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -317,7 +317,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -407,7 +407,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "60",
-              "notes": "macOS support was enabled in Firefox 60."
+              "version_added": "61",
+              "notes": "macOS support was enabled in Firefox 61."
             }
           ],
           "ie": {
@@ -86,8 +86,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -129,8 +129,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -172,8 +172,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -226,8 +226,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -316,8 +316,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -406,8 +406,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "62",
-              "notes": "macOS support was enabled in Firefox 62."
+              "version_added": "63",
+              "notes": "macOS support was enabled in Firefox 63."
             }
           ],
           "ie": {
@@ -86,8 +86,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -129,8 +129,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -172,8 +172,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -226,8 +226,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -316,8 +316,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -406,8 +406,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "60",
-              "notes": "macOS support was enabled in Firefox 60."
+              "version_added": "61",
+              "notes": "macOS support was enabled in Firefox 61."
             }
           ],
           "ie": {
@@ -123,8 +123,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -177,8 +177,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -231,8 +231,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -285,8 +285,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -34,7 +34,7 @@
             },
             {
               "version_added": "61",
-              "notes": "macOS support was enabled in Firefox 61."
+              "notes": "macOS support was enabled in Firefox 62."
             }
           ],
           "ie": {
@@ -124,7 +124,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -178,7 +178,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -232,7 +232,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -286,7 +286,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "62",
-              "notes": "macOS support was enabled in Firefox 62."
+              "version_added": "63",
+              "notes": "macOS support was enabled in Firefox 63."
             }
           ],
           "ie": {
@@ -123,8 +123,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -177,8 +177,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -231,8 +231,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -285,8 +285,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -33,7 +33,7 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "61",
+              "version_added": "62",
               "notes": "macOS support was enabled in Firefox 62."
             }
           ],
@@ -123,7 +123,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -177,7 +177,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -231,7 +231,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -285,7 +285,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -34,7 +34,7 @@
             },
             {
               "version_added": "61",
-              "notes": "macOS support was enabled in Firefox 61."
+              "notes": "macOS support was enabled in Firefox 62."
             }
           ],
           "ie": {
@@ -88,7 +88,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -142,7 +142,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -196,7 +196,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -250,7 +250,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -304,7 +304,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -358,7 +358,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -412,7 +412,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -33,7 +33,7 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "61",
+              "version_added": "62",
               "notes": "macOS support was enabled in Firefox 62."
             }
           ],
@@ -87,7 +87,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -141,7 +141,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -195,7 +195,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -249,7 +249,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -303,7 +303,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -357,7 +357,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -411,7 +411,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "60",
-              "notes": "macOS support was enabled in Firefox 60."
+              "version_added": "61",
+              "notes": "macOS support was enabled in Firefox 61."
             }
           ],
           "ie": {
@@ -87,8 +87,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -141,8 +141,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -195,8 +195,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -249,8 +249,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -303,8 +303,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -357,8 +357,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -411,8 +411,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "62",
-              "notes": "macOS support was enabled in Firefox 62."
+              "version_added": "63",
+              "notes": "macOS support was enabled in Firefox 63."
             }
           ],
           "ie": {
@@ -87,8 +87,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -141,8 +141,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -195,8 +195,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -249,8 +249,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -303,8 +303,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -357,8 +357,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -411,8 +411,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {

--- a/api/VRLayerInit.json
+++ b/api/VRLayerInit.json
@@ -33,7 +33,7 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "61",
+              "version_added": "62",
               "notes": "macOS support was enabled in Firefox 62."
             }
           ],
@@ -86,7 +86,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -140,7 +140,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -194,7 +194,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],

--- a/api/VRLayerInit.json
+++ b/api/VRLayerInit.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "60",
-              "notes": "macOS support was enabled in Firefox 60."
+              "version_added": "61",
+              "notes": "macOS support was enabled in Firefox 61."
             }
           ],
           "ie": {
@@ -86,8 +86,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -140,8 +140,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -194,8 +194,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {

--- a/api/VRLayerInit.json
+++ b/api/VRLayerInit.json
@@ -34,7 +34,7 @@
             },
             {
               "version_added": "61",
-              "notes": "macOS support was enabled in Firefox 61."
+              "notes": "macOS support was enabled in Firefox 62."
             }
           ],
           "ie": {
@@ -87,7 +87,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -141,7 +141,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -195,7 +195,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {

--- a/api/VRLayerInit.json
+++ b/api/VRLayerInit.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "62",
-              "notes": "macOS support was enabled in Firefox 62."
+              "version_added": "63",
+              "notes": "macOS support was enabled in Firefox 63."
             }
           ],
           "ie": {
@@ -86,8 +86,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -140,8 +140,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -194,8 +194,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -34,7 +34,7 @@
             },
             {
               "version_added": "61",
-              "notes": "macOS support was enabled in Firefox 61."
+              "notes": "macOS support was enabled in Firefox 62."
             }
           ],
           "ie": {
@@ -87,7 +87,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -141,7 +141,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -264,7 +264,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -321,7 +321,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -375,7 +375,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -429,7 +429,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "60",
-              "notes": "macOS support was enabled in Firefox 60."
+              "version_added": "61",
+              "notes": "macOS support was enabled in Firefox 61."
             }
           ],
           "ie": {
@@ -86,8 +86,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -140,8 +140,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -263,8 +263,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -320,8 +320,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -374,8 +374,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -428,8 +428,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -33,7 +33,7 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "61",
+              "version_added": "62",
               "notes": "macOS support was enabled in Firefox 62."
             }
           ],
@@ -86,7 +86,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -140,7 +140,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -263,7 +263,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -320,7 +320,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -374,7 +374,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -428,7 +428,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "62",
-              "notes": "macOS support was enabled in Firefox 62."
+              "version_added": "63",
+              "notes": "macOS support was enabled in Firefox 63."
             }
           ],
           "ie": {
@@ -86,8 +86,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -140,8 +140,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -263,8 +263,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -320,8 +320,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -374,8 +374,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -428,8 +428,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -33,7 +33,7 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "61",
+              "version_added": "62",
               "notes": "macOS support was enabled in Firefox 62."
             }
           ],
@@ -86,7 +86,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -140,7 +140,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],
@@ -194,7 +194,7 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "61",
+                "version_added": "62",
                 "notes": "macOS support was enabled in Firefox 62."
               }
             ],

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "60",
-              "notes": "macOS support was enabled in Firefox 60."
+              "version_added": "61",
+              "notes": "macOS support was enabled in Firefox 61."
             }
           ],
           "ie": {
@@ -86,8 +86,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -140,8 +140,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {
@@ -194,8 +194,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "60",
-                "notes": "macOS support was enabled in Firefox 60."
+                "version_added": "61",
+                "notes": "macOS support was enabled in Firefox 61."
               }
             ],
             "ie": {

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -34,7 +34,7 @@
             },
             {
               "version_added": "61",
-              "notes": "macOS support was enabled in Firefox 61."
+              "notes": "macOS support was enabled in Firefox 62."
             }
           ],
           "ie": {
@@ -87,7 +87,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -141,7 +141,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {
@@ -195,7 +195,7 @@
               },
               {
                 "version_added": "61",
-                "notes": "macOS support was enabled in Firefox 61."
+                "notes": "macOS support was enabled in Firefox 62."
               }
             ],
             "ie": {

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -33,8 +33,8 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "62",
-              "notes": "macOS support was enabled in Firefox 62."
+              "version_added": "63",
+              "notes": "macOS support was enabled in Firefox 63."
             }
           ],
           "ie": {
@@ -86,8 +86,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -140,8 +140,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {
@@ -194,8 +194,8 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "62",
-                "notes": "macOS support was enabled in Firefox 62."
+                "version_added": "63",
+                "notes": "macOS support was enabled in Firefox 63."
               }
             ],
             "ie": {


### PR DESCRIPTION
This accidentally picked up a change from a previous PR I submitted, and I can't figure out how to get that file out of here. If anyone can help, I'd appreciate that.