### PR TITLE
Add compatibility data for AudioNodeOptions

### DIFF
--- a/api/AudioNodeOptions.json
+++ b/api/AudioNodeOptions.json
@@ -1,0 +1,47 @@
+{
+  "api": {
+    "AudioNodeOptions": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioNodeOptions",
+        "support": {
+          "webview_android": {
+            "version_added": "55"
+          },
+          "chrome": {
+            "version_added": "55"
+          },
+          "chrome_android": {
+            "version_added": "55"
+          },
+          "firefox": {
+            "version_added": "53"
+          },
+          "firefox_android": {
+            "version_added": "53"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "42"
+          },
+          "opera_android": {
+            "version_added": "42"
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
There is not a column for Edge in the original table so I did not add a field for Edge in the new compatibility table here.

Also, there is both an Android and Android Webview column but only one browser identifier (`webview_android`), so I only put the data for the Android Webview column:
![Android and Android Webview columns](https://user-images.githubusercontent.com/24855774/40565176-8153fc5a-6039-11e8-92a7-331030b4f069.png)
