### PR TITLE
Fix capitalization of Firefox's DocumentOrShadowRoot.fullscreenElement

### DIFF
--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -430,7 +430,7 @@
             },
             "firefox": [
               {
-                "alternative_name": "mozFullscreenElement",
+                "alternative_name": "mozFullScreenElement",
                 "version_added": "9"
               },
               {
@@ -446,7 +446,7 @@
             ],
             "firefox_android": [
               {
-                "alternative_name": "mozFullscreenElement",
+                "alternative_name": "mozFullScreenElement",
                 "version_added": "9"
               },
               {


### PR DESCRIPTION
As explained in issue #2070, Firefox and its mobile counterpart capitalize `fullscreen` as `fullScreen`. This updates the compatibility table to reflect that for the `fullscreenElement` subfeature.