### PR TITLE
ChildNode.remove works in iOS Safari

### DIFF
--- a/api/ChildNode.json
+++ b/api/ChildNode.json
@@ -190,7 +190,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
According to https://caniuse.com/#search=remove.