### PR TITLE
Add `viewport-fit` @viewport descriptor

### DIFF
--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -472,6 +472,25 @@
             }
           }
         },
+        "viewport-fit": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport/viewport-fit",
+            "description": "<code>viewport-fit</code> descriptor",
+            "support": {
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "width": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport/width",


### PR DESCRIPTION
This adds the browser compatibility table data for the [`viewport-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/@viewport/viewport-fit) [`@viewport` descriptor](https://developer.mozilla.org/en-US/docs/Web/CSS/@viewport)