### PR TITLE
Correct Chrome version for "is" support

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -553,13 +553,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/is",
           "support": {
             "webview_android": {
-              "version_added": "66"
+              "version_added": "67"
             },
             "chrome": {
               "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "66"
+              "version_added": "67"
             },
             "edge": {
               "version_added": false
@@ -627,10 +627,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "53"
+              "version_added": "55"
             },
             "opera_android": {
-              "version_added": "53"
+              "version_added": "55"
             },
             "safari": {
               "version_added": false

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -556,7 +556,7 @@
               "version_added": "66"
             },
             "chrome": {
-              "version_added": "66"
+              "version_added": "67"
             },
             "chrome_android": {
               "version_added": "66"


### PR DESCRIPTION
Was not supported in 66 but is in 67, per both “Can I use” and my own testing.