### PR TITLE
Add data for display media features to media at-rule

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -365,6 +365,58 @@
             }
           }
         },
+        "grid": {
+          "__compat": {
+            "description": "<code>grid</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/grid",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "height": {
           "__compat": {
             "description": "<code>height</code> media feature",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -630,6 +630,58 @@
             }
           }
         },
+        "scan": {
+          "__compat": {
+            "description": "<code>scan</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/scan",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "width": {
           "__compat": {
             "description": "<code>width</code> media feature",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -295,10 +295,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": null

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -734,6 +734,58 @@
             }
           }
         },
+        "update": {
+          "__compat": {
+            "description": "<code>update</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/update-frequency",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "width": {
           "__compat": {
             "description": "<code>width</code> media feature",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -627,6 +627,7 @@
         "resolution": {
           "__compat": {
             "description": "<code>resolution</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/resolution",
             "support": {
               "webview_android": {
                 "version_added": null


### PR DESCRIPTION
This PR adds (or updates) data for:

* https://developer.mozilla.org/docs/Web/CSS/@media/grid
* https://developer.mozilla.org/docs/Web/CSS/@media/resolution
* https://developer.mozilla.org/docs/Web/CSS/@media/scan
* https://developer.mozilla.org/docs/Web/CSS/@media/update-frequency (aka `update`)

This is part of the continuing adventures of #2009 