### PR TITLE
Add more Opera versions

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -302,15 +302,32 @@
         "52": {
           "release_date": "2018-03-22",
           "release_notes": "https://dev.opera.com/blog/opera-52/",
-          "status": "current"
+          "status": "retired"
         },
         "53": {
-          "status": "beta"
+          "release_date": "2018-05-10",
+          "release_notes": "https://dev.opera.com/blog/opera-53/",
+          "status": "current"
         },
         "54": {
-          "status": "nightly"
+          "status": "beta"
         },
         "55": {
+          "status": "nightly"
+        },
+        "56": {
+          "status": "planned"
+        },
+        "57": {
+          "status": "planned"
+        },
+        "58": {
+          "status": "planned"
+        },
+        "59": {
+          "status": "planned"
+        },
+        "60": {
           "status": "planned"
         }
       }


### PR DESCRIPTION
Opera 53 was released: https://dev.opera.com/blog/opera-53/

Also adding a few more planned releases, so that tests don't fail when adding features for these releases.