### PR TITLE
Rename flattten to flat; add Chrome and Opera versions

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -486,18 +486,18 @@
             }
           }
         },
-        "flatten": {
+        "flat": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flatten",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flat",
             "support": {
               "webview_android": {
-                "version_added": false
+                "version_added": "69"
               },
               "chrome": {
-                "version_added": false
+                "version_added": "69"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "69"
               },
               "edge": {
                 "version_added": false
@@ -520,10 +520,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "56"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "56"
               },
               "safari": {
                 "version_added": false
@@ -547,13 +547,13 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap",
             "support": {
               "webview_android": {
-                "version_added": false
+                "version_added": "69"
               },
               "chrome": {
-                "version_added": false
+                "version_added": "69"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "69"
               },
               "edge": {
                 "version_added": false
@@ -576,10 +576,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "56"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "56"
               },
               "safari": {
                 "version_added": false


### PR DESCRIPTION
See https://www.chromestatus.com/feature/6629507075145728

https://github.com/mdn/browser-compat-data/pull/2178 needs to be merged first.