### PR TITLE
Add color media features to media at-rule data

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -311,6 +311,58 @@
             }
           }
         },
+        "color": {
+          "__compat": {
+            "description": "<code>color</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/color",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "display-mode": {
           "__compat": {
             "description": "<code>display-mode</code> media feature",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -415,6 +415,58 @@
             }
           }
         },
+        "color-index": {
+          "__compat": {
+            "description": "<code>color-index</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/color-index",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "display-mode": {
           "__compat": {
             "description": "<code>display-mode</code> media feature",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -363,6 +363,58 @@
             }
           }
         },
+        "color-gamut": {
+          "__compat": {
+            "description": "<code>color-gamut</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/color-gamut",
+            "support": {
+              "chrome": {
+                "version_added": "58"
+              },
+              "chrome_android": {
+                "version_added": "58"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "45"
+              },
+              "opera_android": {
+                "version_added": "45"
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "display-mode": {
           "__compat": {
             "description": "<code>display-mode</code> media feature",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -677,6 +677,58 @@
             }
           }
         },
+        "monochrome": {
+          "__compat": {
+            "description": "<code>monochrome</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/monochrome",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "orientation": {
           "__compat": {
             "description": "<code>orientation</code> media feature",


### PR DESCRIPTION
This PR adds the data for the [color features](https://www.w3.org/TR/mediaqueries-4/#mf-colors) for the `media` at-rule:

* https://developer.mozilla.org/docs/Web/CSS/@media/color
* https://developer.mozilla.org/docs/Web/CSS/@media/color-gamut
* https://developer.mozilla.org/docs/Web/CSS/@media/color-index
* https://developer.mozilla.org/docs/Web/CSS/@media/monochrome

Another PR towards #2009.