### PR TITLE
add compat data for CSS type timing-function

### DIFF
--- a/css/types/timing-function.json
+++ b/css/types/timing-function.json
@@ -1,0 +1,223 @@
+{
+  "css": {
+    "types": {
+      "timing-function": {
+        "__compat": {
+          "description": "<code>&lt;timing-function&gt;</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/single-transition-timing-function",
+          "support": {
+            "webview_android": {
+              "version_added": "4"
+            },
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": "10"
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": "2"
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "cubic_bezier": {
+          "__compat": {
+            "description": "<code>cubic-bezier()</code> with ordinate ∉ [0,1]",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "16"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "4"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "10"
+              },
+              "opera": {
+                "version_added": "12.1"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "steps": {
+          "__compat": {
+            "description": "<code>steps()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "4"
+              },
+              "chrome": {
+                "version_added": "8"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "4"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "10"
+              },
+              "opera": {
+                "version_added": "12.1"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "5"
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "frames": {
+          "__compat": {
+            "description": "<code>frames()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false,
+                "notes": [
+                  "The name of the <code>frames()</code> timing function is <a href='https://github.com/w3c/csswg-drafts/issues/1301'>currently under discussion</a>, so it is currently disabled in browser release versions until a final decision is reached. It is currently turned on in Nightly/Canary only."
+                ]
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": [
+                  "The name of the <code>frames()</code> timing function is <a href='https://github.com/w3c/csswg-drafts/issues/1301'>currently under discussion</a>, so it is currently disabled in browser release versions until a final decision is reached. It is currently turned on in Nightly/Canary only."
+                ]
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": [
+                  "The name of the <code>frames()</code> timing function is <a href='https://github.com/w3c/csswg-drafts/issues/1301'>currently under discussion</a>, so it is currently disabled in browser release versions until a final decision is reached. It is currently turned on in Nightly/Canary only."
+                ]
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false,
+                "notes": [
+                  "The name of the <code>frames()</code> timing function is <a href='https://github.com/w3c/csswg-drafts/issues/1301'>currently under discussion</a>, so it is currently disabled in browser release versions until a final decision is reached. It is currently turned on in Nightly/Canary only."
+                ]
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/types/timing-function.json
+++ b/css/types/timing-function.json
@@ -52,7 +52,7 @@
             "deprecated": false
           }
         },
-        "cubic_bezier": {
+        "cubic-bezier": {
           "__compat": {
             "description": "<code>cubic-bezier()</code> with ordinate ∉ [0,1]",
             "support": {
@@ -142,69 +142,6 @@
               },
               "safari_ios": {
                 "version_added": "5"
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "frames": {
-          "__compat": {
-            "description": "<code>frames()</code>",
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": false,
-                "notes": [
-                  "The name of the <code>frames()</code> timing function is <a href='https://github.com/w3c/csswg-drafts/issues/1301'>currently under discussion</a>, so it is currently disabled in browser release versions until a final decision is reached. It is currently turned on in Nightly/Canary only."
-                ]
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": false,
-                "notes": [
-                  "The name of the <code>frames()</code> timing function is <a href='https://github.com/w3c/csswg-drafts/issues/1301'>currently under discussion</a>, so it is currently disabled in browser release versions until a final decision is reached. It is currently turned on in Nightly/Canary only."
-                ]
-              },
-              "firefox_android": {
-                "version_added": false,
-                "notes": [
-                  "The name of the <code>frames()</code> timing function is <a href='https://github.com/w3c/csswg-drafts/issues/1301'>currently under discussion</a>, so it is currently disabled in browser release versions until a final decision is reached. It is currently turned on in Nightly/Canary only."
-                ]
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false,
-                "notes": [
-                  "The name of the <code>frames()</code> timing function is <a href='https://github.com/w3c/csswg-drafts/issues/1301'>currently under discussion</a>, so it is currently disabled in browser release versions until a final decision is reached. It is currently turned on in Nightly/Canary only."
-                ]
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
               },
               "samsunginternet_android": {
                 "version_added": null


### PR DESCRIPTION
Added CSS type timing-function:
https://developer.mozilla.org/en-US/docs/Web/CSS/single-transition-timing-function