### PR TITLE
Add nonstandard media features to media at-rule data

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -729,6 +729,58 @@
             }
           }
         },
+        "light-level": {
+          "__compat": {
+            "description": "<code>light-level</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/light-level",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "monochrome": {
           "__compat": {
             "description": "<code>monochrome</code> media feature",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1217,6 +1217,58 @@
               "deprecated": false
             }
           }
+        },
+        "-webkit-animation": {
+          "__compat": {
+            "description": "<code>-webkit-animation</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-animation",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1269,6 +1269,58 @@
               "deprecated": false
             }
           }
+        },
+        "-webkit-transform-2d": {
+          "__compat": {
+            "description": "<code>-webkit-transform-2d</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-transform-2d",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1047,6 +1047,73 @@
             }
           }
         },
+        "scripting": {
+          "__compat": {
+            "description": "<code>scripting</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/scripting",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": [
+                  "See <a href='https://crbug.com/489957'>bug 489957</a>."
+                ]
+              },
+              "chrome_android": {
+                "version_added": false,
+                "notes": [
+                  "See <a href='https://crbug.com/489957'>bug 489957</a>."
+                ]
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": [
+                  "See <a href='https://bugzil.la/1166581'>bug 1166581</a>."
+                ]
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": [
+                  "See <a href='https://bugzil.la/1166581'>bug 1166581</a>."
+                ]
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": false,
+                "notes": [
+                  "See <a href='https://crbug.com/489957'>bug 489957</a>."
+                ]
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "update": {
           "__compat": {
             "description": "<code>update</code> media feature",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1218,6 +1218,58 @@
             }
           }
         },
+        "-moz-device-pixel-ratio": {
+          "__compat": {
+            "description": "<code>-moz-device-pixel-ratio</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/-moz-device-pixel-ratio",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "4"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
         "-webkit-animation": {
           "__compat": {
             "description": "<code>-webkit-animation</code> media feature",
@@ -1246,6 +1298,252 @@
               },
               "opera": {
                 "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "-webkit-device-pixel-ratio": {
+          "__compat": {
+            "description": "<code>-webkit-device-pixel-ratio</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-device-pixel-ratio",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "49",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": [
+                    "Implemented as an alias for for <code>-moz-device-pixel-ratio</code>."
+                  ]
+                },
+                {
+                  "version_added": "45",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.prefixes.webkit",
+                      "value_to_set": "true"
+                    },
+                    {
+                      "type": "preference",
+                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": [
+                    "Implemented as an alias for for <code>-moz-device-pixel-ratio</code>."
+                  ]
+                }
+              ],
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "-webkit-max-device-pixel-ratio": {
+          "__compat": {
+            "description": "<code>-webkit-max-device-pixel-ratio</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-device-pixel-ratio",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "49",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": [
+                    "Implemented as an alias for for <code>max--moz-device-pixel-ratio</code>."
+                  ]
+                },
+                {
+                  "version_added": "45",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.prefixes.webkit",
+                      "value_to_set": "true"
+                    },
+                    {
+                      "type": "preference",
+                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": [
+                    "Implemented as an alias for for <code>max--moz-device-pixel-ratio</code>."
+                  ]
+                }
+              ],
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "-webkit-min-device-pixel-ratio": {
+          "__compat": {
+            "description": "<code>-webkit-min-device-pixel-ratio</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-device-pixel-ratio",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "49",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": [
+                    "Implemented as an alias for for <code>min--moz-device-pixel-ratio</code>."
+                  ]
+                },
+                {
+                  "version_added": "45",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.prefixes.webkit",
+                      "value_to_set": "true"
+                    },
+                    {
+                      "type": "preference",
+                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": [
+                    "Implemented as an alias for for <code>min--moz-device-pixel-ratio</code>."
+                  ]
+                }
+              ],
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -625,6 +625,58 @@
             }
           }
         },
+        "inverted-colors": {
+          "__compat": {
+            "description": "<code>inverted-colors</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/inverted-colors",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "hover": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/hover",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1321,6 +1321,70 @@
               "deprecated": false
             }
           }
+        },
+        "-webkit-transform-3d": {
+          "__compat": {
+            "description": "<code>-webkit-transform-3d</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-transform-3d",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "49"
+                },
+                {
+                  "version_added": "46",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.prefixes.webkit",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1385,6 +1385,58 @@
               "deprecated": false
             }
           }
+        },
+        "-webkit-transition": {
+          "__compat": {
+            "description": "<code>-webkit-transition</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-transition",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This PR adds the data for the following non-standard media features for the `@media` at-rule:

- https://developer.mozilla.org/docs/Web/CSS/@media/inverted-colors
- https://developer.mozilla.org/docs/Web/CSS/@media/light-level
- https://developer.mozilla.org/docs/Web/CSS/@media/scripting
- https://developer.mozilla.org/docs/Web/CSS/@media/-moz-device-pixel-ratio
- https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-animation
- https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-device-pixel-ratio
- https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-transform-2d
- https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-transform-3d
- https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-transition

This is the bulk of the remaining data needed to finish #2009.