### PR TITLE
Tidy up `media` at-rule data

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -476,10 +476,10 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": null
+                "version_added": "46"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "46"
               },
               "edge": {
                 "version_added": false

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -154,57 +154,6 @@
             }
           }
         },
-        "any-pointer": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/any-pointer",
-            "description": "<code>any-pointer</code> media feature",
-            "support": {
-              "webview_android": {
-                "version_added": "41"
-              },
-              "chrome": {
-                "version_added": "41"
-              },
-              "chrome_android": {
-                "version_added": "41"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
-              },
-              "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "28"
-              },
-              "opera_android": {
-                "version_added": "28"
-              },
-              "safari": {
-                "version_added": "9"
-              },
-              "safari_ios": {
-                "version_added": "9.2"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "any-hover": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/any-hover",
@@ -250,6 +199,57 @@
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "any-pointer": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/any-pointer",
+            "description": "<code>any-pointer</code> media feature",
+            "support": {
+              "webview_android": {
+                "version_added": "41"
+              },
+              "chrome": {
+                "version_added": "41"
+              },
+              "chrome_android": {
+                "version_added": "41"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "28"
+              },
+              "opera_android": {
+                "version_added": "28"
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9.2"
               }
             },
             "status": {


### PR DESCRIPTION
OK, this is the very last thing I have for #2009. This fixes a couple of miscellaneous issues I spotted in the `@media` data: a couple of missing `display-mode` data points and a mistake in the order of the features (my mistake, in fact).

When this is done, we'll have migrated all the existing data in the `@media` pages.