### PR TITLE
Correct node support for spread in object literals (#2003)

### DIFF
--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -195,7 +195,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "8.3"
               },
               "opera": {
                 "version_added": null

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -195,7 +195,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "8.3"
+                "version_added": "8.3.0"
               },
               "opera": {
                 "version_added": null

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -195,7 +195,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": true
               },
               "opera": {
                 "version_added": null


### PR DESCRIPTION
Fixing issue [2003](https://github.com/mdn/browser-compat-data/issues/2003)

Node.js supports spread in object literals since 8.3 due to updating V8 to version 6.0

> Object rest/spread properties
> This release introduces rest properties for object destructuring assignment and spread properties for object literals. Object rest/spread properties are Stage 3 ES.next features.

Source: [V8 release notes](https://v8project.blogspot.com/2017/06/v8-release-60.html)