### PR TITLE
Add missing :‑moz‑system‑metric(…) values

### DIFF
--- a/css/selectors/-moz-system-metric.json
+++ b/css/selectors/-moz-system-metric.json
@@ -64,6 +64,136 @@
             "deprecated": true
           }
         },
+        "images-in-menus": {
+          "__compat": {
+            "description": "<code>:-moz-system-metric(images-in-menus)</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:-moz-system-metric(images-in-menus)",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "3",
+                "version_removed": "58",
+                "notes": "Internal only since Firefox 58 (See <a href='https://bugzil.la/1396066'>bug 1396066</a>)."
+              },
+              "firefox_android": {
+                "version_added": "4",
+                "version_removed": "58",
+                "notes": "Internal only since Firefox 58 (See <a href='https://bugzil.la/1396066'>bug 1396066</a>)."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "qq_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "uc_android": {
+                "version_added": false
+              },
+              "uc_chinese_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "mac-graphite-theme": {
+          "__compat": {
+            "description": "<code>:-moz-system-metric(mac-graphite-theme)</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:-moz-system-metric(mac-graphite-theme)",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "3",
+                "version_removed": "58",
+                "notes": "Internal only since Firefox 58 (See <a href='https://bugzil.la/1396066'>bug 1396066</a>)."
+              },
+              "firefox_android": {
+                "version_added": "4",
+                "version_removed": "58",
+                "notes": "Internal only since Firefox 58 (See <a href='https://bugzil.la/1396066'>bug 1396066</a>)."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "qq_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "uc_android": {
+                "version_added": false
+              },
+              "uc_chinese_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
         "scrollbar-end-backward": {
           "__compat": {
             "description": "<code>:-moz-system-metric(scrollbar-end-backward)</code>",


### PR DESCRIPTION
This adds the browser compatibility table data for the <code>:-moz-⁠system-⁠metric(​[images-⁠in-⁠menus](https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-system-metric(images-in-menus)) and [mac-⁠graphite-⁠theme](https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-system-metric(mac-graphite-theme)))</code> CSS selector.

Follow‑up to #1268 and #1317.