### PR TITLE
Add `images` and `properties` sub-keys to the `theme` manifest.json key

### DIFF
--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -22,7 +22,99 @@
             }
           }
         },
+        "images": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme#images",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55",
+                "notes": "Mandatory before Firefox 60"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          },
+          "headerURL": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "alternative_name": "theme_frame"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": [
+                  {
+                    "version_added": "55"
+                  },
+                  {
+                    "version_added": "55",
+                    "alternative_name": "theme_frame"
+                  }
+                ],
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "additional_backgrounds": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        },
         "colors": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme#colors",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          },
           "accentcolor": {
             "__compat": {
               "support": {
@@ -865,6 +957,28 @@
                 "opera": {
                   "version_added": false
                 }
+              }
+            }
+          }
+        },
+        "properties": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme#properties",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
               }
             }
           }


### PR DESCRIPTION
This adds the [`images`](https://developer.mozilla.org/Add-ons/WebExtensions/manifest.json/theme#images) and [`properties`](https://developer.mozilla.org/Add-ons/WebExtensions/manifest.json/theme#properties) sub-keys [to the `theme` manifest.json key](https://developer.mozilla.org/Add-ons/WebExtensions/manifest.json/theme).