### PR TITLE
Add “Basic support” entries to all WebExtension APIs

### DIFF
--- a/webextensions/api/alarms.json
+++ b/webextensions/api/alarms.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "alarms": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "Alarm": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/Alarm",

--- a/webextensions/api/bookmarks.json
+++ b/webextensions/api/bookmarks.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "bookmarks": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "BookmarkTreeNode": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNode",

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "browserAction": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "ColorArray": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/ColorArray",

--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "browserSettings": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "56"
+            },
+            "firefox_android": {
+              "version_added": "56"
+            },
+            "opera": {
+              "version_added": false
+            }
+          }
+        },
         "allowPopupsForUserEvents": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/allowPopupsForUserEvents",

--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "browsingData": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "56"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "DataTypeSet": {
           "cache": {
             "__compat": {

--- a/webextensions/api/clipboard.json
+++ b/webextensions/api/clipboard.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "clipboard": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/clipboard",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "57"
+            },
+            "firefox_android": {
+              "version_added": "57"
+            },
+            "opera": {
+              "version_added": false
+            }
+          }
+        },
         "setImageData": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/clipboard/setImageData",

--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "commands": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "Command": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/Command",

--- a/webextensions/api/contentScripts.json
+++ b/webextensions/api/contentScripts.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "contentScripts": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contentScripts",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "59"
+            },
+            "opera": {
+              "version_added": false
+            }
+          }
+        },
         "RegisteredContentScript": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contentScripts/RegisteredContentScript",

--- a/webextensions/api/contextualIdentities.json
+++ b/webextensions/api/contextualIdentities.json
@@ -2,6 +2,50 @@
   "webextensions": {
     "api": {
       "contextualIdentities": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "privacy.userContext.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "privacy.userContext.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "opera": {
+              "version_added": false
+            }
+          }
+        },
         "ContextualIdentity": {
           "cookieStoreId": {
             "__compat": {

--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "cookies": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "Cookie": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/Cookie",

--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -273,7 +273,7 @@
                 "version_added": true
               }
             }
-          }
+          },
           "ElementsPanel": {
             "createSidebarPane": {
               "__compat": {

--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -3,6 +3,26 @@
     "api": {
       "devtools": {
         "inspectedWindow": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.inspectedWindow",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
           "eval": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.inspectedWindow/eval",
@@ -134,6 +154,26 @@
           }
         },
         "network": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.network",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
           "getHAR": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.network/getHAR",
@@ -214,6 +254,26 @@
           }
         },
         "panels": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
           "ElementsPanel": {
             "createSidebarPane": {
               "__compat": {

--- a/webextensions/api/dns.json
+++ b/webextensions/api/dns.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "dns": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/dns",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": "60"
+            },
+            "opera": {
+              "version_added": false
+            }
+          }
+        },
         "resolve": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/dns/resolve",

--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "downloads": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "47"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "BooleanDelta": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/BooleanDelta",

--- a/webextensions/api/events.json
+++ b/webextensions/api/events.json
@@ -2,6 +2,29 @@
   "webextensions": {
     "api": {
       "events": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "14",
+              "partial_implementation": true
+            },
+            "firefox": {
+              "version_added": "50",
+              "partial_implementation": true
+            },
+            "firefox_android": {
+              "version_added": "50",
+              "partial_implementation": true
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "Event": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Event",

--- a/webextensions/api/extension.json
+++ b/webextensions/api/extension.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "extension": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "ViewType": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/ViewType",

--- a/webextensions/api/extensionTypes.json
+++ b/webextensions/api/extensionTypes.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "extensionTypes": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extensionTypes",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "ImageDetails": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extensionTypes/ImageDetails",

--- a/webextensions/api/find.json
+++ b/webextensions/api/find.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "find": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/find",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "57"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            }
+          }
+        },
         "find": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/find/find",

--- a/webextensions/api/history.json
+++ b/webextensions/api/history.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "history": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "HistoryItem": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/HistoryItem",

--- a/webextensions/api/i18n.json
+++ b/webextensions/api/i18n.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "i18n": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getMessage",
+          "support": {
+            "chrome": {
+              "version_added": "17"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": "15"
+            }
+          }
+        },
         "LanguageCode": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/i18n/LanguageCode",

--- a/webextensions/api/identity.json
+++ b/webextensions/api/identity.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "identity": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/identity",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            }
+          }
+        },
         "getRedirectURL": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/identity/getRedirectURL",

--- a/webextensions/api/idle.json
+++ b/webextensions/api/idle.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "idle": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/idle",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "IdleState": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/idle/IdleState",

--- a/webextensions/api/management.json
+++ b/webextensions/api/management.json
@@ -2,6 +2,25 @@
   "webextensions": {
     "api": {
       "management": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "51"
+            },
+            "opera": {
+              "version_added": true
+            }
+          },
         "ExtensionInfo": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/ExtensionInfo",

--- a/webextensions/api/management.json
+++ b/webextensions/api/management.json
@@ -20,7 +20,8 @@
             "opera": {
               "version_added": true
             }
-          },
+          }
+        },
         "ExtensionInfo": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/ExtensionInfo",

--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -2,6 +2,35 @@
   "webextensions": {
     "api": {
       "menus": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus",
+          "support": {
+            "chrome": {
+              "alternative_name": "contextMenus",
+              "version_added": true
+            },
+            "edge": {
+              "alternative_name": "contextMenus",
+              "version_added": "14"
+            },
+            "firefox": [
+              {
+                "version_added": "55"
+              },
+              {
+                "alternative_name": "contextMenus",
+                "version_added": "48"
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "alternative_name": "contextMenus",
+              "version_added": true
+            }
+          }
+        },
         "ACTION_MENU_TOP_LEVEL_LIMIT": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/ACTION_MENU_TOP_LEVEL_LIMIT",

--- a/webextensions/api/notifications.json
+++ b/webextensions/api/notifications.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "notifications": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "NotificationOptions": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions",

--- a/webextensions/api/omnibox.json
+++ b/webextensions/api/omnibox.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "omnibox": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/omnibox",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "OnInputEnteredDisposition": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/OnInputEnteredDisposition",

--- a/webextensions/api/pageAction.json
+++ b/webextensions/api/pageAction.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "pageAction": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "50"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "ImageDataType": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/ImageDataType",

--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "permissions": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "contains": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/contains",

--- a/webextensions/api/pkcs11.json
+++ b/webextensions/api/pkcs11.json
@@ -2,6 +2,31 @@
   "webextensions": {
     "api": {
       "pkcs11": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pkcs11",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "58"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        },
         "getModuleSlots": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pkcs11/getModuleSlots",

--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -2,7 +2,47 @@
   "webextensions": {
     "api": {
       "privacy": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/privacy",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "54"
+            },
+            "firefox_android": {
+              "version_added": "54"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "network": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/privacy/network",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
           "networkPredictionEnabled": {
             "__compat": {
               "support": {
@@ -68,6 +108,26 @@
           }
         },
         "services": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/privacy/services",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "56"
+              },
+              "firefox_android": {
+                "version_added": "56"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
           "passwordSavingEnabled": {
             "__compat": {
               "support": {
@@ -91,6 +151,26 @@
           }
         },
         "websites": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/privacy/websites",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          },
           "cookieConfig": {
             "__compat": {
               "support": {

--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -2,6 +2,30 @@
   "webextensions": {
     "api": {
       "proxy": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/proxy",
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Chrome implements its own proxy API, which is incompatible with the one in Firefox."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
+            "opera": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Opera implements Chrome's proxy API, which is incompatible with the one in Firefox."
+            }
+          }
+        },
         "onError": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/proxy/onError",

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "runtime": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": "15"
+            }
+          }
+        },
         "MessageSender": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/MessageSender",

--- a/webextensions/api/sessions.json
+++ b/webextensions/api/sessions.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "sessions": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "Filter": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sessions/Filter",

--- a/webextensions/api/sidebarAction.json
+++ b/webextensions/api/sidebarAction.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "sidebarAction": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "54"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "30"
+            }
+          }
+        },
         "ImageDataType": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/ImageDataType",

--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "storage": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": "33"
+            }
+          }
+        },
         "StorageArea": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea",

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "tabs": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "54"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "MutedInfo": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/MutedInfo",

--- a/webextensions/api/theme.json
+++ b/webextensions/api/theme.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "theme": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/theme",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            }
+          }
+        },
         "Theme": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/theme/Theme",

--- a/webextensions/api/topSites.json
+++ b/webextensions/api/topSites.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "topSites": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/topSites",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "MostVisitedURL": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/topSites/MostVisitedURL",

--- a/webextensions/api/types.json
+++ b/webextensions/api/types.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "types": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "54"
+            },
+            "firefox_android": {
+              "version_added": "54"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "BrowserSetting": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting",

--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "webNavigation": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": "17"
+            }
+          }
+        },
         "TransitionQualifier": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/TransitionQualifier",

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "webRequest": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "BlockingResponse": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/BlockingResponse",

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -2,6 +2,26 @@
   "webextensions": {
     "api": {
       "windows": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        },
         "CreateType": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/CreateType",


### PR DESCRIPTION
This adds the “Basic support” entries to [all WebExtension APIs](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs).