### PR TITLE
Add compat data for input-color

### DIFF
--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -5,6 +5,7 @@
         "input-color": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/color",
+            "description": "<code>type=\"color\"</code>",
             "support": {
               "chrome": {
                 "version_added": "20"

--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "color": {
+        "input-color": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/color",
             "support": {
@@ -70,7 +70,8 @@
                   "notes": "See <a href='https://bugzil.la/960984'>bug 960984</a> for the status of support for the <code>list</code> attribute in Firefox."
                 },
                 "firefox_android": {
-                  "version_added": "27"
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/960984'>bug 960984</a> for the status of support for the <code>list</code> attribute in Firefox."
                 },
                 "ie": {
                   "version_added": false
@@ -118,7 +119,8 @@
                   "notes": "See <a href='https://bugzil.la/960989'>bug 960989</a> for the status of support for the <code>autocomplete</code> attribute in Firefox."
                 },
                 "firefox_android": {
-                  "version_added": "27"
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/960984'>bug 960984</a> for the status of support for the <code>list</code> attribute in Firefox."
                 },
                 "ie": {
                   "version_added": false

--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -1,0 +1,57 @@
+{
+  "html": {
+    "elements": {
+      "input": {
+        "color": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/color",
+            "support": {
+              "chrome": {
+                "version_added": "20"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "29",
+                "notes": "Firefox doesn't yet support inputs of type <code>color</code> on Windows Touch."
+              },
+              "firefox_android": {
+                "version_added": "27"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "12"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "4.4"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -49,6 +49,102 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "list": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "20"
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/960984'>bug 960984</a> for the status of support for the <code>list</code> attribute in Firefox."
+                },
+                "firefox_android": {
+                  "version_added": "27"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "autocomplete": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "20"
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/960989'>bug 960989</a> for the status of support for the <code>autocomplete</code> attribute in Firefox."
+                },
+                "firefox_android": {
+                  "version_added": "27"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Testing a possible structure and format for adding compat data for input types.

See https://github.com/mdn/browser-compat-data/issues/911 and https://github.com/mdn/browser-compat-data/pull/1698

