### PR TITLE
Samsung Internet browser version updates

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -69,6 +69,10 @@
         },
         "7.2": {
           "release_date": "2018-03-07",
+          "status": "retired"
+        },
+        "7.4": {
+          "release_date": "2018-05-31",
           "status": "beta"
         }
       }

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -65,7 +65,7 @@
         },
         "7.0": {
           "release_date": "2018-03-16",
-          "status": "limited"
+          "status": "exclusive"
         },
         "7.2": {
           "release_date": "2018-03-07",

--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -43,7 +43,7 @@ The release objects consist of the following properties:
 * A mandatory `status` property indicating where in the lifetime cycle this release is in. It's an enum accepting these values:
   * `retired`: This release is no longer supported (EOL).
   * `current`: This release is the official latest release.
-  * `limited`: This is a limited release (for example on a flagship device), not generally available.
+  * `exclusive`: This is an exclusive release (for example on a flagship device), not generally available.
   * `beta`: This release will the next official release.
   * `nightly`: This release is the current alpha / experimental release (like Firefox Nightly, Chrome Canary).
   * `esr`: This release is an Extended Support Release.

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -47,7 +47,7 @@
         "release_notes": { "type": "string", "format": "uri" },
         "status": {
           "type": "string",
-          "enum": ["retired", "current", "limited", "beta", "nightly", "esr", "planned"]
+          "enum": ["retired", "current", "exclusive", "beta", "nightly", "esr", "planned"]
         }
       },
       "required": ["status"],


### PR DESCRIPTION
Hi! Two small Samsung Internet browser data tweaks, please:

* We just [announced our new v7.4 Beta](https://medium.com/samsung-internet-dev/samsung-internet-v7-4-beta-is-here-bdbc9be9f102) so I've updated the data to reflect that.

* We previously introduced a new browser version status called 'limited', to use for our Samsung Internet v7.0 which (until the imminent general release) is only available on flagship Samsung devices. I checked that this is still the only example with this status. After discussing, we felt a better word to use to describe this is 'exclusive' (thanks to @torgo for the recommendation)!