### PR TITLE
gitignore: ignore log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /node_modules/
-npm-debug.log
-yarn-error.log
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /node_modules/
+npm-debug.log
+yarn-error.log


### PR DESCRIPTION
I suggest adding the `npm run` and `yarn run` [error] log files to the `.gitignore`.