### PR TITLE
CSS/@media: add device-(aspect-ratio|height|width)

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -462,6 +462,162 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "device-aspect-ratio": {
+          "__compat": {
+            "description": "<code>device-aspect-ratio</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/device-aspect-ratio",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "device-height": {
+          "__compat": {
+            "description": "<code>device-height</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/device-height",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "device-width": {
+          "__compat": {
+            "description": "<code>device-width</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/device-width",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -485,10 +485,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": true
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": true
               },
               "ie": {
                 "version_added": null
@@ -537,10 +537,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": true
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": true
               },
               "ie": {
                 "version_added": null
@@ -589,10 +589,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": true
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": true
               },
               "ie": {
                 "version_added": null

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -473,10 +473,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/device-aspect-ratio",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": null
@@ -525,10 +525,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/device-height",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": null
@@ -577,10 +577,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/device-width",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": null


### PR DESCRIPTION
* [device-aspect-ratio](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/device-aspect-ratio)
* [device-height](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/device-height)
* [device-width](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/device-width)

The MDN pages did not include any legacy compat data, but Chrome and Firefox still support these deprecated `@media` features according to their repositories (see links in commit messages).