### PR TITLE
CSS/@media: add overflow-(block|inline)

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -903,10 +903,12 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1422235'>bug 1422235</a>."
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1422235'>bug 1422235</a>."
               },
               "ie": {
                 "version_added": null
@@ -955,10 +957,12 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1422235'>bug 1422235</a>."
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1422235'>bug 1422235</a>."
               },
               "ie": {
                 "version_added": null

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -891,10 +891,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/overflow-block",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": null
@@ -945,10 +945,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/overflow-inline",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": null

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -885,6 +885,110 @@
             }
           }
         },
+        "overflow-block": {
+          "__compat": {
+            "description": "<code>overflow-block</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/overflow-block",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "overflow-inline": {
+          "__compat": {
+            "description": "<code>overflow-inline</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/overflow-inline",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "pointer": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/pointer",


### PR DESCRIPTION
* [overflow-block](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/overflow-block)
* [overflow-inline](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/overflow-inline)

The MDN pages don't contain legacy compat data, so I added Chrome & Firefox data according to their repository and bug tracker respectively.