### PR TITLE
ImageCapture API

### DIFF
--- a/api/ImageCapture.json
+++ b/api/ImageCapture.json
@@ -53,7 +53,7 @@
       "ImageCapture": {
         "__compat": {
           "description": "<code>ImageCapture()</code> constructor",
-          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/ImageCapture/ImageCapture",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageCapture/ImageCapture",
           "support": {
             "webview_android": {
               "version_added": "59"
@@ -104,7 +104,7 @@
       },
       "track": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/ImageCapture/track",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageCapture/track",
           "support": {
             "webview_android": {
               "version_added": "59"
@@ -155,7 +155,7 @@
       },
       "getPhotoCapabilities": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/ImageCapture/getPhotoCapabilities",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageCapture/getPhotoCapabilities",
           "support": {
             "webview_android": {
               "version_added": "59"
@@ -206,7 +206,7 @@
       },
       "getPhotoSettings": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/ImageCapture/getPhotoSettings",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageCapture/getPhotoSettings",
           "support": {
             "webview_android": {
               "version_added": "61"
@@ -257,7 +257,7 @@
       },
       "grabFrame": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/ImageCapture/grabFrame",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageCapture/grabFrame",
           "support": {
             "webview_android": {
               "version_added": "59"
@@ -308,7 +308,7 @@
       },
       "takePhoto": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/ImageCapture/takePhoto",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageCapture/takePhoto",
           "support": {
             "webview_android": {
               "version_added": "59",

--- a/api/ImageCapture.json
+++ b/api/ImageCapture.json
@@ -1,0 +1,366 @@
+{
+  "api": {
+    "ImageCapture": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageCapture",
+        "support": {
+          "webview_android": {
+            "version_added": "59"
+          },
+          "chrome": {
+            "version_added": "59"
+          },
+          "chrome_android": {
+            "version_added": "59"
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": null
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "46"
+          },
+          "opera_android": {
+            "version_added": "46"
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          },
+          "samsunginternet_android": {
+            "version_added": "7.0"
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "ImageCapture": {
+        "__compat": {
+          "description": "<code>ImageCapture()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/ImageCapture/ImageCapture",
+          "support": {
+            "webview_android": {
+              "version_added": "59"
+            },
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "46"
+            },
+            "opera_android": {
+              "version_added": "46"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }  
+      },
+      "track": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/ImageCapture/track",
+          "support": {
+            "webview_android": {
+              "version_added": "59"
+            },
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "46"
+            },
+            "opera_android": {
+              "version_added": "46"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }  
+      },
+      "getPhotoCapabilities": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/ImageCapture/getPhotoCapabilities",
+          "support": {
+            "webview_android": {
+              "version_added": "59"
+            },
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "46"
+            },
+            "opera_android": {
+              "version_added": "46"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }  
+        }
+      },
+      "getPhotoSettings": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/ImageCapture/getPhotoSettings",
+          "support": {
+            "webview_android": {
+              "version_added": "61"
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "46"
+            },
+            "opera_android": {
+              "version_added": "46"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }  
+        }
+      },
+      "grabFrame": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/ImageCapture/grabFrame",
+          "support": {
+            "webview_android": {
+              "version_added": "59"
+            },
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "46"
+            },
+            "opera_android": {
+              "version_added": "46"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }  
+        }
+      },
+      "takePhoto": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/ImageCapture/takePhoto",
+          "support": {
+            "webview_android": {
+              "version_added": "59",
+              "notes": "<code>photoSettings</code> argument added in version 60"
+            },
+            "chrome": {
+              "version_added": "59",
+              "notes": "<code>photoSettings</code> argument added in version 60"
+            },
+            "chrome_android": {
+              "version_added": "59",
+              "notes": "<code>photoSettings</code> argument added in version 60"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "46",
+              "notes": "<code>photoSettings</code> argument added in version 47"
+            },
+            "opera_android": {
+              "version_added": "46"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }  
+        }
+      }
+    }
+  }
+}

--- a/api/ImageCapture.json
+++ b/api/ImageCapture.json
@@ -100,7 +100,7 @@
             "standard_track": true,
             "deprecated": false
           }
-        }  
+        }
       },
       "track": {
         "__compat": {
@@ -151,7 +151,7 @@
             "standard_track": true,
             "deprecated": false
           }
-        }  
+        }
       },
       "getPhotoCapabilities": {
         "__compat": {
@@ -201,7 +201,7 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }  
+          }
         }
       },
       "getPhotoSettings": {
@@ -252,7 +252,7 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }  
+          }
         }
       },
       "grabFrame": {
@@ -303,7 +303,7 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }  
+          }
         }
       },
       "takePhoto": {
@@ -358,7 +358,7 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }  
+          }
         }
       }
     }

--- a/api/ImageCapture.json
+++ b/api/ImageCapture.json
@@ -4,9 +4,6 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageCapture",
         "support": {
-          "webview_android": {
-            "version_added": "59"
-          },
           "chrome": {
             "version_added": "59"
           },
@@ -42,6 +39,9 @@
           },
           "samsunginternet_android": {
             "version_added": "7.0"
+          },
+          "webview_android": {
+            "version_added": "59"
           }
         },
         "status": {
@@ -55,9 +55,6 @@
           "description": "<code>ImageCapture()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageCapture/ImageCapture",
           "support": {
-            "webview_android": {
-              "version_added": "59"
-            },
             "chrome": {
               "version_added": "59"
             },
@@ -93,57 +90,9 @@
             },
             "samsunginternet_android": {
               "version_added": "7.0"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "track": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageCapture/track",
-          "support": {
+            },
             "webview_android": {
               "version_added": "59"
-            },
-            "chrome": {
-              "version_added": "59"
-            },
-            "chrome_android": {
-              "version_added": "59"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": "46"
-            },
-            "opera_android": {
-              "version_added": "46"
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": "7.0"
             }
           },
           "status": {
@@ -157,9 +106,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageCapture/getPhotoCapabilities",
           "support": {
-            "webview_android": {
-              "version_added": "59"
-            },
             "chrome": {
               "version_added": "59"
             },
@@ -195,6 +141,9 @@
             },
             "samsunginternet_android": {
               "version_added": "7.0"
+            },
+            "webview_android": {
+              "version_added": "59"
             }
           },
           "status": {
@@ -208,9 +157,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageCapture/getPhotoSettings",
           "support": {
-            "webview_android": {
-              "version_added": "61"
-            },
             "chrome": {
               "version_added": "61"
             },
@@ -246,6 +192,9 @@
             },
             "samsunginternet_android": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": "61"
             }
           },
           "status": {
@@ -259,9 +208,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageCapture/grabFrame",
           "support": {
-            "webview_android": {
-              "version_added": "59"
-            },
             "chrome": {
               "version_added": "59"
             },
@@ -297,6 +243,9 @@
             },
             "samsunginternet_android": {
               "version_added": "7.0"
+            },
+            "webview_android": {
+              "version_added": "59"
             }
           },
           "status": {
@@ -310,37 +259,26 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageCapture/takePhoto",
           "support": {
-            "webview_android": [
-              {
-                "version_added": "59",
-                "partial_implementation": true,
-                "version_removed": "60",
-                "notes": "<code>photoSettings</code> argument not supported"
-              },
-              {
-                "version_added": "60"
-              }
-            ],
             "chrome": [
               {
+                "version_added": "60"
+              },
+              {
                 "version_added": "59",
                 "partial_implementation": true,
                 "version_removed": "60",
-                "notes": "<code>photoSettings</code> argument not supported"
-              },
-              {
-                "version_added": "60"
+                "notes": "<code>photoSettings</code> argument not supported."
               }
             ],
             "chrome_android": [
               {
+                "version_added": "60"
+              },
+              {
                 "version_added": "59",
                 "partial_implementation": true,
                 "version_removed": "60",
-                "notes": "<code>photoSettings</code> argument not supported"
-              },
-              {
-                "version_added": "60"
+                "notes": "<code>photoSettings</code> argument not supported."
               }
             ],
             "edge": {
@@ -360,13 +298,13 @@
             },
             "opera": [
               {
+                "version_added": "47"
+              },
+              {
                 "version_added": "46",
                 "partial_implementation": true,
                 "version_removed": "47",
-                "notes": "<code>photoSettings</code> argument not supported"
-              },
-              {
-                "version_added": "47"
+                "notes": "<code>photoSettings</code> argument not supported."
               }
             ],
             "opera_android": {
@@ -380,6 +318,68 @@
             },
             "samsunginternet_android": {
               "version_added": "7.0"
+            },
+            "webview_android": [
+              {
+                "version_added": "60"
+              },
+              {
+                "version_added": "59",
+                "partial_implementation": true,
+                "version_removed": "60",
+                "notes": "<code>photoSettings</code> argument not supported."
+              }
+            ]
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "track": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageCapture/track",
+          "support": {
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "46"
+            },
+            "opera_android": {
+              "version_added": "46"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            },
+            "webview_android": {
+              "version_added": "59"
             }
           },
           "status": {

--- a/api/ImageCapture.json
+++ b/api/ImageCapture.json
@@ -310,18 +310,39 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageCapture/takePhoto",
           "support": {
-            "webview_android": {
-              "version_added": "59",
-              "notes": "<code>photoSettings</code> argument added in version 60"
-            },
-            "chrome": {
-              "version_added": "59",
-              "notes": "<code>photoSettings</code> argument added in version 60"
-            },
-            "chrome_android": {
-              "version_added": "59",
-              "notes": "<code>photoSettings</code> argument added in version 60"
-            },
+            "webview_android": [
+              {
+                "version_added": "59",
+                "partial_implementation": true,
+                "version_removed": "60",
+                "notes": "<code>photoSettings</code> argument not supported"
+              },
+              {
+                "version_added": "60"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "59",
+                "partial_implementation": true,
+                "version_removed": "60",
+                "notes": "<code>photoSettings</code> argument not supported"
+              },
+              {
+                "version_added": "60"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "59",
+                "partial_implementation": true,
+                "version_removed": "60",
+                "notes": "<code>photoSettings</code> argument not supported"
+              },
+              {
+                "version_added": "60"
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -337,10 +358,17 @@
             "ie": {
               "version_added": null
             },
-            "opera": {
-              "version_added": "46",
-              "notes": "<code>photoSettings</code> argument added in version 47"
-            },
+            "opera": [
+              {
+                "version_added": "46",
+                "partial_implementation": true,
+                "version_removed": "47",
+                "notes": "<code>photoSettings</code> argument not supported"
+              },
+              {
+                "version_added": "47"
+              }
+            ],
             "opera_android": {
               "version_added": "46"
             },


### PR DESCRIPTION
Hi. (My first new API file!)

Some notes:

* I used our [Chromium version mapping](https://github.com/SamsungInternet/mdn-bcd-map-browser-data) for Samsung Internet browser support, plus double-checked that by testing [this sample demo](https://rawgit.com/Miguelao/demos/master/imagecapture2.html) in v6.4 (unsupported) and v7.4 (supported).
* The [Constructor page](https://developer.mozilla.org/en-US/docs/Web/API/ImageCapture/ImageCapture) currently shows the non-standard warning, but I updated it to reflect the rest of the API, i.e. experimental, but on the standards track.
* I added `notes` to the `takePhoto` data, to reflect the [additional property included in the table there](https://developer.mozilla.org/en-US/docs/Web/API/ImageCapture/takePhoto).
