### PR TITLE
Update compat data for font properties for CSS Fonts Level 4

### DIFF
--- a/css/properties/font-stretch.json
+++ b/css/properties/font-stretch.json
@@ -53,7 +53,7 @@
         },
         "percentage": {
           "__compat": {
-            "description": "<code>&lt;percentage&gt;</code> syntax.",
+            "description": "<code>&lt;percentage&gt;</code> syntax",
             "support": {
               "webview_android": {
                 "version_added": false

--- a/css/properties/font-stretch.json
+++ b/css/properties/font-stretch.json
@@ -50,6 +50,57 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "percentage": {
+          "__compat": {
+            "description": "<code>&lt;percentage&gt;</code> syntax.",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "61"
+              },
+              "firefox_android": {
+                "version_added": "61"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -55,7 +55,7 @@
         },
         "oblique-angle": {
           "__compat": {
-            "description": "<code>oblique</code> can accept an <code>&lt;angle&gt;</code>.",
+            "description": "<code>oblique</code> can accept an <code>&lt;angle&gt;</code>",
             "support": {
               "webview_android": {
                 "version_added": null

--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -52,6 +52,57 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "oblique-angle": {
+          "__compat": {
+            "description": "<code>oblique</code> can accept an <code>&lt;angle&gt;</code>.",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "61"
+              },
+              "firefox_android": {
+                "version_added": "61"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/font-weight.json
+++ b/css/properties/font-weight.json
@@ -53,7 +53,7 @@
         },
         "number": {
           "__compat": {
-            "description": "<code>&lt;number&gt;</code> syntax.",
+            "description": "<code>&lt;number&gt;</code> syntax",
             "support": {
               "webview_android": {
                 "version_added": null

--- a/css/properties/font-weight.json
+++ b/css/properties/font-weight.json
@@ -50,6 +50,57 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "number": {
+          "__compat": {
+            "description": "<code>&lt;number&gt;</code> syntax.",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "61"
+              },
+              "firefox_android": {
+                "version_added": "61"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This updates the compat data as follows:

* `font-stretch`: add a subfeature representing the ability to take a `<percentage>`
* `font-style`: add a subfeature representing the ability to add an `<angle>` to the `oblique` keyword
* `font-weight`: add a subfeature representing the ability to take a `<number>`

These are all additions in [CSS Fonts Level 4](https://drafts.csswg.org/css-fonts-4/).

They ship in [Firefox 61]( https://bugzilla.mozilla.org/show_bug.cgi?id=1436048). I've added `null` for other browser except where I'm pretty sure it is not supported. I've checked in Chrome.

There's more information in the docs for  [`font-stretch`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-stretch) and [`font-weight`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight), including demos you can use to test whether a given browser does support the new syntaxes.
I didn't update the [`font-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style) docs yet.
