### PR TITLE
font-style property: adding data for optional angle value that can be included after the oblique keyword

### DIFF
--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -52,6 +52,59 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "oblique_angle": {
+          "__compat": {
+            "description": "Angle value after <code>oblique</code> keyword",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "61"
+              },
+              "firefox_android": {
+                "version_added": "61"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "Ignores the angle value but still applies basic oblique rendering to the text."
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "Ignores the angle value but still applies basic oblique rendering to the text."
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1436048