### PR TITLE
API: add HTMLKeygenElement

### DIFF
--- a/api/HTMLKeygenElement.json
+++ b/api/HTMLKeygenElement.json
@@ -1,0 +1,60 @@
+{
+  "api": {
+    "HTMLKeygenElement": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLKeygenElement",
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": true,
+            "version_removed": "57",
+            "notes": "See <a href='https://www.chromestatus.com/features/5716060992962560'>Chrome Platform Status</a>."
+          },
+          "chrome_android": {
+            "version_added": true,
+            "version_removed": "57",
+            "notes": "See <a href='https://www.chromestatus.com/features/5716060992962560'>Chrome Platform Status</a>."
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": true,
+            "partial_implementation": true,
+            "notes": "See <a href='https://bugzil.la/1315460'>Bug 1315460</a>."
+          },
+          "firefox_android": {
+            "version_added": true,
+            "partial_implementation": true,
+            "notes": "See <a href='https://bugzil.la/1315460'>Bug 1315460</a>."
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
[HTMLKeygenElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLKeygenElement)

I have omitted the sub-features (i.e. attributes), since the element [has been removed in HTML 5.2](https://github.com/w3c/html/issues/43), is [no longer supported in Chrome](https://www.chromestatus.com/features/5716060992962560), was [never properly supported in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=101019) and [is being removed in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1315460).

P.S.: It is a pity that the `status` object does not allow `notes`, which would be handy to document the deprecation:

```js
// ...
"status": {
  "experimental": false,
  "standard_track": false,
  "deprecated": true,
  "notes": "Removed in HTML 5.2, see <a href='https://github.com/w3c/html/issues/43>GitHub Issue</a>.",
 }
// ...