### PR TITLE
API: add UserDataHandler

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -1221,6 +1221,56 @@
           }
         }
       },
+      "setUserData": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/setUserData",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "4",
+              "version_removed": "22"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "22"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
       "textContent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/textContent",

--- a/api/UserDataHandler.json
+++ b/api/UserDataHandler.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/UserDataHandler",
         "support": {
           "webview_android": {
-            "version_added": null
+            "version_added": false
           },
           "chrome": {
-            "version_added": null
+            "version_added": false
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": false
           },
           "edge": {
             "version_added": null
@@ -20,25 +20,27 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": "4",
+            "version_removed": "22"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "4",
+            "version_removed": "22"
           },
           "ie": {
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": false
           },
           "opera_android": {
-            "version_added": null
+            "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           }
         },
         "status": {
@@ -52,13 +54,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/UserDataHandler/handle",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -67,25 +69,27 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "22"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "22"
             },
             "ie": {
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/api/UserDataHandler.json
+++ b/api/UserDataHandler.json
@@ -1,0 +1,100 @@
+{
+  "api": {
+    "UserDataHandler": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/UserDataHandler",
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": null
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
+        }
+      },
+      "handle": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/UserDataHandler/handle",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
[UserDataHandler](https://developer.mozilla.org/en-US/docs/Web/API/UserDataHandler)

It's part of [DOM Level 3 Core](https://www.w3.org/TR/DOM-Level-3-Core/core.html#UserDataHandler), but [meanwhile removed in DOM Level 4 Core](https://dom.spec.whatwg.org/#dom-core-changes) and doesn't seem to be exposed in Firefox anymore (because it was only available in the context of [Node.setUserData()](https://developer.mozilla.org/en-US/docs/Web/API/Node/setUserData), which was only supported in Firefox versions 1 to 22).

I have now added compat data for `Node.setUserData()` from [the corresponding MDN page](https://developer.mozilla.org/en-US/docs/Web/API/Node/setUserData) (which was the only place in the API that used `UserDataHandler`) and used the same compat data for `UserDataHandler`.

P.S.: I was not able to determine (and so did not add) compat data for Edge/IE, even though it may be fair to assume that they don't support `UserDataHandler`.