### PR TITLE
HTTP/Headers: add X-DNS-Prefetch-Control

### DIFF
--- a/http/headers/x-dns-prefetch-control.json
+++ b/http/headers/x-dns-prefetch-control.json
@@ -1,0 +1,57 @@
+{
+  "http": {
+    "headers": {
+      "X-DNS-Prefetch-Control": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "1"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "2"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
[X-DNS-Prefetch-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control)

Sources:
1. Chromium repository:
   https://chromium.googlesource.com/chromium/src/+/9445cf2dd8d8ec3e156d999fd37d097530e98e0f%5E%21/third_party/WebKit/WebCore/dom/Document.cpp
2. Firefox bug tracker:
   https://bugzil.la/492196