### PR TITLE
HTTP/Headers: add Tk

### DIFF
--- a/http/headers/tk.json
+++ b/http/headers/tk.json
@@ -46,7 +46,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/http/headers/tk.json
+++ b/http/headers/tk.json
@@ -1,0 +1,57 @@
+{
+  "http": {
+    "headers": {
+      "Tk": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Tk",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Tk

The draft of the Tracking Preference Expression specification [1]
doesn't mention any browser behaviour linked to the `Tk` header.
Therefore it is hard to say whether a browser is compatible.

A browser could parse and visualize the content of the header,
but this should not be considered a requirement for compatibility.

[1] https://www.w3.org/2011/tracking-protection/drafts/tracking-dnt.html#Tk-header-defn