### PR TITLE
HTTP/Headers: add Forwarded

### DIFF
--- a/http/headers/forwarded.json
+++ b/http/headers/forwarded.json
@@ -1,0 +1,57 @@
+{
+  "http": {
+    "headers": {
+      "Forwarded": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Forwarded",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The header is, according to RFC 7739 [1], "only for use in HTTP
requests and is not to be used in HTTP responses". Therefore
it is unclear how to decide upon browser compatibility.

[1] https://tools.ietf.org/html/rfc7239#section-4