### PR TITLE
HTTP/Headers: add Expect

### DIFF
--- a/http/headers/expect.json
+++ b/http/headers/expect.json
@@ -1,0 +1,57 @@
+{
+  "http": {
+    "headers": {
+      "Expect": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Expect",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/expect.json
+++ b/http/headers/expect.json
@@ -9,10 +9,10 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": false
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -21,19 +21,19 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": null
             },
             "ie": {
               "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
               "version_added": null


### PR DESCRIPTION
I have defined compatibility here as using the header, i.e.
a browser that doesn't use/send the header, is not compatible.

Sources:
1. Chrome repository:
   https://cs.chromium.org/search/?q=%22%27Expect%27%22&sq=package:chromium&type=cs
2. Firefox repository:
   https://dxr.mozilla.org/mozilla-central/search?q=%2Bvar-ref%3Amozilla%3A%3Anet%3A%3AnsHttp%3A%3AExpect