### PR TITLE
javascript/operators/spread.json: nodejs update

### DIFF
--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -195,7 +195,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.3.0"
               },
               "opera": {
                 "version_added": null

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -5,7 +5,7 @@
         "spread_in_arrays": {
           "__compat": {
             "description": "Spread in array literals",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_operator#Spread_in_array_literals",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_array_literals",
             "support": {
               "webview_android": {
                 "version_added": "46"
@@ -60,7 +60,7 @@
         "spread_in_function_calls": {
           "__compat": {
             "description": "Spread in function calls",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_operator#Spread_in_function_calls",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_function_calls",
             "support": {
               "webview_android": {
                 "version_added": "46"
@@ -169,6 +169,7 @@
         "spread_in_object_literals": {
           "__compat": {
             "description": "Spread in object literals",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_object_literals",
             "support": {
               "webview_android": {
                 "version_added": "60"

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -37,7 +37,6 @@
                 },
                 {
                   "version_added": "4.0.0",
-                  "version_removed": "5.0.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -104,7 +103,6 @@
                 },
                 {
                   "version_added": "4.0.0",
-                  "version_removed": "5.0.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -225,7 +223,6 @@
                 },
                 {
                   "version_added": "8.0.0",
-                  "version_removed": "8.3.0",
                   "flags": [
                     {
                       "type": "runtime_flag",

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -31,9 +31,21 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": true
-              },
+              "nodejs": [
+                {
+                  "version_added": "5.0.0"
+                },
+                {
+                  "version_added": "4.0.0",
+                  "version_removed": "5.0.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": "37"
               },

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -195,10 +195,21 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "8",
-                "notes": "Available since Node.js 8.3.0 (was a staged feature available with --harmony flag since Node.js 8.0.0)"
-              },
+              "nodejs": [
+                {
+                  "version_added": "8.3.0"
+                },
+                {
+                  "version_added": "8.0.0",
+                  "version_removed": "8.3.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": null
               },

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -195,7 +195,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "8.3.0"
+                "version_added": "8"
               },
               "opera": {
                 "version_added": null

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -98,9 +98,21 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": true
-              },
+              "nodejs": [
+                {
+                  "version_added": "5.0.0"
+                },
+                {
+                  "version_added": "4.0.0",
+                  "version_removed": "5.0.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": "37"
               },

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -195,7 +195,8 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "8"
+                "version_added": "8",
+                "notes": "Available since Node.js 8.3.0 (was a staged feature available with --harmony flag since Node.js 8.0.0)"
               },
               "opera": {
                 "version_added": null


### PR DESCRIPTION
Spread in object literals has been available in Node.js since 8.3.0. (Since 8.0.0, it was available with the `--harmony` flag.)
- https://node.green/#ES2018-features-object-rest-spread-properties shows that object rest/spread properties have been available since 8.3.0
- https://nodejs.org/en/blog/release/v8.3.0/ says: "V8 engine has been upgraded to version 6.0"
- https://v8project.blogspot.com/2017/06/v8-release-60.html says: "This release introduces rest properties for object destructuring assignment and spread properties for object literals"