### PR TITLE
API: add StyleSheet

### DIFF
--- a/api/StyleSheet.json
+++ b/api/StyleSheet.json
@@ -1,0 +1,388 @@
+{
+  "api": {
+    "StyleSheet": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet",
+        "support": {
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome": {
+            "version_added": "1"
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "22"
+          },
+          "firefox_android": {
+            "version_added": "22"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "type": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/type",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "22"
+            },
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "href": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/href",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "22"
+            },
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ownerNode": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/ownerNode",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "22"
+            },
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "parentStyleSheet": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/parentStyleSheet",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "22"
+            },
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "title": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/title",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "22"
+            },
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "media": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/media",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "22"
+            },
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "disabled": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/disabled",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "22"
+            },
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/StyleSheet.json
+++ b/api/StyleSheet.json
@@ -4,9 +4,6 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet",
         "support": {
-          "webview_android": {
-            "version_added": true
-          },
           "chrome": {
             "version_added": "1"
           },
@@ -20,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": "22"
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": "22"
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -39,6 +36,9 @@
           },
           "safari_ios": {
             "version_added": null
+          },
+          "webview_android": {
+            "version_added": true
           }
         },
         "status": {
@@ -47,13 +47,10 @@
           "deprecated": false
         }
       },
-      "type": {
+      "disabled": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/type",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/disabled",
           "support": {
-            "webview_android": {
-              "version_added": true
-            },
             "chrome": {
               "version_added": "1"
             },
@@ -67,10 +64,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": "22"
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -86,6 +83,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -99,9 +99,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/href",
           "support": {
-            "webview_android": {
-              "version_added": true
-            },
             "chrome": {
               "version_added": "1"
             },
@@ -115,10 +112,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": "22"
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -134,150 +131,9 @@
             },
             "safari_ios": {
               "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "ownerNode": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/ownerNode",
-          "support": {
+            },
             "webview_android": {
               "version_added": true
-            },
-            "chrome": {
-              "version_added": "1"
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "22"
-            },
-            "firefox_android": {
-              "version_added": "22"
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "parentStyleSheet": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/parentStyleSheet",
-          "support": {
-            "webview_android": {
-              "version_added": true
-            },
-            "chrome": {
-              "version_added": "1"
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "22"
-            },
-            "firefox_android": {
-              "version_added": "22"
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "title": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/title",
-          "support": {
-            "webview_android": {
-              "version_added": true
-            },
-            "chrome": {
-              "version_added": "1"
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "22"
-            },
-            "firefox_android": {
-              "version_added": "22"
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
             }
           },
           "status": {
@@ -291,9 +147,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/media",
           "support": {
-            "webview_android": {
-              "version_added": true
-            },
             "chrome": {
               "version_added": "1"
             },
@@ -307,10 +160,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": "22"
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -326,6 +179,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -335,13 +191,10 @@
           }
         }
       },
-      "disabled": {
+      "ownerNode": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/disabled",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/ownerNode",
           "support": {
-            "webview_android": {
-              "version_added": true
-            },
             "chrome": {
               "version_added": "1"
             },
@@ -355,10 +208,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": "22"
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -374,6 +227,153 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "parentStyleSheet": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/parentStyleSheet",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "title": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/title",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "type": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheet/type",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
Sources:
1. CSS Object Model specification:
   https://drafts.csswg.org/cssom/#stylesheet
2. Chromium repository:
   https://github.com/chromium/chromium/blob/1182c84d9849940a6f6be3ec22d8b244dc554a53/third_party/blink/renderer/core/css/style_sheet.idl
   https://chromium.googlesource.com/chromium/src/+blame/3c5d7826be996563c73451a09bcbbddee8b3fed6/third_party/WebKit/WebCore/css/StyleSheet.idl
3. Firefox bug tracker:
   https://bugzil.la/846972
4. Firefox repository:
   https://github.com/mozilla/gecko-dev/blob/2169694adb1b691bcea73840bf3233de7379bcc5/dom/webidl/StyleSheet.webidl