### PR TITLE
API: add StorageEvent

### DIFF
--- a/api/StorageEvent.json
+++ b/api/StorageEvent.json
@@ -1,0 +1,389 @@
+{
+  "api": {
+    "StorageEvent": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent",
+        "support": {
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome": {
+            "version_added": "1"
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "24"
+          },
+          "firefox_android": {
+            "version_added": "24"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "StorageEvent": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent/StorageEvent",
+          "description": "<code>StorageEvent</code> constructor",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "17"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "24"
+            },
+            "firefox_android": {
+              "version_added": "24"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "key": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent/key",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "24"
+            },
+            "firefox_android": {
+              "version_added": "24"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "oldValue": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent/oldValue",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "24"
+            },
+            "firefox_android": {
+              "version_added": "24"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "newValue": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent/newValue",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "24"
+            },
+            "firefox_android": {
+              "version_added": "24"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "url": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent/url",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "5"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "24"
+            },
+            "firefox_android": {
+              "version_added": "24"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "storageArea": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent/storageArea",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "24"
+            },
+            "firefox_android": {
+              "version_added": "24"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "initStorageEvent": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent/initStorageEvent",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "24"
+            },
+            "firefox_android": {
+              "version_added": "24"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/StorageEvent.json
+++ b/api/StorageEvent.json
@@ -4,9 +4,6 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent",
         "support": {
-          "webview_android": {
-            "version_added": true
-          },
           "chrome": {
             "version_added": "1"
           },
@@ -39,6 +36,9 @@
           },
           "safari_ios": {
             "version_added": null
+          },
+          "webview_android": {
+            "version_added": true
           }
         },
         "status": {
@@ -50,11 +50,8 @@
       "StorageEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent/StorageEvent",
-          "description": "<code>StorageEvent</code> constructor",
+          "description": "<code>StorageEvent()</code> constructor",
           "support": {
-            "webview_android": {
-              "version_added": true
-            },
             "chrome": {
               "version_added": "17"
             },
@@ -87,11 +84,62 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "initStorageEvent": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent/initStorageEvent",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "24"
+            },
+            "firefox_android": {
+              "version_added": "24"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -100,9 +148,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent/key",
           "support": {
-            "webview_android": {
-              "version_added": true
-            },
             "chrome": {
               "version_added": "1"
             },
@@ -135,54 +180,9 @@
             },
             "safari_ios": {
               "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "oldValue": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent/oldValue",
-          "support": {
+            },
             "webview_android": {
               "version_added": true
-            },
-            "chrome": {
-              "version_added": "1"
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "24"
-            },
-            "firefox_android": {
-              "version_added": "24"
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
             }
           },
           "status": {
@@ -196,9 +196,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent/newValue",
           "support": {
-            "webview_android": {
-              "version_added": true
-            },
             "chrome": {
               "version_added": "1"
             },
@@ -231,6 +228,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -240,15 +240,12 @@
           }
         }
       },
-      "url": {
+      "oldValue": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent/url",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent/oldValue",
           "support": {
-            "webview_android": {
-              "version_added": true
-            },
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -279,6 +276,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -292,9 +292,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent/storageArea",
           "support": {
-            "webview_android": {
-              "version_added": true
-            },
             "chrome": {
               "version_added": "3"
             },
@@ -327,6 +324,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -336,15 +336,12 @@
           }
         }
       },
-      "initStorageEvent": {
+      "url": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent/initStorageEvent",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEvent/url",
           "support": {
-            "webview_android": {
-              "version_added": true
-            },
             "chrome": {
-              "version_added": true
+              "version_added": "5"
             },
             "chrome_android": {
               "version_added": true
@@ -375,11 +372,14 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/StorageEvent.json
+++ b/api/StorageEvent.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": "24"
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": "24"
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -65,10 +65,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "24"
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": "24"
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -113,10 +113,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "24"
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": "24"
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -161,10 +161,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "24"
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": "24"
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -209,10 +209,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "24"
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": "24"
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -257,10 +257,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "24"
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": "24"
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -305,10 +305,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "24"
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": "24"
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -353,10 +353,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "24"
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": "24"
+              "version_added": true
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
Sources:
1. HTML Living Standard:
   https://html.spec.whatwg.org/multipage/webstorage.html#storageevent
2. Chromium repository:
   https://chromium.googlesource.com/chromium/src/+/eabc6317c04db020078231bf47d6a72c7625c118/third_party/blink/renderer/modules/storage/storage_event.idl (status quo)
   https://chromium.googlesource.com/chromium/src/+/0d01a365329d7c8d80f8c14193f2ab98188b0ac3%5E%21/third_party/WebKit/WebCore/storage/StorageEvent.idl (initial)
   https://chromium.googlesource.com/chromium/src/+/2f0abcf327d15a82d7f230929d1f2336e6882898%5E%21/third_party/WebKit/WebCore/storage/StorageEvent.idl (storageArea)
   https://chromium.googlesource.com/chromium/src/+/2f86fb1a99635cc0c72cf0e4d3c459fd5f36fd3b%5E%21/third_party/WebKit/WebCore/storage/StorageEvent.idl (url)
   https://chromium.googlesource.com/chromium/src/+/1f5ca965858592f4c071b81e955087d4fe7d2670%5E%21/third_party/WebKit/Source/WebCore/storage/StorageEvent.idl (constructor)
3. Firefox bug tracker:
   https://bugzil.la/847611
4. Firefox repository:
   https://github.com/mozilla/gecko-dev/blob/04b9cbbc2be2137a37e158a5ebaf9c7bef2364f9/dom/webidl/StorageEvent.webidl