### PR TITLE
API: add StorageEstimate

### DIFF
--- a/api/StorageEstimate.json
+++ b/api/StorageEstimate.json
@@ -1,0 +1,148 @@
+{
+  "api": {
+    "StorageEstimate": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageEstimate",
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": "52"
+          },
+          "chrome_android": {
+            "version_added": "52"
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "51"
+          },
+          "firefox_android": {
+            "version_added": "51"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "42"
+          },
+          "opera_android": {
+            "version_added": "42"
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "quota": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/quota",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "52"
+            },
+            "chrome_android": {
+              "version_added": "52"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "51"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "42"
+            },
+            "opera_android": {
+              "version_added": "42"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "usage": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/usage",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "52"
+            },
+            "chrome_android": {
+              "version_added": "52"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "51"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "42"
+            },
+            "opera_android": {
+              "version_added": "42"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Sources:
1. Storage Standard:
2. Chromium repository:
   https://chromium.googlesource.com/chromium/src/+/703806a09a9c9dc295e29c86d079dfef4dc67f40%5E%21/third_party/WebKit/Source/modules/quota/StorageEstimate.idl
3. Firefox bug tracker:
   https://bugzil.la/1267941 (initial)
4. Firefox repository:
   https://github.com/mozilla/gecko-dev/blob/73b4d6b26a1d1ff689079c7b5bc8d4f9a4aed1bc/dom/webidl/StorageManager.webidl