### PR TITLE
API/StorageManager: add compat data

### DIFF
--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -4,9 +4,6 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageManager",
         "support": {
-          "webview_android": {
-            "version_added": "48"
-          },
           "chrome": {
             "version_added": "48"
           },
@@ -64,6 +61,9 @@
           },
           "samsunginternet_android": {
             "version_added": null
+          },
+          "webview_android": {
+            "version_added": "48"
           }
         },
         "status": {
@@ -76,9 +76,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageManager/estimate",
           "support": {
-            "webview_android": {
-              "version_added": "52"
-            },
             "chrome": {
               "version_added": "52"
             },
@@ -114,6 +111,9 @@
             },
             "samsunginternet_android": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": "52"
             }
           },
           "status": {
@@ -127,16 +127,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageManager/persist",
           "support": {
-            "webview_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "alternative_name": "requestPersistend",
-                "version_added": "48",
-                "version_removed": "52"
-              }
-            ],
             "chrome": [
               {
                 "version_added": "52"
@@ -186,7 +176,17 @@
             },
             "samsunginternet_android": {
               "version_added": null
-            }
+            },
+            "webview_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "alternative_name": "requestPersistend",
+                "version_added": "48",
+                "version_removed": "52"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -199,16 +199,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageManager/persisted",
           "support": {
-            "webview_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "alternative_name": "persistentPermission",
-                "version_added": "48",
-                "version_removed": "52"
-              }
-            ],
             "chrome": [
               {
                 "version_added": "52"
@@ -258,7 +248,17 @@
             },
             "samsunginternet_android": {
               "version_added": null
-            }
+            },
+            "webview_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "alternative_name": "persistentPermission",
+                "version_added": "48",
+                "version_removed": "52"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -26,7 +26,7 @@
             {
               "version_added": "51",
               "version_removed": "57",
-              "notes": "See <a href='https://bugzil.la/1304966'>Bug 1304966</a> and <a href='https://bugzil.la/1399038'>Bug 1399038</a>.",
+              "notes": "See <a href='https://bugzil.la/1304966'>bug 1304966</a> and <a href='https://bugzil.la/1399038'>bug 1399038</a>.",
               "flags": [
                 {
                   "type": "preference",
@@ -38,7 +38,7 @@
           ],
           "firefox_android": {
             "version_added": "51",
-            "notes": "See <a href='https://bugzil.la/1304966'>Bug 1304966</a> and <a href='https://bugzil.la/1399038'>Bug 1399038</a>.",
+            "notes": "See <a href='https://bugzil.la/1304966'>bug 1304966</a> and <a href='https://bugzil.la/1399038'>bug 1399038</a>.",
             "flags": [
               {
                 "type": "preference",

--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageManager",
         "support": {
           "webview_android": {
-            "version_added": null
+            "version_added": "48"
           },
           "chrome": {
-            "version_added": null
+            "version_added": "48"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "48"
           },
           "edge": {
             "version_added": null
@@ -19,20 +19,42 @@
           "edge_mobile": {
             "version_added": null
           },
-          "firefox": {
-            "version_added": null
-          },
+          "firefox": [
+            {
+              "version_added": "57"
+            },
+            {
+              "version_added": "51",
+              "version_removed": "57",
+              "notes": "See <a href='https://bugzil.la/1304966'>Bug 1304966</a> and <a href='https://bugzil.la/1399038'>Bug 1399038</a>.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.storageManager.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
-            "version_added": null
+            "version_added": "51",
+            "notes": "See <a href='https://bugzil.la/1304966'>Bug 1304966</a> and <a href='https://bugzil.la/1399038'>Bug 1399038</a>.",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.storageManager.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "ie": {
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -55,13 +77,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageManager/estimate",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "52"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "edge": {
               "version_added": null
@@ -70,19 +92,19 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "51"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "51"
             },
             "ie": {
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -105,15 +127,36 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageManager/persist",
           "support": {
-            "webview_android": {
-              "version_added": null
-            },
-            "chrome": {
-              "version_added": null
-            },
-            "chrome_android": {
-              "version_added": null
-            },
+            "webview_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "alternative_name": "requestPersistend",
+                "version_added": "48",
+                "version_removed": "52"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "52"
+              },
+              {
+                "alternative_name": "requestPersistend",
+                "version_added": "48",
+                "version_removed": "52"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "alternative_name": "requestPersistend",
+                "version_added": "48",
+                "version_removed": "52"
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -121,19 +164,19 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "ie": {
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -156,15 +199,36 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageManager/persisted",
           "support": {
-            "webview_android": {
-              "version_added": null
-            },
-            "chrome": {
-              "version_added": null
-            },
-            "chrome_android": {
-              "version_added": null
-            },
+            "webview_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "alternative_name": "persistentPermission",
+                "version_added": "48",
+                "version_removed": "52"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": "52"
+              },
+              {
+                "alternative_name": "persistentPermission",
+                "version_added": "48",
+                "version_removed": "52"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "alternative_name": "requestPersistend",
+                "version_added": "48",
+                "version_removed": "52"
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -172,19 +236,19 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "ie": {
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null


### PR DESCRIPTION
Sources:
1. MDN article:
   https://developer.mozilla.org/en-US/docs/Web/API/StorageManager#Browser_compatibility
2. Chromium repository:
   https://chromium.googlesource.com/chromium/src/+/21ba553558ed7cd65f59199b28dd8732f5dc93a0%5E%21/third_party/WebKit/Source/modules/quota/StorageManager.idl (initial)
   https://chromium.googlesource.com/chromium/src/+/703806a09a9c9dc295e29c86d079dfef4dc67f40%5E!/third_party/WebKit/Source/modules/quota/StorageManager.idl (estimate)
   https://chromium.googlesource.com/chromium/src/+/0b5bf0fd87c2dad9b2c7223a20f2b8b7756f3e57%5E%21/third_party/WebKit/Source/modules/quota/StorageManager.idl (persisted, persist)
3. Firefox bug tracker:
   https://bugzil.la/1267941 (estimate)
   https://bugzil.la/1286717 (persist, persisted)
4. Firefox repository:
   https://github.com/mozilla/gecko-dev/blob/ba9fa0d68ab991dd0eb90ab6545e82a38abf5678/dom/webidl/StorageManager.webidl (initial)
   https://github.com/mozilla/gecko-dev/blob/04b9cbbc2be2137a37e158a5ebaf9c7bef2364f9/dom/webidl/StorageManager.webidl (status quo)
   https://github.com/mozilla/gecko-dev/blob/04b9cbbc2be2137a37e158a5ebaf9c7bef2364f9/modules/libpref/init/all.js#L5723-L5727 (flag on Android)