### PR TITLE
API: add PublicKeyCredentialCreationOptions

### DIFF
--- a/api/PublicKeyCredentialCreationOptions.json
+++ b/api/PublicKeyCredentialCreationOptions.json
@@ -4,9 +4,6 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions",
         "support": {
-          "webview_android": {
-            "version_added": null
-          },
           "chrome": {
             "version_added": "67"
           },
@@ -39,6 +36,9 @@
           },
           "safari_ios": {
             "version_added": null
+          },
+          "webview_android": {
+            "version_added": null
           }
         },
         "status": {
@@ -47,61 +47,10 @@
           "deprecated": false
         }
       },
-      "rp": {
+      "attestation": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/rp",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/attestation",
           "support": {
-            "webview_android": {
-              "version_added": null
-            },
-            "chrome": {
-              "version_added": "67"
-            },
-            "chrome_android": {
-              "version_added": null
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "60"
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "user": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/user",
-          "support": {
-            "webview_android": {
-              "version_added": null
-            },
             "chrome": {
               "version_added": "67"
             },
@@ -134,197 +83,8 @@
             },
             "safari_ios": {
               "version_added": null
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "challenge": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/challenge",
-          "support": {
+            },
             "webview_android": {
-              "version_added": null
-            },
-            "chrome": {
-              "version_added": "67"
-            },
-            "chrome_android": {
-              "version_added": null
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "60"
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "pubKeyCredParams": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/pubKeyCredParams",
-          "support": {
-            "webview_android": {
-              "version_added": null
-            },
-            "chrome": {
-              "version_added": "67"
-            },
-            "chrome_android": {
-              "version_added": null
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "60"
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "timeout": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/timeout",
-          "support": {
-            "webview_android": {
-              "version_added": null
-            },
-            "chrome": {
-              "version_added": "67"
-            },
-            "chrome_android": {
-              "version_added": null
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "60"
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "excludeCredentials": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/excludeCredentials",
-          "support": {
-            "webview_android": {
-              "version_added": null
-            },
-            "chrome": {
-              "version_added": "67"
-            },
-            "chrome_android": {
-              "version_added": null
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "60"
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
               "version_added": null
             }
           },
@@ -339,9 +99,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/authenticatorSelection",
           "support": {
-            "webview_android": {
-              "version_added": null
-            },
             "chrome": {
               "version_added": "67"
             },
@@ -373,6 +130,9 @@
               "version_added": null
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
               "version_added": null
             }
           },
@@ -383,13 +143,10 @@
           }
         }
       },
-      "attestation": {
+      "challenge": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/attestation",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/challenge",
           "support": {
-            "webview_android": {
-              "version_added": null
-            },
             "chrome": {
               "version_added": "67"
             },
@@ -421,6 +178,57 @@
               "version_added": null
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "excludeCredentials": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/excludeCredentials",
+          "support": {
+            "chrome": {
+              "version_added": "67"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
               "version_added": null
             }
           },
@@ -435,9 +243,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/extensions",
           "support": {
-            "webview_android": {
-              "version_added": null
-            },
             "chrome": {
               "version_added": "67"
             },
@@ -469,6 +274,201 @@
               "version_added": null
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pubKeyCredParams": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/pubKeyCredParams",
+          "support": {
+            "chrome": {
+              "version_added": "67"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rp": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/rp",
+          "support": {
+            "chrome": {
+              "version_added": "67"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "timeout": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/timeout",
+          "support": {
+            "chrome": {
+              "version_added": "67"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "user": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/user",
+          "support": {
+            "chrome": {
+              "version_added": "67"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
               "version_added": null
             }
           },

--- a/api/PublicKeyCredentialCreationOptions.json
+++ b/api/PublicKeyCredentialCreationOptions.json
@@ -1,0 +1,484 @@
+{
+  "api": {
+    "PublicKeyCredentialCreationOptions": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions",
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": "67"
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "60"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "rp": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/rp",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "67"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "user": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/user",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "67"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "challenge": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/challenge",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "67"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "pubKeyCredParams": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/pubKeyCredParams",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "67"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "timeout": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/timeout",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "67"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "excludeCredentials": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/excludeCredentials",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "67"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "authenticatorSelection": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/authenticatorSelection",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "67"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "attestation": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/attestation",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "67"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "extensions": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/extensions",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "67"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/PublicKeyCredentialCreationOptions.json
+++ b/api/PublicKeyCredentialCreationOptions.json
@@ -93,389 +93,389 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "user": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/user",
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": "67"
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "60"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
+        }
+      },
+      "user": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/user",
+          "support": {
+            "webview_android": {
+              "version_added": null
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "chrome": {
+              "version_added": "67"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "challenge": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/challenge",
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": "67"
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "60"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
+        }
+      },
+      "challenge": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/challenge",
+          "support": {
+            "webview_android": {
+              "version_added": null
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "chrome": {
+              "version_added": "67"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "pubKeyCredParams": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/pubKeyCredParams",
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": "67"
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "60"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
+        }
+      },
+      "pubKeyCredParams": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/pubKeyCredParams",
+          "support": {
+            "webview_android": {
+              "version_added": null
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "chrome": {
+              "version_added": "67"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "timeout": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/timeout",
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": "67"
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "60"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
+        }
+      },
+      "timeout": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/timeout",
+          "support": {
+            "webview_android": {
+              "version_added": null
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "chrome": {
+              "version_added": "67"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "excludeCredentials": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/excludeCredentials",
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": "67"
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "60"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
+        }
+      },
+      "excludeCredentials": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/excludeCredentials",
+          "support": {
+            "webview_android": {
+              "version_added": null
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "chrome": {
+              "version_added": "67"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "authenticatorSelection": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/authenticatorSelection",
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": "67"
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "60"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
+        }
+      },
+      "authenticatorSelection": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/authenticatorSelection",
+          "support": {
+            "webview_android": {
+              "version_added": null
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "chrome": {
+              "version_added": "67"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "attestation": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/attestation",
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": "67"
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "60"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
+        }
+      },
+      "attestation": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/attestation",
+          "support": {
+            "webview_android": {
+              "version_added": null
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "chrome": {
+              "version_added": "67"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "extensions": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/extensions",
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": "67"
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "60"
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              }
+        }
+      },
+      "extensions": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions/extensions",
+          "support": {
+            "webview_android": {
+              "version_added": null
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "chrome": {
+              "version_added": "67"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
Sources:
1. Web Authentication specification:
   https://w3c.github.io/webauthn/#dictionary-makecredentialoptions
2. Chrome bug tracker:
   https://crbug.com/664630
3. Chrome repository:
   https://chromium.googlesource.com/chromium/src/+/586b4ccc5fa5b38e1c7e23589d4c96231f1fb5dc/third_party/blink/renderer/modules/credentialmanager/public_key_credential_creation_options.idl (status quo)
4. Firefox bug tracker:
   https://bugzil.la/1436473 [rename]
5. Firefox repository:
   https://github.com/mozilla/gecko-dev/blob/830478fd5fb48dfdd0ce301b54075d63fd2f53f4/dom/webidl/WebAuthentication.webidl#L46-L58 (status quo)