### PR TITLE
API/Credential: deprecate name + add Firefox compat data

### DIFF
--- a/api/Credential.json
+++ b/api/Credential.json
@@ -14,7 +14,7 @@
             "version_added": "51"
           },
           "firefox": {
-            "version_added": null
+            "version_added": "60"
           },
           "firefox_android": {
             "version_added": null
@@ -58,7 +58,7 @@
               "version_added": "51"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "60"
             },
             "firefox_android": {
               "version_added": null
@@ -103,7 +103,7 @@
               "version_added": "51"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "60"
             },
             "firefox_android": {
               "version_added": null
@@ -139,19 +139,25 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Credential/name",
           "support": {
             "webview_android": {
-              "version_added": "51"
+              "version_added": "51",
+              "version_removed": "52",
+              "notes": "See <a href='https://crbug.com/602980'>Bug 602980</a>."
             },
             "chrome": {
-              "version_added": "51"
+              "version_added": "51",
+              "version_removed": "52",
+              "notes": "See <a href='https://crbug.com/602980'>Bug 602980</a>."
             },
             "chrome_android": {
-              "version_added": "51"
+              "version_added": "51",
+              "version_removed": "52",
+              "notes": "See <a href='https://crbug.com/602980'>Bug 602980</a>."
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null
@@ -173,9 +179,9 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/api/Credential.json
+++ b/api/Credential.json
@@ -137,6 +137,7 @@
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Credential/name",
+          "description": "<code>name</code> (from <code>CredentialUserData</code> mixin)",
           "support": {
             "webview_android": {
               "version_added": "51",
@@ -179,9 +180,9 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
Sources:
1. Credential Management Level 1 specification:
   https://w3c.github.io/webappsec-credential-management/#credential
2. Chrome repository:
   https://chromium.googlesource.com/chromium/src/+/2388feb43e89660223fe86f63a298ce07870c2cd/third_party/blink/renderer/modules/credentialmanager/credential.idl (status quo)
3. Firefox repository:
   https://github.com/mozilla/gecko-dev/blob/852a0c88903d1204f99dfc3821b282780547fd2e/dom/webidl/CredentialManagement.webidl#L11-L14 (status quo)