### PR TITLE
API: add NavigatorContentUtils

### DIFF
--- a/api/NavigatorContentUtils.json
+++ b/api/NavigatorContentUtils.json
@@ -1,0 +1,148 @@
+{
+  "api": {
+    "NavigatorContentUtils": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorContentUtils",
+        "support": {
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome": {
+            "version_added": "45"
+          },
+          "chrome_android": {
+            "version_added": "45"
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "registerProtocolHandler": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorContentUtil/registerProtocolHandler",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "45"
+            },
+            "chrome_android": {
+              "version_added": "45"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unregisterProtocolHandler": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorContentUtil/unregisterProtocolHandler",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "45"
+            },
+            "chrome_android": {
+              "version_added": "45"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Sources:
1. HTML Living Standard
   https://html.spec.whatwg.org/#navigatorcontentutils
2. Chromium repository:
   https://github.com/chromium/chromium/commit/324ce78ad8ea5d77742ace98a93e320fe2047f1f [as NavigatorRegisterProtocolHandler]
   https://github.com/chromium/chromium/commit/8d468b76c543a3df412d0510e8e751b84597eec4 [as NavigatorContentUtils]
   https://chromium.googlesource.com/chromium/src/+/65ce78ca60eb998704a07457a5552349000fb825/third_party/blink/renderer/modules/navigatorcontentutils/navigator_content_utils.idl [status quo]
3. Firefox bug tracker:
   https://bugzil.la/838146
4. Firefox repository:
   https://github.com/mozilla/gecko-dev/blob/d4b9e50875ad7e5d20f2fee6a53418315f6dfcc0/dom/webidl/Navigator.webidl#L80-L91 [status quo]
   https://github.com/mozilla/gecko-dev/blob/90497723d21c4824ae4005a359ff10808b1d1d96/dom/webidl/Navigator.webidl#L59-L70 [initial]