### PR TITLE
API: add NavigatorStorageUtils

### DIFF
--- a/api/NavigatorStorageUtils.json
+++ b/api/NavigatorStorageUtils.json
@@ -1,0 +1,160 @@
+{
+  "api": {
+    "NavigatorStorageUtils": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorStorageUtils",
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": "45",
+            "version_removed": "59",
+            "notes": "Renamed to <code>NavigatorCookies</code>."
+          },
+          "chrome_android": {
+            "version_added": "45",
+            "version_removed": "59",
+            "notes": "Renamed to <code>NavigatorCookies</code>."
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": true,
+            "version_removed": "59",
+            "notes": "Renamed to <code>NavigatorCookies</code>."
+          },
+          "opera_android": {
+            "version_added": true,
+            "version_removed": "59",
+            "notes": "Renamed to <code>NavigatorCookies</code>."
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": true
+        }
+      },
+      "cookieEnabled": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorStorageUtils/cookieEnabled",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": "45",
+              "version_removed": "59"
+            },
+            "chrome_android": {
+              "version_added": "45",
+              "version_removed": "59"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true,
+              "version_removed": true
+            },
+            "opera_android": {
+              "version_added": true,
+              "version_removed": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "yieldForStorageUpdates": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorStorageUtils/yieldForStorageUpdates",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Sources:
1. HTML 5, W3C Recommendation, 2014-10-28:
   https://www.w3.org/TR/2014/REC-html5-20141028/webappapis.html#navigatorstorageutils
2. Chromium repository:
   https://github.com/chromium/chromium/commit/603a807091c48a9d7142c821da928d29eb153ab8#diff-a9d3e29d048487f8614c51c04008370d [intial]
   https://github.com/chromium/chromium/commit/0b4c5c0569ed07445c3e6e785567db8ed500977c#diff-04f9e5307561902484088132b43e1104 [rename]
3. Firefox repository:
   https://github.com/mozilla/gecko-dev/blob/d4b9e50875ad7e5d20f2fee6a53418315f6dfcc0/dom/webidl/Navigator.webidl#L99-L103 [status quo]