### PR TITLE
API: add NavigatorUserMedia

### DIFF
--- a/api/NavigatorUserMedia.json
+++ b/api/NavigatorUserMedia.json
@@ -1,0 +1,108 @@
+{
+  "api": {
+    "NavigatorUserMedia": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorUserMedia",
+        "support": {
+          "webview_android": {
+            "version_added": true
+          },
+          "chrome": {
+            "version_added": "45"
+          },
+          "chrome_android": {
+            "version_added": "45"
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "36",
+            "partial_implementation": true,
+            "notes": "The interface is not implemented separately, but directly integrated into <code>Navigator</code>."
+          },
+          "firefox_android": {
+            "version_added": "36",
+            "partial_implementation": true,
+            "notes": "The interface is not implemented separately, but directly integrated into <code>Navigator</code>."
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "mediaDevices": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorUserMedia/mediaDevices",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": "45"
+            },
+            "chrome_android": {
+              "version_added": "45"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "36",
+              "partial_implementation": true,
+              "notes": "See <code>Navigator.mediaDevices</code>."
+            },
+            "firefox_android": {
+              "version_added": "36",
+              "partial_implementation": true,
+              "notes": "See <code>Navigator.mediaDevices</code>."
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Sources:
1. Media Capture and Streams specification:
   https://www.w3.org/TR/mediacapture-streams/#navigatorusermedia
2. Chromium repository:
   https://github.com/chromium/chromium/commit/3d6c00a97432756b77dc496719a7ac8942ab1071 [initial]
   https://github.com/chromium/chromium/blob/0aee4434a4dba42a42abaea9bfbc0cd196a63bc1/third_party/blink/renderer/modules/mediastream/navigator_user_media.idl [status quo]
3. Firefox repository:
   https://github.com/mozilla/gecko-dev/search?q=NavigatorUserMedia [search]
   https://bugzil.la/1033885 [initial Navigator.mediaDevices]
   https://github.com/mozilla/gecko-dev/blob/d4b9e50875ad7e5d20f2fee6a53418315f6dfcc0/dom/webidl/Navigator.webidl#L250 [status quo Navigator.mediaDevices]