### PR TITLE
Update Edge 17 ParentNode/ChildNode API support

### DIFF
--- a/api/ChildNode.json
+++ b/api/ChildNode.json
@@ -64,7 +64,7 @@
               "version_added": "54"
             },
             "edge": {
-              "version_added": false
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": false
@@ -115,7 +115,7 @@
               "version_added": "54"
             },
             "edge": {
-              "version_added": false
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": false
@@ -217,7 +217,7 @@
               "version_added": "54"
             },
             "edge": {
-              "version_added": false
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": false

--- a/api/ParentNode.json
+++ b/api/ParentNode.json
@@ -626,7 +626,7 @@
               "version_added": "54"
             },
             "edge": {
-              "version_added": false
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": null


### PR DESCRIPTION
Edge 17 supports the ParentNode.append, ParentNode.prepend, ChildNode.before, ChildNode.after, and ChildNode.replaceWith methods.

Support for ParentNode.append was recently added in #1973.