### PR TITLE
Add safari compatibility for navigator.sendBeacon

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -261,7 +261,7 @@
               "notes": "Starting in Opera 46, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information see <a href='https://crbug.com/720283'>Chrome bug 720283</a>."
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
Here is the source: https://webkit.org/blog/8216/new-webkit-features-in-safari-11-1/