### PR TITLE
Add Response.{error, redirect} for Edge/Safari

### DIFF
--- a/api/Response.json
+++ b/api/Response.json
@@ -1041,7 +1041,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "17"
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1062,7 +1062,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -1092,7 +1092,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "17"
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1113,7 +1113,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false

--- a/api/Response.json
+++ b/api/Response.json
@@ -1041,7 +1041,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": null
@@ -1062,7 +1062,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": false
@@ -1092,7 +1092,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": null
@@ -1113,7 +1113,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
They were possibly available earlier but both of these functions definitely exist in Edge 17/Safari 11.1.