### PR TITLE
Use strict mode for the linter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,14 @@
-var fs = require('fs'),
-    path = require('path'),
-    extend = require('extend');
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const extend = require('extend');
 
 function load() {
   // Recursively load one or more directories passed as arguments.
-  var dir, result = {};
+  let dir, result = {};
 
   function processFilename(fn) {
-    let fp = path.join(dir, fn);
+    const fp = path.join(dir, fn);
     let extra;
 
     // If the given filename is a directory, recursively load it.

--- a/test/lint.js
+++ b/test/lint.js
@@ -1,19 +1,30 @@
-var fs = require('fs');
-var path = require('path');
-var {testStyle} = require('./test-style');
-var {testSchema} = require('./test-schema');
-var {testVersions} = require('./test-versions');
-var hasErrors, hasStyleErrors, hasSchemaErrors, hasVersionErrors = false;
-var filesWithErrors = {};
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const {testStyle} = require('./test-style');
+const {testSchema} = require('./test-schema');
+const {testVersions} = require('./test-versions');
+/** @type {Map<string,string>} */
+const filesWithErrors = new Map();
 
+let hasErrors = false;
+
+/**
+ * @param {string[]} files
+ */
 function load(...files) {
   for (let file of files) {
     if (file.indexOf(__dirname) !== 0) {
       file = path.resolve(__dirname, '..', file);
     }
 
+    if (!fs.existsSync(file)) {
+      continue; // Ignore non-existent files
+    }
+
     if (fs.statSync(file).isFile()) {
       if (path.extname(file) === '.json') {
+        let hasStyleErrors, hasSchemaErrors, hasVersionErrors = false;
         console.log(file.replace(path.resolve(__dirname, '..') + path.sep, ''));
         if (file.indexOf('browsers' + path.sep) !== -1) {
           hasSchemaErrors = testSchema(file, './../schemas/browsers.schema.json');
@@ -24,15 +35,15 @@ function load(...files) {
         }
         if (hasStyleErrors || hasSchemaErrors || hasVersionErrors) {
           hasErrors = true;
-          fileName = file.replace(path.resolve(__dirname, '..') + path.sep, '');
-          filesWithErrors[fileName] = file;
+          const fileName = file.replace(path.resolve(__dirname, '..') + path.sep, '');
+          filesWithErrors.set(fileName, file);
         }
       }
 
       continue;
     }
 
-    let subFiles = fs.readdirSync(file).map((subfile) => {
+    const subFiles = fs.readdirSync(file).map((subfile) => {
       return path.join(file, subfile);
     });
 
@@ -41,7 +52,7 @@ function load(...files) {
 }
 
 if (process.argv[2]) {
-  load(process.argv[2])
+  load(process.argv[2]);
 } else {
   load(
     'api',
@@ -60,12 +71,12 @@ if (process.argv[2]) {
 
 if (hasErrors) {
   console.log("");
-  console.log(`Problems in ${Object.keys(filesWithErrors).length} files:`);
-  for (let file in filesWithErrors) {
-    console.log(file);
-    testSchema(filesWithErrors[file]);
-    testStyle(filesWithErrors[file]);
-    testVersions(filesWithErrors[file]);
+  console.warn(`Problems in ${filesWithErrors.size} file${filesWithErrors.size > 1 ? 's' : ''}:`);
+  for (const [fileName, file] of filesWithErrors) {
+    console.log(fileName);
+    testSchema(file);
+    testStyle(file);
+    testVersions(file);
   }
   process.exit(1);
 }

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -1,5 +1,6 @@
-var Ajv = require('ajv');
-var ajv = new Ajv({ allErrors: true });
+'use strict';
+const Ajv = require('ajv');
+const ajv = new Ajv({ allErrors: true });
 
 function testSchema(dataFilename, schemaFilename = './../schemas/compat-data.schema.json') {
   var valid = ajv.validate(

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -1,6 +1,6 @@
-var fs = require('fs');
-var path = require('path');
-var hasErrors = false;
+'use strict';
+const fs = require('fs');
+let hasErrors = false;
 
 function jsonDiff(actual, expected) {
   var actualLines = actual.split(/\n/);
@@ -18,10 +18,10 @@ function jsonDiff(actual, expected) {
 }
 
 function testStyle(filename) {
-  var actual = fs.readFileSync(filename, 'utf-8').trim();
-  var expected = JSON.stringify(JSON.parse(actual), null, 2);
+  let actual = fs.readFileSync(filename, 'utf-8').trim();
+  let expected = JSON.stringify(JSON.parse(actual), null, 2);
 
-  var platform = require("os").platform;
+  const {platform} = require("os");
   if (platform() === "win32") { // prevent false positives from git.core.autocrlf on Windows
     actual = actual.replace(/\r/g, "");
     expected = expected.replace(/\r/g, "");
@@ -35,7 +35,7 @@ function testStyle(filename) {
     console.error('\x1b[31m  Style – Error on line ' + jsonDiff(actual, expected));
   }
 
-  let bugzillaMatch = actual.match(String.raw`https?://bugzilla\.mozilla\.org/show_bug\.cgi\?id=(\d+)`);
+  const bugzillaMatch = actual.match(String.raw`https?://bugzilla\.mozilla\.org/show_bug\.cgi\?id=(\d+)`);
   if (bugzillaMatch) {
     // use https://bugzil.la/1000000 instead
     hasErrors = true;
@@ -43,7 +43,7 @@ function testStyle(filename) {
       bugzillaMatch[1]);
   }
 
-  let crbugMatch = actual.match(String.raw`https?://bugs\.chromium\.org/p/chromium/issues/detail\?id=(\d+)`);
+  const crbugMatch = actual.match(String.raw`https?://bugs\.chromium\.org/p/chromium/issues/detail\?id=(\d+)`);
   if (crbugMatch) {
     // use https://crbug.com/100000 instead
     hasErrors = true;
@@ -51,7 +51,7 @@ function testStyle(filename) {
       crbugMatch[1]);
   }
 
-  let mdnUrlMatch = actual.match(String.raw`https?://developer.mozilla.org/(\w\w-\w\w)/(.*?)(?=["'\s])`)
+  const mdnUrlMatch = actual.match(String.raw`https?://developer.mozilla.org/(\w\w-\w\w)/(.*?)(?=["'\s])`);
   if (mdnUrlMatch) {
     hasErrors = true;
     console.error(
@@ -62,7 +62,7 @@ function testStyle(filename) {
 
   if (actual.includes("href=\\\"")) {
     hasErrors = true;
-    console.error('\x1b[33m  Style – Found \\\" but expected \' for <a href>.\x1b[0m');
+    console.error('\x1b[33m  Style – Found \\" but expected \' for <a href>.\x1b[0m');
   }
 
   return hasErrors;

--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -1,7 +1,8 @@
-var browsers = require('..').browsers;
+'use strict';
+const {browsers} = require('..');
 
-var validBrowserVersions = {};
-for (let browser of Object.keys(browsers)) {
+const validBrowserVersions = {};
+for (const browser of Object.keys(browsers)) {
   validBrowserVersions[browser] = Object.keys(browsers[browser].releases);
 }
 
@@ -14,22 +15,22 @@ function isValidVersion(browserIdentifier, version) {
 }
 
 function testVersions(dataFilename) {
-  var hasErrors = false;
-  var data = require(dataFilename);
+  const data = require(dataFilename);
+  let hasErrors = false;
 
   function checkVersions(supportData) {
-    var browsersToCheck = Object.keys(supportData);
-    for (let browser of browsersToCheck) {
+    const browsersToCheck = Object.keys(supportData);
+    for (const browser of browsersToCheck) {
       if (validBrowserVersions[browser]) {
 
-        let supportStatements = [];
+        const supportStatements = [];
         if (Array.isArray(supportData[browser])) {
           Array.prototype.push.apply(supportStatements, supportData[browser]);
         } else {
           supportStatements.push(supportData[browser]);
         }
 
-        for (let statement of supportStatements) {
+        for (const statement of supportStatements) {
           if (!isValidVersion(browser, statement.version_added)) {
             console.error('\x1b[31m  version_added: "' + statement.version_added + '" is not a valid version number for ' + browser);
             console.error('  Valid ' + browser + ' versions are: ' + validBrowserVersions[browser].join(', '));
@@ -53,11 +54,11 @@ function testVersions(dataFilename) {
   }
 
   function findSupport(data) {
-    for (var prop in data) {
+    for (const prop in data) {
       if (prop === 'support') {
         checkVersions(data[prop]);
       }
-      var sub = data[prop];
+      const sub = data[prop];
       if (typeof(sub) === "object") {
         findSupport(sub);
       }


### PR DESCRIPTION
Also fixes the issue where an error in a single file would cause all subsequent files to be printed at the end.