### PR TITLE
Add the MediaMetadata constructor to the MediaMetadata interface.

### DIFF
--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -50,6 +50,58 @@
           "deprecated": false
         }
       },
+      "MediaMetadata": {
+        "__compat": {
+          "description": "<code>MediaMetadata()</code> constructor.",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/MediaMetadata",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "album": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/album",


### PR DESCRIPTION
The `MediaMetadata` interface was added in #1533, but it didn't include the constructor. This adds the constructor

https://developer.mozilla.org/en-US/docs/Web/API/MediaMetadata/MediaMetadata