### PR TITLE
update safari support for idb 2.0

### DIFF
--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -354,10 +354,10 @@
                 "version_added": "45"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
@@ -672,10 +672,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -394,10 +394,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -887,10 +887,10 @@
               "version_added": "35"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -950,10 +950,10 @@
               "version_added": "35"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/IDBKeyRange.json
+++ b/api/IDBKeyRange.json
@@ -476,10 +476,10 @@
               "version_added": "39"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -1263,10 +1263,10 @@
               "version_added": "35"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1314,10 +1314,10 @@
               "version_added": "35"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -1365,10 +1365,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
Safari 10.1 added a bunch of IDB 2.0 stuff: https://webkit.org/blog/7477/new-web-features-in-safari-10-1/

detailed on these posts:

* https://webkit.org/blog/7071/release-notes-for-safari-technology-preview-17/
* https://webkit.org/blog/7078/release-notes-for-safari-technology-preview-18/
* https://webkit.org/blog/7093/release-notes-for-safari-technology-preview-19/

https://wpt.fyi/results/IndexedDB also confirms these changes.

cc @pwnall 