### PR TITLE
Fix an incorrect MDN URL for HTMLTextAreaElement.

### DIFF
--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -145,7 +145,7 @@
       },
       "labels": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/textLength",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/labels",
           "support": {
             "chrome": {
               "version_added": "14"


### PR DESCRIPTION
#1586 had a small error where the `mdn_url` for the `labels` property was pointing to the page for `textLength`.