### PR TITLE
Update compat for HTMLMediaElement.captureStream()

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -264,6 +264,15 @@
               "version_added": "15",
               "prefix": "moz"
             },
+            "ie": {
+              "version_added": false 
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": "53"
             }

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -265,7 +265,7 @@
               "prefix": "moz"
             },
             "ie": {
-              "version_added": false 
+              "version_added": false
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
Tested on:
Safari 11.1 / macOS 10.12
Safari 11 / iOS 11
IE 11 / Win 10