### PR TITLE
Add the MutationObserverInit dictionary

### DIFF
--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -164,7 +164,7 @@
             },
             "firefox": {
               "version_added": "14",
-              "notes": "Starting in Firefox 61, <code>attributeOldValue</code> has no default value; previously, its default value was <code>false</code>."
+              "notes": "Starting in Firefox 36, <code>attributeOldValue</code> has no default value; previously, its default value was <code>false</code>."
             },
             "ie": {
               "version_added": "11"
@@ -194,7 +194,7 @@
             ],
             "firefox_android": {
               "version_added": "14",
-              "notes": "Starting in Firefox 61, <code>attributeOldValue</code> has no default value; previously, its default value was <code>false</code>."
+              "notes": "Starting in Firefox 36, <code>attributeOldValue</code> has no default value; previously, its default value was <code>false</code>."
             },
             "opera_android": {
               "version_added": "15"
@@ -239,7 +239,7 @@
             },
             "firefox": {
               "version_added": "14",
-              "notes": "Starting in Firefox 61, <code>attributes</code> has no default value; previously, its default value was <code>false</code>."
+              "notes": "Starting in Firefox 36, <code>attributes</code> has no default value; previously, its default value was <code>false</code>."
             },
             "ie": {
               "version_added": "11"
@@ -269,7 +269,7 @@
             ],
             "firefox_android": {
               "version_added": "14",
-              "notes": "Starting in Firefox 61, <code>attributes</code> has no default value; previously, its default value was <code>false</code>."
+              "notes": "Starting in Firefox 36, <code>attributes</code> has no default value; previously, its default value was <code>false</code>."
             },
             "opera_android": {
               "version_added": "15"
@@ -314,7 +314,7 @@
             },
             "firefox": {
               "version_added": "14",
-              "notes": "Starting in Firefox 61, <code>characterData</code> has no default value; previously, its default value was <code>false</code>."
+              "notes": "Starting in Firefox 36, <code>characterData</code> has no default value; previously, its default value was <code>false</code>."
             },
             "ie": {
               "version_added": "11"
@@ -344,7 +344,7 @@
             ],
             "firefox_android": {
               "version_added": "14",
-              "notes": "Starting in Firefox 61, <code>characterData</code> has no default value; previously, its default value was <code>false</code>."
+              "notes": "Starting in Firefox 36, <code>characterData</code> has no default value; previously, its default value was <code>false</code>."
             },
             "opera_android": {
               "version_added": "15"
@@ -389,7 +389,7 @@
             },
             "firefox": {
               "version_added": "14",
-              "notes": "Starting in Firefox 61, <code>characterDataOldValue</code> has no default value; previously, its default value was <code>false</code>."
+              "notes": "Starting in Firefox 36, <code>characterDataOldValue</code> has no default value; previously, its default value was <code>false</code>."
             },
             "ie": {
               "version_added": "11"
@@ -419,7 +419,7 @@
             ],
             "firefox_android": {
               "version_added": "14",
-              "notes": "Starting in Firefox 61, <code>characterDataOldValue</code> has no default value; previously, its default value was <code>false</code>."
+              "notes": "Starting in Firefox 36, <code>characterDataOldValue</code> has no default value; previously, its default value was <code>false</code>."
             },
             "opera_android": {
               "version_added": "15"

--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -14,16 +14,32 @@
               "version_removed": "26"
             }
           ],
+          "chrome_android": [
+            {
+              "version_added": "26"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "18",
+              "version_removed": "26"
+            }
+          ],
           "edge": {
             "version_added": true
           },
           "firefox": {
             "version_added": "14"
           },
+          "firefox_android": {
+            "version_added": "14"
+          },
           "ie": {
             "version_added": "11"
           },
           "opera": {
+            "version_added": "15"
+          },
+          "opera_android": {
             "version_added": "15"
           },
           "safari": [
@@ -36,22 +52,6 @@
               "version_removed": "7"
             }
           ],
-          "chrome_android": [
-            {
-              "version_added": "26"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "18",
-              "version_removed": "26"
-            }
-          ],
-          "firefox_android": {
-            "version_added": "14"
-          },
-          "opera_android": {
-            "version_added": "15"
-          },
           "safari_ios": [
             {
               "version_added": "7"
@@ -86,16 +86,32 @@
                 "version_removed": "26"
               }
             ],
+            "chrome_android": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
             "edge": {
               "version_added": true
             },
             "firefox": {
               "version_added": "14"
             },
+            "firefox_android": {
+              "version_added": "14"
+            },
             "ie": {
               "version_added": "11"
             },
             "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
               "version_added": "15"
             },
             "safari": [
@@ -108,22 +124,6 @@
                 "version_removed": "7"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
-            "firefox_android": {
-              "version_added": "14"
-            },
-            "opera_android": {
-              "version_added": "15"
-            },
             "safari_ios": [
               {
                 "version_added": "7"
@@ -159,6 +159,16 @@
                 "version_removed": "26"
               }
             ],
+            "chrome_android": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
             "edge": {
               "version_added": true
             },
@@ -166,10 +176,17 @@
               "version_added": "14",
               "notes": "Starting in Firefox 36, <code>attributeOldValue</code> has no default value; previously, its default value was <code>false</code>."
             },
+            "firefox_android": {
+              "version_added": "14",
+              "notes": "Starting in Firefox 36, <code>attributeOldValue</code> has no default value; previously, its default value was <code>false</code>."
+            },
             "ie": {
               "version_added": "11"
             },
             "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
               "version_added": "15"
             },
             "safari": [
@@ -182,23 +199,6 @@
                 "version_removed": "7"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
-            "firefox_android": {
-              "version_added": "14",
-              "notes": "Starting in Firefox 36, <code>attributeOldValue</code> has no default value; previously, its default value was <code>false</code>."
-            },
-            "opera_android": {
-              "version_added": "15"
-            },
             "safari_ios": [
               {
                 "version_added": "7"
@@ -234,6 +234,16 @@
                 "version_removed": "26"
               }
             ],
+            "chrome_android": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
             "edge": {
               "version_added": true
             },
@@ -241,10 +251,17 @@
               "version_added": "14",
               "notes": "Starting in Firefox 36, <code>attributes</code> has no default value; previously, its default value was <code>false</code>."
             },
+            "firefox_android": {
+              "version_added": "14",
+              "notes": "Starting in Firefox 36, <code>attributes</code> has no default value; previously, its default value was <code>false</code>."
+            },
             "ie": {
               "version_added": "11"
             },
             "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
               "version_added": "15"
             },
             "safari": [
@@ -257,23 +274,6 @@
                 "version_removed": "7"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
-            "firefox_android": {
-              "version_added": "14",
-              "notes": "Starting in Firefox 36, <code>attributes</code> has no default value; previously, its default value was <code>false</code>."
-            },
-            "opera_android": {
-              "version_added": "15"
-            },
             "safari_ios": [
               {
                 "version_added": "7"
@@ -309,6 +309,16 @@
                 "version_removed": "26"
               }
             ],
+            "chrome_android": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
             "edge": {
               "version_added": true
             },
@@ -316,10 +326,17 @@
               "version_added": "14",
               "notes": "Starting in Firefox 36, <code>characterData</code> has no default value; previously, its default value was <code>false</code>."
             },
+            "firefox_android": {
+              "version_added": "14",
+              "notes": "Starting in Firefox 36, <code>characterData</code> has no default value; previously, its default value was <code>false</code>."
+            },
             "ie": {
               "version_added": "11"
             },
             "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
               "version_added": "15"
             },
             "safari": [
@@ -332,23 +349,6 @@
                 "version_removed": "7"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
-            "firefox_android": {
-              "version_added": "14",
-              "notes": "Starting in Firefox 36, <code>characterData</code> has no default value; previously, its default value was <code>false</code>."
-            },
-            "opera_android": {
-              "version_added": "15"
-            },
             "safari_ios": [
               {
                 "version_added": "7"
@@ -384,6 +384,16 @@
                 "version_removed": "26"
               }
             ],
+            "chrome_android": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
             "edge": {
               "version_added": true
             },
@@ -391,10 +401,17 @@
               "version_added": "14",
               "notes": "Starting in Firefox 36, <code>characterDataOldValue</code> has no default value; previously, its default value was <code>false</code>."
             },
+            "firefox_android": {
+              "version_added": "14",
+              "notes": "Starting in Firefox 36, <code>characterDataOldValue</code> has no default value; previously, its default value was <code>false</code>."
+            },
             "ie": {
               "version_added": "11"
             },
             "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
               "version_added": "15"
             },
             "safari": [
@@ -407,23 +424,6 @@
                 "version_removed": "7"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
-            "firefox_android": {
-              "version_added": "14",
-              "notes": "Starting in Firefox 36, <code>characterDataOldValue</code> has no default value; previously, its default value was <code>false</code>."
-            },
-            "opera_android": {
-              "version_added": "15"
-            },
             "safari_ios": [
               {
                 "version_added": "7"
@@ -459,16 +459,32 @@
                 "version_removed": "26"
               }
             ],
+            "chrome_android": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
             "edge": {
               "version_added": true
             },
             "firefox": {
               "version_added": "14"
             },
+            "firefox_android": {
+              "version_added": "14"
+            },
             "ie": {
               "version_added": "11"
             },
             "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
               "version_added": "15"
             },
             "safari": [
@@ -481,22 +497,6 @@
                 "version_removed": "7"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
-            "firefox_android": {
-              "version_added": "14"
-            },
-            "opera_android": {
-              "version_added": "15"
-            },
             "safari_ios": [
               {
                 "version_added": "7"
@@ -532,16 +532,32 @@
                 "version_removed": "26"
               }
             ],
+            "chrome_android": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
             "edge": {
               "version_added": true
             },
             "firefox": {
               "version_added": "14"
             },
+            "firefox_android": {
+              "version_added": "14"
+            },
             "ie": {
               "version_added": "11"
             },
             "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
               "version_added": "15"
             },
             "safari": [
@@ -554,22 +570,6 @@
                 "version_removed": "7"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
-            "firefox_android": {
-              "version_added": "14"
-            },
-            "opera_android": {
-              "version_added": "15"
-            },
             "safari_ios": [
               {
                 "version_added": "7"

--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -163,7 +163,8 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Starting in Firefox 61, <code>attributeOldValue</code> has no default value; previously, its default value was <code>false</code>."
             },
             "ie": {
               "version_added": "11"
@@ -192,7 +193,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Starting in Firefox 61, <code>attributeOldValue</code> has no default value; previously, its default value was <code>false</code>."
             },
             "opera_android": {
               "version_added": "15"
@@ -236,7 +238,8 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Starting in Firefox 61, <code>attributes</code> has no default value; previously, its default value was <code>false</code>."
             },
             "ie": {
               "version_added": "11"
@@ -265,7 +268,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Starting in Firefox 61, <code>attributes</code> has no default value; previously, its default value was <code>false</code>."
             },
             "opera_android": {
               "version_added": "15"
@@ -309,7 +313,8 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Starting in Firefox 61, <code>characterData</code> has no default value; previously, its default value was <code>false</code>."
             },
             "ie": {
               "version_added": "11"
@@ -338,7 +343,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Starting in Firefox 61, <code>characterData</code> has no default value; previously, its default value was <code>false</code>."
             },
             "opera_android": {
               "version_added": "15"
@@ -382,7 +388,8 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Starting in Firefox 61, <code>characterDataOldValue</code> has no default value; previously, its default value was <code>false</code>."
             },
             "ie": {
               "version_added": "11"
@@ -411,7 +418,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Starting in Firefox 61, <code>characterDataOldValue</code> has no default value; previously, its default value was <code>false</code>."
             },
             "opera_android": {
               "version_added": "15"

--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -1,0 +1,588 @@
+{
+  "api": {
+    "MutationObserverInit": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationObserverInit",
+        "support": {
+          "chrome": [
+            {
+              "version_added": "26"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "18",
+              "version_removed": "26"
+            }
+          ],
+          "edge": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "14"
+          },
+          "ie": {
+            "version_added": "11"
+          },
+          "opera": {
+            "version_added": "15"
+          },
+          "safari": [
+            {
+              "version_added": "7"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "6",
+              "version_removed": "7"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "26"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "18",
+              "version_removed": "26"
+            }
+          ],
+          "firefox_android": {
+            "version_added": "14"
+          },
+          "opera_android": {
+            "version_added": "15"
+          },
+          "safari_ios": [
+            {
+              "version_added": "7"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "6",
+              "version_removed": "7"
+            }
+          ],
+          "samsunginternet_android": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "attributeFilter": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationObserverInit/attributeFilter",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "14"
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "6",
+                "version_removed": "7"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "14"
+            },
+            "opera_android": {
+              "version_added": "15"
+            },
+            "safari_ios": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "6",
+                "version_removed": "7"
+              }
+            ],
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "attributeOldValue": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationObserverInit/attributeOldValue",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "14"
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "6",
+                "version_removed": "7"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "14"
+            },
+            "opera_android": {
+              "version_added": "15"
+            },
+            "safari_ios": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "6",
+                "version_removed": "7"
+              }
+            ],
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "attributes": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationObserverInit/attributes",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "14"
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "6",
+                "version_removed": "7"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "14"
+            },
+            "opera_android": {
+              "version_added": "15"
+            },
+            "safari_ios": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "6",
+                "version_removed": "7"
+              }
+            ],
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "characterData": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationObserverInit/characterData",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "14"
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "6",
+                "version_removed": "7"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "14"
+            },
+            "opera_android": {
+              "version_added": "15"
+            },
+            "safari_ios": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "6",
+                "version_removed": "7"
+              }
+            ],
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "characterDataOldValue": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationObserverInit/characterDataOldValue",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "14"
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "6",
+                "version_removed": "7"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "14"
+            },
+            "opera_android": {
+              "version_added": "15"
+            },
+            "safari_ios": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "6",
+                "version_removed": "7"
+              }
+            ],
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "childList": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationObserverInit/childList",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "14"
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "6",
+                "version_removed": "7"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "14"
+            },
+            "opera_android": {
+              "version_added": "15"
+            },
+            "safari_ios": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "6",
+                "version_removed": "7"
+              }
+            ],
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "subtree": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationObserverInit/subtree",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "14"
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "safari": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "6",
+                "version_removed": "7"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "26"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "18",
+                "version_removed": "26"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "14"
+            },
+            "opera_android": {
+              "version_added": "15"
+            },
+            "safari_ios": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "6",
+                "version_removed": "7"
+              }
+            ],
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds MutationObserverInit, a dictionary used by the
Mutation Observer API. Primarily used as an input into
the MutationObserver.observe() method.