### PR TITLE
Add a description for javascript.builtins.Promise.Promise

### DIFF
--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -4,6 +4,7 @@
       "Promise": {
         "Promise": {
           "__compat": {
+            "description": "<code>Promise()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise",
             "support": {
               "webview_android": {


### PR DESCRIPTION
because "Promise" attributes is duplicated.

while I am writing an adapter between browser-compat-data and [eslint-plugin-compat](https://github.com/amilajack/eslint-plugin-compat/issues/104), I realized the `javascript.builtins.Primose` files' "Promise" attributes is duplicated.

please review.