### PR TITLE
Bug 1449268 - touch events and passive mode

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -450,10 +450,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "61"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "61"
                 },
                 "ie": {
                   "version_added": false


### PR DESCRIPTION
Updated EventTarget.addEventListener() to cover bug
1449268 - touchstart and touchmove now default to
passive set to true.