### PR TITLE
Fix an incorrect MDN URL in Range.json.

### DIFF
--- a/api/Range.json
+++ b/api/Range.json
@@ -1165,7 +1165,7 @@
       },
       "selectNodeContents": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Range/selectNode",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Range/selectNodeContents",
           "support": {
             "chrome": {
               "version_added": true


### PR DESCRIPTION
I noticed `selectNodeContents` was linking to the page for `selectNode`. Fixed that :)