### PR TITLE
Capitalize Console for the Console API in MDN URLs.

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -96,7 +96,7 @@
       },
       "assert": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/assert",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/assert",
           "support": {
             "webview_android": {
               "version_added": null
@@ -141,7 +141,7 @@
       },
       "clear": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/clear",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/clear",
           "support": {
             "webview_android": {
               "version_added": null
@@ -189,7 +189,7 @@
       },
       "count": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/count",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/count",
           "support": {
             "webview_android": {
               "version_added": null
@@ -237,7 +237,7 @@
       },
       "dir": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/dir",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/dir",
           "support": {
             "webview_android": {
               "version_added": null
@@ -285,7 +285,7 @@
       },
       "dirxml": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/dirxml",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/dirxml",
           "support": {
             "webview_android": {
               "version_added": null
@@ -333,7 +333,7 @@
       },
       "error": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/error",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/error",
           "support": {
             "webview_android": {
               "version_added": true
@@ -427,7 +427,7 @@
       },
       "exception": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/exception",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/exception",
           "description": "Alias for Console.error",
           "support": {
             "webview_android": {
@@ -519,7 +519,7 @@
       },
       "group": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/group",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/group",
           "support": {
             "webview_android": {
               "version_added": null
@@ -567,7 +567,7 @@
       },
       "groupCollapsed": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/groupCollapsed",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/groupCollapsed",
           "support": {
             "webview_android": {
               "version_added": null
@@ -615,7 +615,7 @@
       },
       "groupEnd": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/groupEnd",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/groupEnd",
           "support": {
             "webview_android": {
               "version_added": null
@@ -663,7 +663,7 @@
       },
       "info": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/info",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/info",
           "support": {
             "webview_android": {
               "version_added": null
@@ -760,7 +760,7 @@
       },
       "log": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/log",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/log",
           "support": {
             "webview_android": {
               "version_added": null
@@ -857,7 +857,7 @@
       },
       "profile": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/profile",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/profile",
           "support": {
             "webview_android": {
               "version_added": null
@@ -905,7 +905,7 @@
       },
       "profileEnd": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/profileEnd",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/profileEnd",
           "support": {
             "webview_android": {
               "version_added": null
@@ -953,7 +953,7 @@
       },
       "table": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/table",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/table",
           "support": {
             "webview_android": {
               "version_added": null
@@ -1001,7 +1001,7 @@
       },
       "time": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/time",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/time",
           "support": {
             "webview_android": {
               "version_added": null
@@ -1049,7 +1049,7 @@
       },
       "timeEnd": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/timeEnd",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/timeEnd",
           "support": {
             "webview_android": {
               "version_added": null
@@ -1097,7 +1097,7 @@
       },
       "timestamp": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/timestamp",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/timestamp",
           "support": {
             "webview_android": {
               "version_added": null
@@ -1145,7 +1145,7 @@
       },
       "trace": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/trace",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/trace",
           "support": {
             "webview_android": {
               "version_added": null
@@ -1193,7 +1193,7 @@
       },
       "warn": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/warn",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/warn",
           "support": {
             "webview_android": {
               "version_added": null


### PR DESCRIPTION
This was causing the tables on Console subfeature articles to display a link, when it was just linking to the same page but with `Console` not capitalized. e.g. `https://developer.mozilla.org/en-US/docs/Web/API/Console/timeEnd` would link to `https://developer.mozilla.org/en-US/docs/Web/API/console/timeEnd`.

<img width="1067" alt="screen shot 2018-06-14 at 4 54 59 pm" src="https://user-images.githubusercontent.com/2977353/41442281-b28144ee-6ff3-11e8-86b6-3489c2efc865.png">