### PR TITLE
Add `Promise` basic support

### DIFF
--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -2,6 +2,58 @@
   "javascript": {
     "builtins": {
       "Promise": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise",
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "32"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "29"
+            },
+            "firefox_android": {
+              "version_added": "29"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": "0.12"
+            },
+            "opera": {
+              "version_added": "19"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "safari_ios": {
+              "version_added": "8"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "4.4.4"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "Promise": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise",


### PR DESCRIPTION
This adds the basic support entry to the `Promise` global object.

~~Also ~~closes~~ #2303~~. Not anymore as of https://github.com/mdn/browser-compat-data/pull/2319/commits/5fc401a5373d4721b75b19582f1612afee5c8eb6,