### PR TITLE
Updated NodeList apis for Edge

### DIFF
--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -115,7 +115,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": null
+              "version_added": "16",
             },
             "edge_mobile": {
               "version_added": null
@@ -268,7 +268,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": null
+              "version_added": "16"
             },
             "edge_mobile": {
               "version_added": null
@@ -319,7 +319,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": null
+              "version_added": "16"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -115,7 +115,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": "16",
+              "version_added": "16"
             },
             "edge_mobile": {
               "version_added": null


### PR DESCRIPTION
I just checked in the VMs for Edge, and these apis were not in the Edge 15.15063 build, but do exist in the 16.16299 build.