### PR TITLE
Update grammar.json

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -83,7 +83,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "nodejs": {
               "version_added": true
@@ -413,7 +413,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "nodejs": {
               "version_added": true


### PR DESCRIPTION
I have windows 7 with IE11. Ran `eval("0x1")` in the IE console, and it outputted 1. Ran `eval("0b1")` and it outputted the error "Expected ';'".