### PR TITLE
Add `externally_connectable` (fixes #2326)

### DIFF
--- a/webextensions/manifest/externally_connectable.json
+++ b/webextensions/manifest/externally_connectable.json
@@ -1,0 +1,19 @@
+{
+  "webextensions": {
+    "manifest": {
+      "externally_connectable": {
+        "__compat": {
+          "description": "Whitelist for sending messages to extension",
+          "support": {
+            "chrome": {
+              "version_added": true,
+            },
+            "opera": {
+              "version_added": true
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/webextensions/manifest/externally_connectable.json
+++ b/webextensions/manifest/externally_connectable.json
@@ -13,7 +13,7 @@
             },
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1319168'>bug 1319168</a>"
+              "notes": "See <a href='https://bugzil.la/1319168'>bug 1319168</a>."
             },
             "firefox_android": {
               "version_added": false

--- a/webextensions/manifest/externally_connectable.json
+++ b/webextensions/manifest/externally_connectable.json
@@ -1,6 +1,5 @@
 {
   "webextensions": {
- 
     "manifest": {
       "externally_connectable": {
         "__compat": {
@@ -16,6 +15,5 @@
         }
       }
     }
-
   }
 }

--- a/webextensions/manifest/externally_connectable.json
+++ b/webextensions/manifest/externally_connectable.json
@@ -1,12 +1,13 @@
 {
   "webextensions": {
+ 
     "manifest": {
       "externally_connectable": {
         "__compat": {
           "description": "Whitelist for sending messages to extension",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -15,5 +16,6 @@
         }
       }
     }
+
   }
 }

--- a/webextensions/manifest/externally_connectable.json
+++ b/webextensions/manifest/externally_connectable.json
@@ -3,10 +3,20 @@
     "manifest": {
       "externally_connectable": {
         "__compat": {
-          "description": "Whitelist for sending messages to extension",
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/externally_connectable",
           "support": {
             "chrome": {
               "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1319168'>bug 1319168</a>"
+            },
+            "firefox_android": {
+              "version_added": false
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
* Chrome: https://developer.chrome.com/extensions/manifest/externally_connectable
* Opera: https://dev.opera.com/extensions/message-passing/
Not implemented
* Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1319168
* Edge: https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/33408253-implement-externally-connectable-from-webpages-to