### PR TITLE
Migrate compatibility data for ReadableStreamBYOBRequest

### DIFF
--- a/api/ReadableStreamBYOBRequest.json
+++ b/api/ReadableStreamBYOBRequest.json
@@ -1,0 +1,97 @@
+{
+  "api": {
+    "ReadableStreamBYOBRequest": {
+      "view": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/view",
+          "support": {}
+        }
+      },
+      "respond": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/respond",
+          "support": {}
+        }
+      },
+      "respondWithNewView": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/respondWithNewView",
+          "support": {}
+        }
+      },
+      "ReadableStreamBYOBRequest": {
+        "__compat": {
+          "description": "<code>ReadableStreamBYOBRequest()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/ReadableStreamBYOBRequest",
+          "support": {
+            "android_webview": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest",
+        "support": {
+          "android_webview": {
+            "version_added": false
+          },
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/ReadableStreamBYOBRequest.json
+++ b/api/ReadableStreamBYOBRequest.json
@@ -1,68 +1,9 @@
 {
   "api": {
     "ReadableStreamBYOBRequest": {
-      "view": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/view",
-          "support": {}
-        }
-      },
-      "respond": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/respond",
-          "support": {}
-        }
-      },
-      "respondWithNewView": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/respondWithNewView",
-          "support": {}
-        }
-      },
-      "ReadableStreamBYOBRequest": {
-        "__compat": {
-          "description": "<code>ReadableStreamBYOBRequest()</code> constructor",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/ReadableStreamBYOBRequest",
-          "support": {
-            "android_webview": {
-              "version_added": false
-            },
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            }
-          }
-        }
-      },
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest",
         "support": {
-          "android_webview": {
-            "version_added": false
-          },
           "chrome": {
             "version_added": false
           },
@@ -89,7 +30,66 @@
           },
           "safari_ios": {
             "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
           }
+        }
+      },
+      "ReadableStreamBYOBRequest": {
+        "__compat": {
+          "description": "<code>ReadableStreamBYOBRequest()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/ReadableStreamBYOBRequest",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "respond": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/respond",
+          "support": {}
+        }
+      },
+      "respondWithNewView": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/respondWithNewView",
+          "support": {}
+        }
+      },
+      "view": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/view",
+          "support": {}
         }
       }
     }

--- a/api/ReadableStreamBYOBRequest.json
+++ b/api/ReadableStreamBYOBRequest.json
@@ -77,19 +77,112 @@
       "respond": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/respond",
-          "support": {}
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          }
         }
       },
       "respondWithNewView": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/respondWithNewView",
-          "support": {}
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          }
         }
       },
       "view": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/view",
-          "support": {}
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This pull request migrates compatibility data for ReadableStreamBYOBRequest from the wiki. As I do not have access to Android or Windows, I cannot supply missing data for the properties and methods.