### PR TITLE
Firefox does not support browser.tabs.getAllInWindow

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1329,10 +1329,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "45"
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": "54"
+                "version_added": false
               },
               "opera": {
                 "version_added": false


### PR DESCRIPTION
`browser.tabs.getAllInWindow` is deprecated, and not supported by Firefox:
https://searchfox.org/mozilla-central/rev/d0a41d2e7770fc00df7844d5f840067cc35ba26f/mobile/android/components/extensions/schemas/tabs.json#348-350
https://searchfox.org/mozilla-central/rev/d0a41d2e7770fc00df7844d5f840067cc35ba26f/browser/components/extensions/schemas/tabs.json#506-508