### PR TITLE
Update compat data for the browsingData API in Firefox and Firefox for Android

### DIFF
--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -139,7 +139,7 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "57"
                 },
                 "firefox_android": {
                   "version_added": false

--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -163,7 +163,7 @@
                   "version_added": "57"
                 },
                 "firefox_android": {
-                  "version_added": "57"
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": true
@@ -184,7 +184,7 @@
                   "version_added": "53"
                 },
                 "firefox_android": {
-                  "version_added": "56"
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": true
@@ -205,7 +205,7 @@
                   "version_added": "53"
                 },
                 "firefox_android": {
-                  "version_added": "56"
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": true
@@ -247,7 +247,7 @@
                   "version_added": "53"
                 },
                 "firefox_android": {
-                  "version_added": "56"
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": true
@@ -270,7 +270,7 @@
                   "version_added": "56"
                 },
                 "firefox_android": {
-                  "version_added": "56"
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": false
@@ -508,6 +508,9 @@
                 "version_added": "53"
               },
               "firefox_android": {
+                "notes": [
+                  "See <a href='https://bugzil.la/1363010'>bug 1363010</a>. <a href='https://developer.mozilla.org/Add-ons/WebExtensions/API/browsingData/remove'><code>browser.history.remove(options, {history:true})</code></a> can be used instead."
+                ],
                 "version_added": false
               },
               "opera": {
@@ -533,10 +536,8 @@
                 "version_added": "57"
               },
               "firefox_android": {
-                "notes": [
-                  "<code>removalOptions.since</code> is not supported."
-                ],
-                "version_added": "57"
+                "notes": "The method is defined but returns a rejected promise.",
+                "version_added": false
               },
               "opera": {
                 "version_added": true
@@ -557,7 +558,7 @@
                     "version_added": "58"
                   },
                   "firefox_android": {
-                    "version_added": "58"
+                    "version_added": false
                   },
                   "opera": {
                     "version_added": false
@@ -581,6 +582,7 @@
                 "version_added": "53"
               },
               "firefox_android": {
+                "notes": "See <a href='https://bugzil.la/1363012'>bug 1363012</a>.",
                 "version_added": false
               },
               "opera": {


### PR DESCRIPTION
`browsingData.remove` supports the `indexedDB` option since Firefox 57 - https://bugzilla.mozilla.org/show_bug.cgi?id=1333050