### PR TITLE
add note about partial support for Path2D constructor in Edge

### DIFF
--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -65,7 +65,8 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": true,
+              "notes": "The constructor for Path2D objects in Edge does not support being invoked with a string consisting of SVG path data. See https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8438884/ for details."
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -66,7 +66,7 @@
             },
             "edge": {
               "version_added": true,
-              "notes": "The constructor for Path2D objects in Edge does not support being invoked with a string consisting of SVG path data. See https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8438884/ for details."
+              "notes": "The constructor for <code>Path2D</code> objects in Edge does not support being invoked with a string consisting of SVG path data. See <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8438884/'>issue 8438884</a> for details."
             },
             "edge_mobile": {
               "version_added": null


### PR DESCRIPTION
The constructor for Path2D objects in Edge is marked as "fully supported", but it does not support being "invoked with a string consisting of SVG path data".

A relevant bug exists at https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8438884/ .

fixes #1777