### PR TITLE
Add status info to some APIs that were missing it

### DIFF
--- a/api/Comment.json
+++ b/api/Comment.json
@@ -40,6 +40,11 @@
           "safari_ios": {
             "version_added": true
           }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
         }
       },
       "Comment": {

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -628,6 +628,11 @@
               "samsunginternet_android": {
                 "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -461,6 +461,11 @@
               "samsunginternet_android": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -159,6 +159,11 @@
             "samsunginternet_android": {
               "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -50,9 +50,9 @@
           "deprecated": false
         }
       },
-      "workers_support": {
+      "worker_support": {
         "__compat": {
-          "description": "Support in workers",
+          "description": "Available in workers",
           "support": {
             "webview_android": {
               "version_added": true
@@ -93,6 +93,11 @@
             "samsunginternet_android": {
               "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -148,6 +148,11 @@
               "samsunginternet_android": {
                 "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -53,7 +53,7 @@
       },
       "SpeechRecognition": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/SpeechRecognition",
           "description": "<code>SpeechRecognition</code> constructor",
           "support": {
             "chrome": {
@@ -96,6 +96,11 @@
             "webview_android": {
               "version_added": null
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -152,6 +152,11 @@
             "samsunginternet_android": {
               "version_added": null
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
Updated the `Comment`, `DOMTokenList`, `FetchEvent`, `Headers`, `SharedWorker`, `SpeechRecognition`, `TextMetrics`, and `ImageData` APIs with status info.

Some other minor fixes:

- For `ImageData`, I also changed the `workers_support` subfeature to `worker_support` to match the ~dozen other subfeatures of the same name, e.g. in [Console.json](https://github.com/mdn/browser-compat-data/blob/149e4331ac507c3eeb1795b4f8b290dc23c548e9/api/Console.json#L54).
- For `SpeechRecognition`, the constructor's MDN URL was incorrect.