### PR TITLE
Add missing status info for various features.

### DIFF
--- a/api/NavigatorConcurrentHardware.json
+++ b/api/NavigatorConcurrentHardware.json
@@ -50,9 +50,9 @@
           "deprecated": false
         }
       },
-      "available_on_workers": {
+      "worker_support": {
         "__compat": {
-          "description": "Available on Workers",
+          "description": "Available in workers",
           "support": {
             "webview_android": {
               "version_added": "37"
@@ -93,6 +93,11 @@
             "samsunginternet_android": {
               "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/NavigatorLanguage.json
+++ b/api/NavigatorLanguage.json
@@ -87,6 +87,11 @@
             "webview_android": {
               "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/NavigatorOnLine.json
+++ b/api/NavigatorOnLine.json
@@ -87,12 +87,17 @@
             "webview_android": {
               "version_added": null
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
       "onLine": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorLanguage/onLine",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorOnLine/onLine",
           "support": {
             "chrome": {
               "version_added": true,

--- a/api/SyncManager.json
+++ b/api/SyncManager.json
@@ -50,9 +50,9 @@
           "deprecated": false
         }
       },
-      "available_on_workers": {
+      "worker_support": {
         "__compat": {
-          "description": "Available on Workers",
+          "description": "Available in workers",
           "support": {
             "chrome": [
               {

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -144,6 +144,11 @@
               "samsunginternet_android": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -604,6 +604,11 @@
               "samsunginternet_android": {
                 "version_added": "6.0"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -194,6 +194,11 @@
               "samsunginternet_android": {
                 "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -96,6 +96,11 @@
               "samsunginternet_android": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }


### PR DESCRIPTION
Adds status info for the following:

- `api/NavigatorCurrentHardware`
- `api/NavigatorLanguage`
- `api/NavigatorOnLine`
- `api/Worker`
- `api/WorkerGlobalScope`
- `api/XMLHttpRequest`
- `css/properties/overflow`

Also makes some minor improvements to other data, including changing the SyncManager's worker support subfeature name.

Part of #519.