### PR TITLE
Add status info to IDB APIs that were missing it.

### DIFF
--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -185,6 +185,11 @@
                 "version_added": true
               }
             ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -362,6 +367,11 @@
               "samsunginternet_android": {
                 "version_added": "7.0"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/IDBCursorWithValue.json
+++ b/api/IDBCursorWithValue.json
@@ -129,6 +129,11 @@
             "samsunginternet_android": {
               "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -157,6 +157,11 @@
                 "version_added": true
               }
             ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/IDBEnvironment.json
+++ b/api/IDBEnvironment.json
@@ -108,6 +108,11 @@
             "samsunginternet_android": {
               "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -129,6 +129,11 @@
             "samsunginternet_android": {
               "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -129,6 +129,11 @@
             "samsunginternet_android": {
               "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -516,6 +521,11 @@
               "samsunginternet_android": {
                 "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/IDBKeyRange.json
+++ b/api/IDBKeyRange.json
@@ -108,6 +108,11 @@
             "samsunginternet_android": {
               "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -129,6 +129,11 @@
             "samsunginternet_android": {
               "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -522,6 +527,11 @@
               "samsunginternet_android": {
                 "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/IDBOpenDBRequest.json
+++ b/api/IDBOpenDBRequest.json
@@ -129,6 +129,11 @@
             "samsunginternet_android": {
               "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/IDBRequest.json
+++ b/api/IDBRequest.json
@@ -129,6 +129,11 @@
             "samsunginternet_android": {
               "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -261,6 +266,11 @@
               "samsunginternet_android": {
                 "version_added": "5.0"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -129,6 +129,11 @@
             "samsunginternet_android": {
               "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -348,6 +353,11 @@
               "samsunginternet_android": {
                 "version_added": "5.0"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/IDBVersionChangeEvent.json
+++ b/api/IDBVersionChangeEvent.json
@@ -107,6 +107,11 @@
             "samsunginternet_android": {
               "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
Add status info to the following APIs:

- `api/IDBCursor`
- `api/IDBCursorWithValue`
- `api/IDBDatabase`
- `api/IDBEnvironment`
- `api/IDBFactory`
- `api/IDBIndex`
- `api/IDBKeyRange`
- `api/IDBObjectStore`
- `api/IDBOpenDBRequest`
- `api/IDBRequest`
- `api/IDBTransaction`
- `api/IDBVersionChangeEvent`