### PR TITLE
Update Samsung Internet current browsers

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -61,15 +61,15 @@
         },
         "6.4": {
           "release_date": "2018-02-19",
-          "status": "current"
+          "status": "retired"
         },
         "7.0": {
           "release_date": "2018-03-16",
-          "status": "exclusive"
+          "status": "retired"
         },
         "7.2": {
           "release_date": "2018-03-07",
-          "status": "retired"
+          "status": "current"
         },
         "7.4": {
           "release_date": "2018-05-31",


### PR DESCRIPTION
Hi. Samsung Internet v7.2 is [now a stable release](https://medium.com/samsung-internet-dev/7-2-stable-is-here-81fdbfca75b4), so this should update our browser data appropriately.
Thanks!