### PR TITLE
Update RTCIceCandidate

### DIFF
--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -45,7 +45,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -96,7 +96,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -147,7 +147,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -158,13 +158,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/foundation",
           "support": {
             "webview_android": {
-              "version_added": true
+              "version_added": false
             },
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -173,19 +173,19 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -198,7 +198,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -209,13 +209,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/ip",
           "support": {
             "webview_android": {
-              "version_added": true
+              "version_added": false
             },
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -224,19 +224,19 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -249,7 +249,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -260,13 +260,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/port",
           "support": {
             "webview_android": {
-              "version_added": true
+              "version_added": false
             },
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -275,19 +275,19 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -300,7 +300,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -351,7 +351,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -402,7 +402,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -453,7 +453,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -504,7 +504,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -555,7 +555,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -606,7 +606,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -657,7 +657,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -719,13 +719,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/component",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -734,13 +734,13 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -836,10 +836,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "27"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "27"
             },
             "ie": {
               "version_added": null

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -311,13 +311,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/priority",
           "support": {
             "webview_android": {
-              "version_added": true
+              "version_added": false
             },
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -326,19 +326,19 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -362,13 +362,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/protocol",
           "support": {
             "webview_android": {
-              "version_added": true
+              "version_added": false
             },
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -377,19 +377,19 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -413,13 +413,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/relatedAddress",
           "support": {
             "webview_android": {
-              "version_added": true
+              "version_added": false
             },
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -428,19 +428,19 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -464,13 +464,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/relatedPort",
           "support": {
             "webview_android": {
-              "version_added": true
+              "version_added": false
             },
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -479,19 +479,19 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -617,13 +617,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/tcpType",
           "support": {
             "webview_android": {
-              "version_added": true
+              "version_added": false
             },
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -632,19 +632,19 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -668,13 +668,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/type",
           "support": {
             "webview_android": {
-              "version_added": true
+              "version_added": false
             },
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -683,19 +683,19 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -785,10 +785,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This PR updates RTCIceCandidate's data based on the fact that nearly all of its properties are unimplemented in all or most browsers. I have not touched Edge data, even though I expect the values of "true" need to be changed; I will let someone who can more easily confirm that follow up with another PR later.

I've also updated all Firefox compatibility information to be accurate and complete, or as much so as possible based on available information and following conversations with jib and others.