### PR TITLE
Add DOMRectReadOnly.fromRect()

### DIFF
--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -114,6 +114,57 @@
           }
         }
       },
+      "fromRect": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/fromRect",
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "44"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "57"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "bottom": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/bottom",


### PR DESCRIPTION
I didn't notice that [`DOMRectReadOnly.fromRect()`](https://developer.mozilla.org/en-US/docs/Web/API/DOMRectReadOnly/fromRect#Browser_Compatibility) was missing in #1620, so here it is now.