### PR TITLE
Add compat data for StaticRange API.

### DIFF
--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -1,0 +1,413 @@
+{
+  "api": {
+    "StaticRange": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/StaticRange",
+        "support": {
+          "chrome": {
+            "version_added": "60"
+          },
+          "chrome_android": {
+            "version_added": "60"
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": null
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          },
+          "samsunginternet_android": {
+            "version_added": null
+          },
+          "webview_android": {
+            "version_added": "60"
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "StaticRange": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StaticRange/StaticRange",
+          "description": "<code>StaticRange()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "60"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "startContainer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StaticRange/startContainer",
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "60"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "startOffset": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StaticRange/startOffset",
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "60"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "endContainer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StaticRange/endContainer",
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "60"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "endOffset": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StaticRange/endOffset",
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "60"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "collapsed": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StaticRange/collapsed",
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "60"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toRange": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StaticRange/toRange",
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "60"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": "47"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "47"
           },
           "safari": {
             "version_added": null
@@ -77,10 +77,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": null
@@ -128,16 +128,16 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -179,16 +179,16 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -230,16 +230,16 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -281,16 +281,16 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -332,16 +332,16 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -383,10 +383,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": null

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -32,10 +32,10 @@
             "version_added": "47"
           },
           "safari": {
-            "version_added": null
+            "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "10.1"
           },
           "samsunginternet_android": {
             "version_added": null


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/StaticRange

It looks like the API is only supported by Chrome at the moment. I'm basing the data off the MDN pages for each subfeature. Oddly, I can't find it in the Chrome Status list.

Adds the following features:
- `api/StaticRange`
- `api/StaticRange/StaticRange`
- `api/StaticRange/collapsed`
- `api/StaticRange/endContainer`
- `api/StaticRange/endOffset`
- `api/StaticRange/startContainer`
- `api/StaticRange/startOffset`
- `api/StaticRange/toRange`