### PR TITLE
Update UserProximityEvent data

### DIFF
--- a/api/UserProximityEvent.json
+++ b/api/UserProximityEvent.json
@@ -19,6 +19,7 @@
           "firefox": [
             {
               "version_added": "60",
+              "version_removed": "62",
               "flags": [
                 {
                   "type": "preference",
@@ -26,7 +27,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "<a href='https://bugzil.la/1359076'>bug 1359076</a>"
+              "notes": "See <a href='https://bugzil.la/1359076'>bug 1359076</a> and <a href='https://bugzil.la/1462308'>bug 1462308</a>."
             },
             {
               "version_added": true,
@@ -36,6 +37,7 @@
           "firefox_android": [
             {
               "version_added": "60",
+              "version_removed": "62",
               "flags": [
                 {
                   "type": "preference",
@@ -43,7 +45,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "<a href='https://bugzil.la/1359076'>bug 1359076</a>"
+              "notes": "See <a href='https://bugzil.la/1359076'>bug 1359076</a> and <a href='https://bugzil.la/1462308'>bug 1462308</a>."
             },
             {
               "version_added": "15",
@@ -94,6 +96,7 @@
             "firefox": [
               {
                 "version_added": "60",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
@@ -101,7 +104,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "<a href='https://bugzil.la/1359076'>bug 1359076</a>"
+                "notes": "See <a href='https://bugzil.la/1359076'>bug 1359076</a> and <a href='https://bugzil.la/1462308'>bug 1462308</a>."
               },
               {
                 "version_added": true,
@@ -111,6 +114,7 @@
             "firefox_android": [
               {
                 "version_added": "60",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
@@ -118,7 +122,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "<a href='https://bugzil.la/1359076'>bug 1359076</a>"
+                "notes": "See <a href='https://bugzil.la/1359076'>bug 1359076</a> and <a href='https://bugzil.la/1462308'>bug 1462308</a>."
               },
               {
                 "version_added": "15",

--- a/api/UserProximityEvent.json
+++ b/api/UserProximityEvent.json
@@ -93,42 +93,14 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": [
-              {
-                "version_added": "60",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "device.sensors.proximity.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "See <a href='https://bugzil.la/1359076'>bug 1359076</a> and <a href='https://bugzil.la/1462308'>bug 1462308</a>."
-              },
-              {
-                "version_added": true,
-                "version_removed": "60"
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "60",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "device.sensors.proximity.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "See <a href='https://bugzil.la/1359076'>bug 1359076</a> and <a href='https://bugzil.la/1462308'>bug 1462308</a>."
-              },
-              {
-                "version_added": "15",
-                "version_removed": "60"
-              }
-            ],
+            "firefox": {
+              "version_added": true,
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "15",
+              "version_removed": "62"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/UserProximityEvent.json
+++ b/api/UserProximityEvent.json
@@ -74,6 +74,85 @@
           "standard_track": true,
           "deprecated": false
         }
+      },
+      "near": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/UserProximityEvent/near",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "60",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "device.sensors.proximity.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "<a href='https://bugzil.la/1359076'>bug 1359076</a>"
+              },
+              {
+                "version_added": true,
+                "version_removed": "60"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "60",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "device.sensors.proximity.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "<a href='https://bugzil.la/1359076'>bug 1359076</a>"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "60"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/UserProximityEvent.json
+++ b/api/UserProximityEvent.json
@@ -16,30 +16,40 @@
           "edge_mobile": {
             "version_added": null
           },
-          "firefox": {
-            "version_added": true,
-            "version_removed": "60",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "device.sensors.proximity.enabled",
-                "value_to_set": "true"
-              }
-            ],
-            "notes": "<a href='https://bugzil.la/1359076'>bug 1359076</a>"
-          },
-          "firefox_android": {
-            "version_added": "15",
-            "version_removed": "60",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "device.sensors.proximity.enabled",
-                "value_to_set": "true"
-              }
-            ],
-            "notes": "<a href='https://bugzil.la/1359076'>bug 1359076</a>"
-          },
+          "firefox": [
+            {
+              "version_added": "60",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "device.sensors.proximity.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "<a href='https://bugzil.la/1359076'>bug 1359076</a>"
+            },
+            {
+              "version_added": true,
+              "version_removed": "60"
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "60",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "device.sensors.proximity.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "<a href='https://bugzil.la/1359076'>bug 1359076</a>"
+            },
+            {
+              "version_added": "15",
+              "version_removed": "60"
+            }
+          ],
           "ie": {
             "version_added": false
           },


### PR DESCRIPTION
Following up on https://github.com/mdn/browser-compat-data/pull/2125#issuecomment-400112856, this PR adds the data missing for `UserProximityEvent.near` and fixes the story of `UserProximityEvent`'s availability in Firefox (it was once on by default, is now behind a preference, and will be removed in version 62).