### PR TITLE
Update data for DeviceLightEvent and DeviceProximityEvent for removal from Firefox

### DIFF
--- a/api/DeviceLightEvent.json
+++ b/api/DeviceLightEvent.json
@@ -22,6 +22,7 @@
           "firefox": [
             {
               "version_added": "60",
+              "version_removed": "62",
               "flags": [
                 {
                   "type": "preference",
@@ -29,7 +30,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "Disabled by default. See <a href='https://bugzil.la/1359076'>bug 1359076</a>."
+              "notes": "See <a href='https://bugzil.la/1359076'>bug 1359076</a> and <a href='https://bugzil.la/1462308'>bug 1462308</a>."
             },
             {
               "version_added": "22",
@@ -39,6 +40,7 @@
           "firefox_android": [
             {
               "version_added": "60",
+              "version_removed": "62",
               "flags": [
                 {
                   "type": "preference",
@@ -46,7 +48,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "Disabled by default. See <a href='https://bugzil.la/1359076'>bug 1359076</a>."
+              "notes": "See <a href='https://bugzil.la/1359076'>bug 1359076</a> and <a href='https://bugzil.la/1462308'>bug 1462308</a>."
             },
             {
               "version_added": "15"
@@ -96,39 +98,14 @@
             "edge_mobile": {
               "version_added": true
             },
-            "firefox": [
-              {
-                "version_added": "60",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "device.sensors.ambientLight.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Disabled by default. See <a href='https://bugzil.la/1359076'>bug 1359076</a>."
-              },
-              {
-                "version_added": "22",
-                "notes": "Not supported for macbook with touchbar and <a href='https://bugzil.la/754199'>Windows 7</a>."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "60",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "device.sensors.ambientLight.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Disabled by default. See <a href='https://bugzil.la/1359076'>bug 1359076</a>."
-              },
-              {
-                "version_added": "15"
-              }
-            ],
+            "firefox": {
+              "version_added": "22",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "15",
+              "version_removed": "62"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/DeviceProximityEvent.json
+++ b/api/DeviceProximityEvent.json
@@ -22,6 +22,7 @@
           "firefox": [
             {
               "version_added": "60",
+              "version_removed": "62",
               "flags": [
                 {
                   "type": "preference",
@@ -29,7 +30,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "This event is disabled by default. See <a href='https://bugzil.la/1359076'>bug 1359076</a>."
+              "notes": "See <a href='https://bugzil.la/1359076'>bug 1359076</a> and <a href='https://bugzil.la/1462308'>bug 1462308</a>."
             },
             {
               "version_added": true
@@ -38,6 +39,7 @@
           "firefox_android": [
             {
               "version_added": "60",
+              "version_removed": "62",
               "flags": [
                 {
                   "type": "preference",
@@ -45,7 +47,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "This event is disabled by default. See <a href='https://bugzil.la/1359076'>bug 1359076</a>."
+              "notes": "See <a href='https://bugzil.la/1359076'>bug 1359076</a> and <a href='https://bugzil.la/1462308'>bug 1462308</a>."
             },
             {
               "version_added": "15"
@@ -96,10 +98,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": "15"
+              "version_added": "15",
+              "version_removed": "62"
             },
             "ie": {
               "version_added": false
@@ -147,10 +151,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": "15"
+              "version_added": "15",
+              "version_removed": "62"
             },
             "ie": {
               "version_added": false
@@ -198,10 +204,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": "15"
+              "version_added": "15",
+              "version_removed": "62"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
According to https://bugzil.la/1462308, both `DeviceLightEvent` and `DeviceProximityEvent` are removed from Firefox 62. Found this in the course of fixing up #2367.