### PR TITLE
Firefox 62 removes CSP referrer directive (bug 1302449)

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1002,11 +1002,11 @@
               },
               "firefox": {
                 "version_added": "37",
-                "notes": "Will be removed, see <a href='https://bugzil.la/1302449'>Bugzilla bug 1302449</a>."
+                "version_removed": "62"
               },
               "firefox_android": {
                 "version_added": "37",
-                "notes": "Will be removed, see <a href='https://bugzil.la/1302449'>Bugzilla bug 1302449</a>."
+                "version_removed": "62"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1302449