### PR TITLE
Firefox 62 enables Array.flat/flatMap (bug 1435813)

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -506,12 +506,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": "Available in Firefox Nightly only. See <a href='https://bugzil.la/1435813'>bug 1435813</a> for status on enabling this by default."
+                "version_added": "62"
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "Available in Firefox Nightly only. See <a href='https://bugzil.la/1435813'>bug 1435813</a> for status on enabling this by default."
+                "version_added": "62"
               },
               "ie": {
                 "version_added": false
@@ -562,12 +560,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": "Available in Firefox Nightly only. See <a href='https://bugzil.la/1435813'>bug 1435813</a> for status on enabling this by default."
+                "version_added": "62"
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "Available in Firefox Nightly only. See <a href='https://bugzil.la/1435813'>bug 1435813</a> for status on enabling this by default."
+                "version_added": "62"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1435813