### PR TITLE
update Firefox browser version and correct release dates

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -325,22 +325,22 @@
         "60": {
           "release_date": "2018-05-09",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/60",
-          "status": "current"
+          "status": "retired"
         },
         "61": {
-          "release_date": "2018-07-03",
+          "release_date": "2018-06-26",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/61",
-          "status": "beta"
+          "status": "current"
         },
         "62": {
-          "release_date": "2018-08-28",
+          "release_date": "2018-09-05",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/62",
-          "status": "nightly"
+          "status": "beta"
         },
         "63": {
           "release_date": "2018-10-23",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/63",
-          "status": "planned"
+          "status": "nightly"
         },
         "64": {
           "release_date": "2018-11-27",

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -271,22 +271,22 @@
         "60": {
           "release_date": "2018-05-09",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/60",
-          "status": "current"
+          "status": "retired"
         },
         "61": {
-          "release_date": "2018-07-03",
+          "release_date": "2018-06-26",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/61",
-          "status": "beta"
+          "status": "current"
         },
         "62": {
-          "release_date": "2018-08-28",
+          "release_date": "2018-09-05",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/62",
-          "status": "nightly"
+          "status": "beta"
         },
         "63": {
           "release_date": "2018-10-23",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/63",
-          "status": "planned"
+          "status": "nightly"
         },
         "64": {
           "release_date": "2018-11-27",


### PR DESCRIPTION
https://developer.mozilla.org/en-US/Firefox/Releases/61
https://hacks.mozilla.org/2018/06/firefox-61-quantum-of-solstice/