### PR TITLE
Add RTCTrackEventInit and versions for RTCTrackEvent

### DIFF
--- a/api/RTCTrackEventInit.json
+++ b/api/RTCTrackEventInit.json
@@ -1,8 +1,8 @@
 {
   "api": {
-    "RTCTrackEvent": {
+    "RTCTrackEventInit": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCTrackEvent",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCTrackEventInit",
         "support": {
           "webview_android": {
             "version_added": "56"
@@ -52,7 +52,7 @@
       },
       "receiver": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCTrackEvent/receiver",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCTrackEventInit/receiver",
           "support": {
             "webview_android": {
               "version_added": "56"
@@ -103,7 +103,7 @@
       },
       "streams": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCTrackEvent/streams",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCTrackEventInit/streams",
           "support": {
             "webview_android": {
               "version_added": "56"
@@ -154,7 +154,7 @@
       },
       "track": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCTrackEvent/track",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCTrackEventInit/track",
           "support": {
             "webview_android": {
               "version_added": "56"
@@ -205,7 +205,7 @@
       },
       "transceiver": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCTrackEvent/transceiver",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCTrackEventInit/transceiver",
           "support": {
             "webview_android": {
               "version_added": "56"


### PR DESCRIPTION
This adds RTCTrackEventInit.json and also sets version numbers for RTCTrackEvent. The version numbers come from RTCPeerConnection.ontrack, which would have been added at the same time.