### PR TITLE
Node.js 7.6.0 enables async functions

### DIFF
--- a/javascript/builtins/AsyncFunction.json
+++ b/javascript/builtins/AsyncFunction.json
@@ -30,7 +30,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": null
+              "version_added": "7.6.0"
             },
             "opera": {
               "version_added": "42"


### PR DESCRIPTION
V8 was updated to version 5.5 in Node.js 7.6.0.

* [Node.js 7.6.0 release notes](https://nodejs.org/en/blog/release/v7.6.0/)
* [V8 5.5 release notes](https://v8project.blogspot.com/2016/10/v8-release-55.html)