### PR TITLE
Fix `column-gap` support in Flex context

### DIFF
--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -8,22 +8,22 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-gap",
             "support": {
               "chrome": {
-                "version_added": "66"
+                "version_added": null
               },
               "chrome_android": {
-                "version_added": "66"
+                "version_added": null
               },
               "edge": {
-                "version_added": "16"
+                "version_added": null
               },
               "edge_mobile": {
-                "version_added": "16"
+                "version_added": null
               },
               "firefox": {
-                "version_added": "61"
+                "version_added": "63"
               },
               "firefox_android": {
-                "version_added": "61"
+                "version_added": "63"
               },
               "ie": {
                 "version_added": false
@@ -35,7 +35,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": "66"
+                "version_added": null
               }
             },
             "status": {


### PR DESCRIPTION
This is only being added [in Firefox 63](https://bugzil.la/1398483#c30). And I don’t know about Edge or Chrome support.

review?(@Elchi3, @jpmedley)

---

I’d like to get this into `0.0.40`.