### PR TITLE
Firefox 48 aliases `browser_specific_settings` to `applications`

### DIFF
--- a/webextensions/manifest/applications.json
+++ b/webextensions/manifest/applications.json
@@ -9,15 +9,27 @@
               "version_added": false
             },
             "edge": {
-              "alternative_name": "browser_specific_settings",
-              "version_added": "15"
+              "version_added": "15",
+              "alternative_name": "browser_specific_settings"
             },
-            "firefox": {
-              "version_added": "48"
-            },
-            "firefox_android": {
-              "version_added": "48"
-            },
+            "firefox": [
+              {
+                "version_added": "48"
+              },
+              {
+                "version_added": "48",
+                "alternative_name": "browser_specific_settings"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "48"
+              },
+              {
+                "version_added": "48",
+                "alternative_name": "browser_specific_settings"
+              }
+            ],
             "opera": {
               "version_added": false
             }


### PR DESCRIPTION
See [bug 1262005](https://bugzil.la/1262005 "1262005 - Allow a WebExtension to look in a couple of places for the add-on id") for details.