### PR TITLE
Correct input element MDN URLs.

### DIFF
--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -4,7 +4,7 @@
       "input": {
         "input-color": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/color",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/color",
             "description": "<code>type=\"color\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/date.json
+++ b/html/elements/input/date.json
@@ -4,7 +4,7 @@
       "input": {
         "input-date": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/date",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/date",
             "description": "<code>type=\"date\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -4,7 +4,7 @@
       "input": {
         "input-datetime-local": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/datetime-local",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/datetime-local",
             "description": "<code>type=\"datetime-local\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/email.json
+++ b/html/elements/input/email.json
@@ -4,7 +4,7 @@
       "input": {
         "input-email": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/email",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/email",
             "description": "<code>type=\"email\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/file.json
+++ b/html/elements/input/file.json
@@ -5,7 +5,7 @@
         "input-file": {
           "__compat": {
             "description": "<code>type=\"file\"</code>",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/file",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/file",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/html/elements/input/hidden.json
+++ b/html/elements/input/hidden.json
@@ -4,7 +4,7 @@
       "input": {
         "input-hidden": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/hidden",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/hidden",
             "description": "<code>type=\"hidden\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/image.json
+++ b/html/elements/input/image.json
@@ -4,7 +4,7 @@
       "input": {
         "input-image": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/image",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/image",
             "description": "<code>type=\"image\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/month.json
+++ b/html/elements/input/month.json
@@ -4,7 +4,7 @@
       "input": {
         "input-month": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/month",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/month",
             "description": "<code>type=\"month\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/number.json
+++ b/html/elements/input/number.json
@@ -4,7 +4,7 @@
       "input": {
         "input-number": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/number",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/number",
             "description": "<code>type=\"number\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/password.json
+++ b/html/elements/input/password.json
@@ -4,7 +4,7 @@
       "input": {
         "input-password": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/password",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/password",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/html/elements/input/radio.json
+++ b/html/elements/input/radio.json
@@ -4,7 +4,7 @@
       "input": {
         "input-radio": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/radio",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/radio",
             "description": "<code>type=\"radio\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/reset.json
+++ b/html/elements/input/reset.json
@@ -4,7 +4,7 @@
       "input": {
         "input-reset": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/reset",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/reset",
             "description": "<code>type=\"reset\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/submit.json
+++ b/html/elements/input/submit.json
@@ -4,7 +4,7 @@
       "input": {
         "input-submit": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/submit",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/submit",
             "description": "<code>type=\"submit\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/tel.json
+++ b/html/elements/input/tel.json
@@ -4,7 +4,7 @@
       "input": {
         "input-tel": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/tel",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/tel",
             "description": "<code>type=\"tel\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/text.json
+++ b/html/elements/input/text.json
@@ -4,7 +4,7 @@
       "input": {
         "input-text": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/text",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/text",
             "description": "<code>type=\"text\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/url.json
+++ b/html/elements/input/url.json
@@ -4,7 +4,7 @@
       "input": {
         "input-url": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/url",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/url",
             "description": "<code>type=\"url\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/week.json
+++ b/html/elements/input/week.json
@@ -4,7 +4,7 @@
       "input": {
         "input-week": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/html/Element/input/week",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/week",
             "description": "<code>type=\"week\"</code>",
             "support": {
               "chrome": {


### PR DESCRIPTION
The canonical URLs for HTML pages should have HTML capitalized as far as I can tell.

Otherwise, the table has a link despite being on the page already:

<img width="1077" alt="screen shot 2018-06-29 at 12 10 55 pm" src="https://user-images.githubusercontent.com/2977353/42107689-7eff2886-7b95-11e8-9f29-6ecbce4aa65a.png">
