### PR TITLE
Add the last few missing statuses

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -206,6 +206,11 @@
               "samsunginternet_android": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }
@@ -1417,6 +1422,11 @@
               "samsunginternet_android": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -1474,6 +1484,11 @@
               "samsunginternet_android": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -1531,6 +1546,11 @@
               "samsunginternet_android": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -1582,6 +1602,11 @@
               "samsunginternet_android": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -1628,6 +1653,11 @@
               "samsunginternet_android": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }
@@ -2049,6 +2079,11 @@
               "samsunginternet_android": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }
@@ -2431,6 +2466,11 @@
               "samsunginternet_android": {
                 "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }
@@ -2528,6 +2568,11 @@
               "samsunginternet_android": {
                 "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -2574,6 +2619,11 @@
               "samsunginternet_android": {
                 "version_added": "7.0"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -2622,6 +2672,11 @@
               "samsunginternet_android": {
                 "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }
@@ -2872,6 +2927,11 @@
               "samsunginternet_android": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }
@@ -3185,6 +3245,11 @@
               "samsunginternet_android": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }
@@ -3282,6 +3347,11 @@
               "samsunginternet_android": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }
@@ -4168,6 +4238,11 @@
               "samsunginternet_android": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -308,7 +308,7 @@
         },
         "webgl_context": {
           "__compat": {
-            "description": "webgl context",
+            "description": "WebGL context",
             "support": {
               "webview_android": {
                 "version_added": null
@@ -371,12 +371,17 @@
               "samsunginternet_android": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
         "webgl2_context": {
           "__compat": {
-            "description": "webgl2 context",
+            "description": "WebGL2 context",
             "support": {
               "webview_android": {
                 "version_added": null
@@ -424,6 +429,11 @@
               "samsunginternet_android": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -470,6 +480,11 @@
               "samsunginternet_android": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -516,6 +531,11 @@
               "samsunginternet_android": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -562,6 +582,11 @@
               "samsunginternet_android": {
                 "version_added": "6.0"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }
@@ -764,6 +789,11 @@
               "samsunginternet_android": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/ReadableStreamBYOBRequest.json
+++ b/api/ReadableStreamBYOBRequest.json
@@ -34,6 +34,11 @@
           "webview_android": {
             "version_added": false
           }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
         }
       },
       "ReadableStreamBYOBRequest": {
@@ -71,6 +76,11 @@
             "webview_android": {
               "version_added": false
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -108,6 +118,11 @@
             "webview_android": {
               "version_added": false
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -145,6 +160,11 @@
             "webview_android": {
               "version_added": false
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -182,6 +202,11 @@
             "webview_android": {
               "version_added": false
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/Request.json
+++ b/api/Request.json
@@ -210,6 +210,11 @@
               "webview_android": {
                 "version_added": "43"
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -256,6 +261,11 @@
               "webview_android": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -302,6 +312,11 @@
               "samsunginternet_android": {
                 "version_added": "5.0"
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -348,6 +363,11 @@
               "samsunginternet_android": {
                 "version_added": true
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -394,6 +414,11 @@
               "samsunginternet_android": {
                 "version_added": true
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }
@@ -492,6 +517,11 @@
               "samsunginternet_android": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }
@@ -1105,6 +1135,11 @@
               "samsunginternet_android": {
                 "version_added": "5.0"
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -448,6 +448,11 @@
               "webview_android": {
                 "version_added": "52"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -491,6 +496,11 @@
               "webview_android": {
                 "version_added": "54"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -534,6 +544,11 @@
               "webview_android": {
                 "version_added": "59"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }
@@ -666,6 +681,11 @@
               "webview_android": {
                 "version_added": "43"
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -709,6 +729,11 @@
               "webview_android": {
                 "version_added": "43"
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -752,6 +777,11 @@
               "webview_android": {
                 "version_added": "52"
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -795,6 +825,11 @@
               "webview_android": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }
@@ -909,6 +944,11 @@
               "webview_android": {
                 "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }
@@ -1108,6 +1148,11 @@
               "webview_android": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }
@@ -1211,6 +1256,11 @@
               "webview_android": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -1254,6 +1304,11 @@
               "webview_android": {
                 "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }


### PR DESCRIPTION
This finishes adding all the missing statuses from https://github.com/mdn/browser-compat-data/issues/519#issuecomment-398837780.

Adds missing status info for these files:

- `api/CanvasRenderingContext2D.json`
- `api/HTMLCanvasElement.json`
- `api/Request.json`
- `api/WindowOrWorkerGlobalScope.json`
- `api/ReadableStreamBYOBRequest.json`