### PR TITLE
Add data for DOMMatrixReadOnly() constructor

### DIFF
--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -98,7 +98,7 @@
       "DOMMatrixReadOnly": {
         "__compat": {
           "description": "<code>DOMMatrixReadOnly()</code> constructor",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrix/DOMMatrixReadOnly",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/DOMMatrixReadOnly",
           "support": {
             "webview_android": {
               "version_added": "61"

--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -95,6 +95,55 @@
           }
         }
       },
+      "DOMMatrixReadOnly": {
+        "__compat": {
+          "description": "<code>DOMMatrixReadOnly()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrix/DOMMatrixReadOnly",
+          "support": {
+            "webview_android": {
+              "version_added": "61"
+            },
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "m11": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m11",


### PR DESCRIPTION
I put this under `DOMMatrixReadOnly` even though the wiki page seems to (erroneously?) has it nested under `DOMMatrix`.

Brought to my attention by https://github.com/mdn/browser-compat-data/pull/1617#issuecomment-399544940. Thanks @connorshea!