### PR TITLE
Node.js async / await support

### DIFF
--- a/javascript/builtins/AsyncFunction.json
+++ b/javascript/builtins/AsyncFunction.json
@@ -29,9 +29,21 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": null
-            },
+            "nodejs": [
+              {
+                "version_added": "7.6.0"
+              },
+              {
+                "version_added": "7.0.0",
+                "version_removed": "7.6.0",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--harmony"
+                  }
+                ]
+              }
+            ],
             "opera": {
               "version_added": "42"
             },
@@ -82,9 +94,21 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": null
-              },
+              "nodejs": [
+                {
+                  "version_added": "7.6.0"
+                },
+                {
+                  "version_added": "7.0.0",
+                  "version_removed": "7.6.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": "42"
               },

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -794,9 +794,21 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": null
-              },
+              "nodejs": [
+                {
+                  "version_added": "7.6.0"
+                },
+                {
+                  "version_added": "7.0.0",
+                  "version_removed": "7.6.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": null
               },

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -860,9 +860,21 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": null
-              },
+              "nodejs": [
+                {
+                  "version_added": "10.3.0"
+                },
+                {
+                  "version_added": "8.10.0",
+                  "version_removed": "10.3.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": null
               },

--- a/javascript/operators/async_function_expression.json
+++ b/javascript/operators/async_function_expression.json
@@ -30,9 +30,21 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": "7"
-            },
+            "nodejs": [
+              {
+                "version_added": "7.6.0"
+              },
+              {
+                "version_added": "7.0.0",
+                "version_removed": "7.6.0",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--harmony"
+                  }
+                ]
+              }
+            ],
             "opera": {
               "version_added": "42"
             },

--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -29,9 +29,21 @@
             "ie": {
               "version_added": null
             },
-            "nodejs": {
-              "version_added": "7"
-            },
+            "nodejs": [
+              {
+                "version_added": "7.6.0"
+              },
+              {
+                "version_added": "7.0.0",
+                "version_removed": "7.6.0",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--harmony"
+                  }
+                ]
+              }
+            ],
             "opera": {
               "version_added": "42"
             },

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -87,9 +87,21 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": null
-            },
+            "nodejs": [
+              {
+                "version_added": "7.6.0"
+              },
+              {
+                "version_added": "7.0.0",
+                "version_removed": "7.6.0",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--harmony"
+                  }
+                ]
+              }
+            ],
             "opera": {
               "version_added": "42"
             },


### PR DESCRIPTION
Added Node.js async / await version info to all files where I found "async" or "await":

[javascript/functions.json](../blob/master/javascript/functions.json)
[javascript/operators/async_function_expression.json](../blob/master/javascript/operators/async_function_expression.json)
[javascript/statements.json](../blob/master/javascript/statements.json)
[javascript/operators/await.json](../blob/master/javascript/operators/await.json)
[javascript/builtins/AsyncFunction.json](../blob/master/javascript/builtins/AsyncFunction.json)

Did I miss any?

This PR is similar to (and in conflict with) #2380 and #2286, but (hopefully) more complete and more precise.