### PR TITLE
Added the appropriate compatibility to compositing and blending css

### DIFF
--- a/css/properties/background-blend-mode.json
+++ b/css/properties/background-blend-mode.json
@@ -15,10 +15,10 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
               "version_added": "30"

--- a/css/properties/isolation.json
+++ b/css/properties/isolation.json
@@ -15,10 +15,10 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
               "version_added": "36"

--- a/css/properties/mix-blend-mode.json
+++ b/css/properties/mix-blend-mode.json
@@ -15,10 +15,10 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
               "version_added": "32"
@@ -27,7 +27,7 @@
               "version_added": "32"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -65,10 +65,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": true
               },
               "firefox": {
                 "version_added": "32"
@@ -77,7 +77,7 @@
                 "version_added": "32"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": false

--- a/css/types/blend-mode.json
+++ b/css/types/blend-mode.json
@@ -16,10 +16,10 @@
               "version_added": "59"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
               "version_added": "30"


### PR DESCRIPTION
Updated background-blend-mode, blend-mode, isolation, and mix-blend-mode to show that Edge, and IE do not support these properties but Edge mobile does.