### PR TITLE
Edge + Overflow-Wrap

### DIFF
--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -26,15 +26,10 @@
             "chrome_android": {
               "version_added": null
             },
-            "edge": [
-              {
-                "version_added": false
-              },
-              {
-                "alternative_name": "word-wrap",
-                "version_added": "12"
-              }
-            ],
+            "edge": {
+              "alternative_name": "word-wrap",
+              "version_added": "12"
+            },
             "edge_mobile": [
               {
                 "version_added": false

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -30,15 +30,10 @@
               "alternative_name": "word-wrap",
               "version_added": "12"
             },
-            "edge_mobile": [
-              {
-                "version_added": false
-              },
-              {
-                "alternative_name": "word-wrap",
-                "version_added": true
-              }
-            ],
+            "edge_mobile": {
+              "alternative_name": "word-wrap",
+              "version_added": true
+            },
             "firefox": [
               {
                 "version_added": "49"


### PR DESCRIPTION
Without this it's displayed as being incompatible unless expanded.
With this change it should be displayed like IE: compatible with alternate keyword.