### PR TITLE
Add 'x' syntax to the <resolution> type; fix a typo

### DIFF
--- a/css/types/resolution.json
+++ b/css/types/resolution.json
@@ -88,7 +88,7 @@
               },
               "safari": [
                 {
-                  "alternative_name": "device-piexl-ratio",
+                  "alternative_name": "device-pixel-ratio",
                   "version_added": true
                 },
                 {
@@ -98,7 +98,7 @@
               ],
               "safari_ios": [
                 {
-                  "alternative_name": "device-piexl-ratio",
+                  "alternative_name": "device-pixel-ratio",
                   "version_added": true
                 },
                 {
@@ -106,6 +106,57 @@
                   "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=16832'>bug 16832</a>."
                 }
               ],
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "x": {
+          "__compat": {
+            "description": "<code>x</code> units",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "62"
+              },
+              "firefox_android": {
+                "version_added": "62"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
               "samsunginternet_android": {
                 "version_added": null
               }


### PR DESCRIPTION
BCD update to support https://bugzilla.mozilla.org/show_bug.cgi?id=1460655 - adds a new subfeature for the `x` syntax of [`<resolution>`](https://developer.mozilla.org/en-US/docs/Web/CSS/resolution).

Also fixes a typo `device-piexl-ratio`. I'm pretty sure this is actually a typo, since apart from the unlikeliness of this actually being the name, the original compat table had the `device-pixel-ratio` spelling: https://developer.mozilla.org/en-US/docs/Web/CSS/resolution$revision/1310643.