### PR TITLE
CSSStyleDeclaration.getPropertyCSSValue and associated objects are re…

### DIFF
--- a/api/CSSPrimitiveValue.json
+++ b/api/CSSPrimitiveValue.json
@@ -17,10 +17,12 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": true
+            "version_added": true,
+            "version_removed": "62"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": true,
+            "version_removed": "62"
           },
           "ie": {
             "version_added": null
@@ -47,7 +49,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "primitiveType": {
@@ -67,10 +69,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -97,7 +101,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -118,10 +122,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -148,7 +154,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -169,10 +175,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -199,7 +207,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -220,10 +228,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -250,7 +260,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -271,10 +281,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -301,7 +313,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -322,10 +334,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -352,7 +366,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -373,10 +387,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -403,7 +419,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -424,10 +440,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -454,7 +472,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/CSSStyleDeclaration.json
+++ b/api/CSSStyleDeclaration.json
@@ -268,7 +268,8 @@
               "notes": "Only returns a result if called on the result of <code>getComputedStyle()</code>."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": false

--- a/api/CSSValue.json
+++ b/api/CSSValue.json
@@ -20,10 +20,12 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": true
+            "version_added": true,
+            "version_removed": "62"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": true,
+            "version_removed": "62"
           },
           "ie": {
             "version_added": null
@@ -44,7 +46,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "cssText": {
@@ -67,10 +69,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -91,7 +95,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -115,10 +119,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -139,7 +145,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/CSSValueList.json
+++ b/api/CSSValueList.json
@@ -20,10 +20,12 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": true
+            "version_added": true,
+            "version_removed": "62"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": true,
+            "version_removed": "62"
           },
           "ie": {
             "version_added": null
@@ -44,7 +46,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "length": {
@@ -67,10 +69,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -91,7 +95,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -115,10 +119,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -139,7 +145,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
…moved in Firefox 62

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1459871
https://www.fxsitecompat.com/en-CA/docs/2018/cssstyledeclaration-getpropertycssvalue-and-related-interfaces-have-been-removed/

This PR says that from version 62 onwards, Firefox and Firefox for Android no longer support `CSSStyleDeclaration.getPropertyCSSValue()` or the interfaces it can return. It also marks it and the interfaces deprecated. I'm not sure if we should also mark them as not standard_track any more?
