### PR TITLE
calc() is usable inside repeat() from Firefox 57

### DIFF
--- a/api/CSSPrimitiveValue.json
+++ b/api/CSSPrimitiveValue.json
@@ -17,10 +17,12 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": true
+            "version_added": true,
+            "version_removed": "62"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": true,
+            "version_removed": "62"
           },
           "ie": {
             "version_added": null
@@ -47,7 +49,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "primitiveType": {
@@ -67,10 +69,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -97,7 +101,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -118,10 +122,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -148,7 +154,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -169,10 +175,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -199,7 +207,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -220,10 +228,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -250,7 +260,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -271,10 +281,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -301,7 +313,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -322,10 +334,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -352,7 +366,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -373,10 +387,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -403,7 +419,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -424,10 +440,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -454,7 +472,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/CSSStyleDeclaration.json
+++ b/api/CSSStyleDeclaration.json
@@ -268,7 +268,8 @@
               "notes": "Only returns a result if called on the result of <code>getComputedStyle()</code>."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": false

--- a/api/CSSValue.json
+++ b/api/CSSValue.json
@@ -20,10 +20,12 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": true
+            "version_added": true,
+            "version_removed": "62"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": true,
+            "version_removed": "62"
           },
           "ie": {
             "version_added": null
@@ -44,7 +46,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "cssText": {
@@ -67,10 +69,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -91,7 +95,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -115,10 +119,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -139,7 +145,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/CSSValueList.json
+++ b/api/CSSValueList.json
@@ -20,10 +20,12 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": true
+            "version_added": true,
+            "version_removed": "62"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": true,
+            "version_removed": "62"
           },
           "ie": {
             "version_added": null
@@ -44,7 +46,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "length": {
@@ -67,10 +69,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -91,7 +95,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -115,10 +119,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "62"
             },
             "ie": {
               "version_added": null
@@ -139,7 +145,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -239,11 +239,16 @@
               },
               "firefox": [
                 {
+                  "version_added": "57"
+                },
+                {
                   "version_added": "52",
+                  "version_removed": "57",
                   "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>)."
                 },
                 {
                   "version_added": true,
+                  "version_removed": "52",
                   "flags": [
                     {
                       "type": "preference",
@@ -255,11 +260,16 @@
               ],
               "firefox_android": [
                 {
+                  "version_added": "57"
+                },
+                {
                   "version_added": "52",
+                  "version_removed": "57",
                   "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>)."
                 },
                 {
                   "version_added": true,
+                  "version_removed": "52",
                   "flags": [
                     {
                       "type": "preference",

--- a/css/properties/shape-margin.json
+++ b/css/properties/shape-margin.json
@@ -20,26 +20,38 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.shape-outside.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.shape-outside.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "version_removed": "62",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.shape-outside.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "version_removed": "62",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.shape-outside.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/shape-outside.json
+++ b/css/properties/shape-outside.json
@@ -20,26 +20,38 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.shape-outside.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.shape-outside.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "version_removed": "62",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.shape-outside.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "version_removed": "62",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.shape-outside.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -85,26 +97,38 @@
               "edge_mobile": {
                 "version_added": null
               },
-              "firefox": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "firefox_android": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.shape-outside.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.shape-outside.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -151,26 +175,38 @@
               "edge_mobile": {
                 "version_added": null
               },
-              "firefox": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "firefox_android": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.shape-outside.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.shape-outside.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -217,26 +253,38 @@
               "edge_mobile": {
                 "version_added": null
               },
-              "firefox": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "firefox_android": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.shape-outside.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.shape-outside.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -283,26 +331,38 @@
               "edge_mobile": {
                 "version_added": null
               },
-              "firefox": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "firefox_android": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.shape-outside.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.shape-outside.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -349,26 +409,38 @@
               "edge_mobile": {
                 "version_added": null
               },
-              "firefox": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "firefox_android": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.shape-outside.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.shape-outside.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1350069 and in particular https://bugzilla.mozilla.org/show_bug.cgi?id=1350069#c2 and https://bugzilla.mozilla.org/show_bug.cgi?id=1350069#c6. I've tested, and confirmed that this started working in 57.

I've also changed the other bit here to explicitly close the first version range ("Yes"->"52").