### PR TITLE
calc() is usable inside repeat() from Firefox 57

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -239,11 +239,16 @@
               },
               "firefox": [
                 {
+                  "version_added": "57"
+                },
+                {
                   "version_added": "52",
+                  "version_removed": "57",
                   "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>)."
                 },
                 {
                   "version_added": true,
+                  "version_removed": "52",
                   "flags": [
                     {
                       "type": "preference",
@@ -255,11 +260,16 @@
               ],
               "firefox_android": [
                 {
+                  "version_added": "57"
+                },
+                {
                   "version_added": "52",
+                  "version_removed": "57",
                   "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>)."
                 },
                 {
                   "version_added": true,
+                  "version_removed": "52",
                   "flags": [
                     {
                       "type": "preference",

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -244,7 +244,8 @@
                 {
                   "version_added": "52",
                   "version_removed": "57",
-                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>)."
+                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>).",
+                  "partial_implementation": true
                 },
                 {
                   "version_added": true,
@@ -265,7 +266,8 @@
                 {
                   "version_added": "52",
                   "version_removed": "57",
-                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>)."
+                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>).",
+                  "partial_implementation": true
                 },
                 {
                   "version_added": true,


### PR DESCRIPTION
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1350069 and in particular https://bugzilla.mozilla.org/show_bug.cgi?id=1350069#c2 and https://bugzilla.mozilla.org/show_bug.cgi?id=1350069#c6. I've tested, and confirmed that this started working in 57.

I've also changed the other bit here to explicitly close the first version range ("Yes"->"52").