### PR TITLE
Bug 1342012 - Implement dynamic import()

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1724,10 +1724,12 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1342012'>bug 1342012</a>."
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1342012'>bug 1342012</a>."
               },
               "ie": {
                 "version_added": null


### PR DESCRIPTION
Firefox is still implementing the dynamic `import()` proposal in [bug 1342012](https://bugzil.la/1342012), so its `version_added` is `false`.