### PR TITLE
Rename reading to illuminance

### DIFF
--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -84,9 +84,9 @@
           }
         }
       },
-      "reading": {
+      "illuminance": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AmbientLightSensor/reading",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AmbientLightSensor/illuminance",
           "support": {
             "chrome": {
               "version_added": "54"


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/AmbientLightSensor/illuminance
https://w3c.github.io/ambient-light/#ambient-light-sensor-interface

It was "reading" in an old spec only, I've fixed the MDN docs now.