### PR TITLE
Add open_at_install for sidebar_action for WebExtensions

### DIFF
--- a/webextensions/manifest/sidebar_action.json
+++ b/webextensions/manifest/sidebar_action.json
@@ -42,6 +42,27 @@
               }
             }
           }
+        },
+        "open_at_install": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "62"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Available on Firefox 62

https://bugzilla.mozilla.org/show_bug.cgi?id=1460910
https://blog.mozilla.org/addons/2018/07/05/extensions-in-firefox-62/