### PR TITLE
Add missing getGamepads() subfeature to Navigator.

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -802,6 +802,75 @@
           }
         }
       },
+      "getGamepads": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/getGamepads",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "35"
+              },
+              {
+                "version_added": "21",
+                "prefix": "-webkit-"
+              }
+            ],
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "29"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "-webkit-"
+              }
+            ],
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": [
+              {
+                "version_added": "35"
+              },
+              {
+                "version_added": "21",
+                "prefix": "-webkit-"
+              }
+            ]
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getUserMedia": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia",


### PR DESCRIPTION
#2069 missed the `getGamepads()` subfeature in the Navigator interface.

https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getGamepads