### PR TITLE
Add `‑ms‑scrollbar‑*‑color` properties

### DIFF
--- a/css/properties/-ms-scrollbar-3dlight-color.json
+++ b/css/properties/-ms-scrollbar-3dlight-color.json
@@ -1,0 +1,67 @@
+{
+  "css": {
+    "properties": {
+      "-ms-scrollbar-3dlight-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-scrollbar-3dlight-color",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "5",
+              "version_removed": true
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "qq_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "uc_android": {
+              "version_added": false
+            },
+            "uc_chinese_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "deprecated": true,
+            "experimental": false,
+            "standard_track": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-ms-scrollbar-arrow-color.json
+++ b/css/properties/-ms-scrollbar-arrow-color.json
@@ -1,0 +1,67 @@
+{
+  "css": {
+    "properties": {
+      "-ms-scrollbar-arrow-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-scrollbar-arrow-color",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "5",
+              "version_removed": true
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "qq_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "uc_android": {
+              "version_added": false
+            },
+            "uc_chinese_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "deprecated": true,
+            "experimental": false,
+            "standard_track": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-ms-scrollbar-base-color.json
+++ b/css/properties/-ms-scrollbar-base-color.json
@@ -1,0 +1,67 @@
+{
+  "css": {
+    "properties": {
+      "-ms-scrollbar-base-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-scrollbar-base-color",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "5",
+              "version_removed": true
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "qq_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "uc_android": {
+              "version_added": false
+            },
+            "uc_chinese_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "deprecated": true,
+            "experimental": false,
+            "standard_track": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-ms-scrollbar-darkshadow-color.json
+++ b/css/properties/-ms-scrollbar-darkshadow-color.json
@@ -1,0 +1,67 @@
+{
+  "css": {
+    "properties": {
+      "-ms-scrollbar-darkshadow-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-scrollbar-darkshadow-color",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "5",
+              "version_removed": true
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "qq_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "uc_android": {
+              "version_added": false
+            },
+            "uc_chinese_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "deprecated": true,
+            "experimental": false,
+            "standard_track": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-ms-scrollbar-face-color.json
+++ b/css/properties/-ms-scrollbar-face-color.json
@@ -1,0 +1,67 @@
+{
+  "css": {
+    "properties": {
+      "-ms-scrollbar-face-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-scrollbar-face-color",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "5",
+              "version_removed": true
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "qq_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "uc_android": {
+              "version_added": false
+            },
+            "uc_chinese_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "deprecated": true,
+            "experimental": false,
+            "standard_track": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-ms-scrollbar-highlight-color.json
+++ b/css/properties/-ms-scrollbar-highlight-color.json
@@ -1,0 +1,67 @@
+{
+  "css": {
+    "properties": {
+      "-ms-scrollbar-highlight-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-scrollbar-highlight-color",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "5",
+              "version_removed": true
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "qq_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "uc_android": {
+              "version_added": false
+            },
+            "uc_chinese_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "deprecated": true,
+            "experimental": false,
+            "standard_track": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-ms-scrollbar-shadow-color.json
+++ b/css/properties/-ms-scrollbar-shadow-color.json
@@ -1,0 +1,67 @@
+{
+  "css": {
+    "properties": {
+      "-ms-scrollbar-shadow-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-scrollbar-shadow-color",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "5",
+              "version_removed": true
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "qq_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "uc_android": {
+              "version_added": false
+            },
+            "uc_chinese_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "deprecated": true,
+            "experimental": false,
+            "standard_track": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-ms-scrollbar-track-color.json
+++ b/css/properties/-ms-scrollbar-track-color.json
@@ -1,0 +1,67 @@
+{
+  "css": {
+    "properties": {
+      "-ms-scrollbar-track-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-scrollbar-track-color",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "5",
+              "version_removed": true
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "qq_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "uc_android": {
+              "version_added": false
+            },
+            "uc_chinese_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "deprecated": true,
+            "experimental": false,
+            "standard_track": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the deprecated and non-standard `‑ms‑scrollbar‑*‑color` properties.

(In reply to @ExE-Boss from https://github.com/w3c/csswg-drafts/issues/107#issuecomment-380605416)
> > `scrollbar‑3dlight‑color`, `scrollbar‑arrow‑color`, `scrollbar‑base‑color`, `scrollbar‑darkshadow‑color`, `scrollbar‑face‑color`, `scrollbar‑highlight‑color`, `scrollbar‑track‑color`, `scrollbar‑shadow‑color`
>
> ## 🤦🏻‍♂️ Definitive **NO** from me for [this draft](https://drafts.csswg.org/css-scrollbars-1/),<br/>I am in support of https://github.com/w3c/csswg-drafts/issues/2153 instead
>
> Yeah, Windows ME scrollbars <i title="sarcasm">obviously won’t</i> look out of place in modern operating systems.<sup title="the sarcasm is so thick here, you could slice it with a knife">&lt;/sarcasm&gt;</sup>
>
> ![Microsoft Edge with Windows ME scrollbars](https://user-images.githubusercontent.com/3889017/38644029-7fa81098-3ddf-11e8-900a-e5e8a9fedd36.png "Microsoft Edge with Windows ME scrollbars")

needinfo?(@erikadoyle): What is MS Edge’s plan with this?
needinfo?(@jpmedley): What is Chrome’s plan with this?