### PR TITLE
Add missing FetchEvent() constructor

### DIFF
--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -51,6 +51,59 @@
           "deprecated": false
         }
       },
+      "FetchEvent": {
+        "__compat": {
+          "description": "<code>FetchEvent()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FetchEvent/FetchEvent",
+          "support": {
+            "webview_android": {
+              "version_added": "40"
+            },
+            "chrome": {
+              "version_added": "40"
+            },
+            "chrome_android": {
+              "version_added": "40"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "44",
+              "notes": "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45 and 52 Extended Support Releases</a> (ESR.)"
+            },
+            "firefox_android": {
+              "version_added": "44"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "27"
+            },
+            "opera_android": {
+              "version_added": "27"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "client": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FetchEvent/client",


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent/FetchEvent

#922 didn't add the `FetchEvent()` constructor. 