### PR TITLE
Bug 1449791 - Remove XUL Overlays

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4652,6 +4652,7 @@
             "firefox": [
               {
                 "version_added": "61",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "compile_flag",


### PR DESCRIPTION
XUL Overlays have been completely removed from Firefox 63 in [bug 1449791](https://bugzil.la/1449791).