### PR TITLE
Add data for getSecurityInfo

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -46,6 +46,28 @@
             }
           }
         },
+        "CertificateInfo": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/CertificateInfo",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "62"
+              },
+              "firefox_android": {
+                "version_added": "62"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "HttpHeaders": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/HttpHeaders",
@@ -467,6 +489,28 @@
             }
           }
         },
+        "SecurityInfo": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/SecurityInfo",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "62"
+              },
+              "firefox_android": {
+                "version_added": "62"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "StreamFilter": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter",
@@ -768,6 +812,28 @@
               },
               "firefox_android": {
                 "version_added": "57"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "getSecurityInfo": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/getSecurityInfo",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "62"
+              },
+              "firefox_android": {
+                "version_added": "62"
               },
               "opera": {
                 "version_added": false


### PR DESCRIPTION
See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1322748

This adds a new method `getSecurityInfo()`, and two associated types, `SecurityInfo` and `CertificateInfo`:

https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webRequest/getSecurityInfo
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webRequest/SecurityInfo
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webRequest/CertificateInfo