### PR TITLE
Update compat data for input color on Edge

### DIFF
--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -14,10 +14,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "14"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "29",
@@ -61,10 +61,10 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "14"
                 },
                 "edge_mobile": {
-                  "version_added": null
+                  "version_added": "14"
                 },
                 "firefox": {
                   "version_added": false,
@@ -110,10 +110,10 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "14"
                 },
                 "edge_mobile": {
-                  "version_added": null
+                  "version_added": "14"
                 },
                 "firefox": {
                   "version_added": false,


### PR DESCRIPTION
Edge seems to support input[type=color] since version 14.

caniuse.com: https://caniuse.com/#feat=input-color
Changelog: https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/14316/
Edge Developer Feedback: https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6514216--input-type-color