### PR TITLE
Update backdrop-filter compat

### DIFF
--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -44,7 +44,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "34",
               "flags": [
                 {
                   "type": "preference",

--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -18,7 +18,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "47",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable Experimental Web Platform Features"
+                }
+              ]
             },
             "edge": {
               "version_added": "17"
@@ -38,7 +44,13 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable Experimental Web Platform Features"
+                }
+              ]
             },
             "opera_android": {
               "version_added": null
@@ -51,7 +63,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
I can confirm the following changes:

  - Chrome for android is in exactly the same situation as Chrome for desktop.
  - Opera for desktop is based on Chromium, but its versioning is different so the exact verion number is unknown.
  - Samsung internet has no support in its latest version.