### PR TITLE
Update registerProtocolHandler/registerContentHandler

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1374,8 +1374,7 @@
             },
             "firefox": {
               "version_added": "2",
-              "version_removed": "62",
-              "notes": "Deprecated in Firefox 59."
+              "version_removed": "62"
             },
             "firefox_android": {
               "version_added": null
@@ -1427,8 +1426,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "3",
-              "notes": "Starting in Firefox 62, this function must only be used in a secure context."
+              "version_added": "3"
             },
             "firefox_android": {
               "version_added": "4"
@@ -1459,6 +1457,57 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "secure_context_required": {
+          "__compat": {
+            "description": "Secure context required (HTTPS)",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "62"
+              },
+              "firefox_android": {
+                "version_added": "62"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1374,7 +1374,8 @@
             },
             "firefox": {
               "version_added": "2",
-              "version_removed": "59"
+              "version_removed": "62",
+              "notes": "Deprecated in Firefox 59."
             },
             "firefox_android": {
               "version_added": null
@@ -1426,7 +1427,8 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "notes": "Starting in Firefox 62, this function must only be used in a secure context."
             },
             "firefox_android": {
               "version_added": "4"


### PR DESCRIPTION
registerProtocolHandler must be used in a secure context
in Firefox 62. registerContentHandler has been removed
in Firefox 62.