### PR TITLE
Bug1067769 KeyframeEffect.target on Firefox

### DIFF
--- a/api/KeyframeEffect.json
+++ b/api/KeyframeEffect.json
@@ -279,10 +279,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "62"
+              "version_added": "49"
             },
             "firefox_android": {
-              "version_added": "62"
+              "version_added": "49"
             },
             "ie": {
               "version_added": null

--- a/api/KeyframeEffect.json
+++ b/api/KeyframeEffect.json
@@ -279,10 +279,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "62"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "62"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This was added to Firefox in version 49.