### PR TITLE
Add browsers compatibility to scrollTo

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4533,7 +4533,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -4545,22 +4545,22 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Window.json
+++ b/api/Window.json
@@ -4536,7 +4536,7 @@
               "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
               "version_added": true
@@ -4545,7 +4545,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "9"
+              "version_added": true
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
Tested with available `BrowserStack`.
I do believe that `edge_mobile` works as well and that previous version of `IE` (eg. 6) also do work. 