### PR TITLE
Add data for input-time

### DIFF
--- a/html/elements/input/time.json
+++ b/html/elements/input/time.json
@@ -1,0 +1,57 @@
+{
+  "html": {
+    "elements": {
+      "input": {
+        "input-time": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/time",
+            "description": "<code>type=\"time\"</code>",
+            "support": {
+              "chrome": {
+                "version_added": "20"
+              },
+              "chrome_android": {
+                "version_added": "20"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "57"
+              },
+              "firefox_android": {
+                "version_added": "57"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "10"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#Browser_compatibility

According to https://github.com/mdn/browser-compat-data/issues/911, this is the last of the `input` types \o/.