### PR TITLE
Add Clear-Site-Data header

### DIFF
--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -26,7 +26,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "See Bugzilla <a href='https://bugzil.la/1470111'>bug 1470111</a> for enabling this by default."
+              "notes": "See <a href='https://bugzil.la/1470111'>bug 1470111</a> for enabling this by default."
             },
             "firefox_android": {
               "version_added": "62",
@@ -37,7 +37,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "See Bugzilla <a href='https://bugzil.la/1470111'>bug 1470111</a> for enabling this by default."
+              "notes": "See <a href='https://bugzil.la/1470111'>bug 1470111</a> for enabling this by default."
             },
             "ie": {
               "version_added": null

--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -1,0 +1,73 @@
+{
+  "http": {
+    "headers": {
+      "Clear-Site-Data": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "62",
+              "flags": [
+                {
+                  "name": "dom.clearSiteData.enabled",
+                  "type": "preference",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "See Bugzilla <a href='https://bugzil.la/1470111'>bug 1470111</a> for enabling this by default."
+            },
+            "firefox_android": {
+              "version_added": "62",
+              "flags": [
+                {
+                  "name": "dom.clearSiteData.enabled",
+                  "type": "preference",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "See Bugzilla <a href='https://bugzil.la/1470111'>bug 1470111</a> for enabling this by default."
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Firefox bug that implemented this behind a pref in 62: https://bugzilla.mozilla.org/show_bug.cgi?id=1268889
Firefox bug that will enable this by default: https://bugzilla.mozilla.org/show_bug.cgi?id=1470111
Chrome/Opera status: https://www.chromestatus.com/feature/4713262029471744

MDN page: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data