### PR TITLE
lint/style: check constructor description + fix inconsistent ones

### DIFF
--- a/api/DocumentTimeline.json
+++ b/api/DocumentTimeline.json
@@ -53,7 +53,7 @@
       "DocumentTimeline": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentTimeline/DocumentTimeline",
-          "description": "<code>DocumentTimeline</code> constructor",
+          "description": "<code>DocumentTimeline()</code> constructor",
           "support": {
             "webview_android": {
               "version_added": "61"

--- a/api/FocusEvent.json
+++ b/api/FocusEvent.json
@@ -53,7 +53,7 @@
       "FocusEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FocusEvent/FocusEvent",
-          "description": "<code>FocusEvent</code> constructor",
+          "description": "<code>FocusEvent()</code> constructor",
           "support": {
             "webview_android": {
               "version_added": true

--- a/api/KeyframeEffectReadOnly.json
+++ b/api/KeyframeEffectReadOnly.json
@@ -52,7 +52,7 @@
       },
       "KeyframeEffectReadOnly": {
         "__compat": {
-          "description": "<code>KeyframeEffectReadOnly</code> constructor",
+          "description": "<code>KeyframeEffectReadOnly()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffectReadOnly/KeyframeEffectReadOnly",
           "support": {
             "webview_android": {

--- a/api/MediaStreamTrackEvent.json
+++ b/api/MediaStreamTrackEvent.json
@@ -56,7 +56,7 @@
       "MediaStreamTrackEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackEvent/MediaStreamTrackEvent",
-          "description": "<code>MediaStreamTrackEvent</code> constructor",
+          "description": "<code>MediaStreamTrackEvent()</code> constructor",
           "support": {
             "webview_android": {
               "version_added": "55"

--- a/api/NotificationEvent.json
+++ b/api/NotificationEvent.json
@@ -53,7 +53,7 @@
       },
       "NotificationEvent": {
         "__compat": {
-          "description": "<code>NotificationEvent</code> constructor",
+          "description": "<code>NotificationEvent()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NotificationEvent/NotificationEvent",
           "support": {
             "webview_android": {

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -80,7 +80,7 @@
       },
       "PaymentRequest": {
         "__compat": {
-          "description": "<code>PaymentRequest</code> constructor",
+          "description": "<code>PaymentRequest()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/PaymentRequest",
           "support": {
             "webview_android": {

--- a/api/PresentationConnectionAvailableEvent.json
+++ b/api/PresentationConnectionAvailableEvent.json
@@ -67,7 +67,7 @@
       "PresentationConnectionAvailableEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationConnectionAvailableEvent/PresentationConnectionAvailableEvent",
-          "description": "<code>PresentationConnectionAvailableEvent</code> constructor",
+          "description": "<code>PresentationConnectionAvailableEvent()</code> constructor",
           "support": {
             "chrome": {
               "version_added": "48"

--- a/api/PresentationConnectionCloseEvent.json
+++ b/api/PresentationConnectionCloseEvent.json
@@ -67,7 +67,7 @@
       "PresentationConnectionCloseEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationConnectionCloseEvent/PresentationConnectionCloseEvent",
-          "description": "<code>PresentationConnectionCloseEvent</code> constructor",
+          "description": "<code>PresentationConnectionCloseEvent()</code> constructor",
           "support": {
             "chrome": {
               "version_added": "50"

--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -118,7 +118,7 @@
       "PresentationRequest": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationRequest/PresentationRequest",
-          "description": "<code>PresentationRequest</code> constructor",
+          "description": "<code>PresentationRequest()</code> constructor",
           "support": {
             "webview_android": {
               "version_added": "48"

--- a/api/RTCDataChannelEvent.json
+++ b/api/RTCDataChannelEvent.json
@@ -53,7 +53,7 @@
       "RTCDataChannelEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannelEvent/RTCDataChannelEvent",
-          "description": "<code>RTCDataChannelEvent</code> constructor",
+          "description": "<code>RTCDataChannelEvent()</code> constructor",
           "support": {
             "webview_android": {
               "version_added": "57"

--- a/api/RTCSessionDescription.json
+++ b/api/RTCSessionDescription.json
@@ -157,7 +157,7 @@
       },
       "RTCSessionDescription": {
         "__compat": {
-          "description": "<code>RTCSessionDescription</code> constructor",
+          "description": "<code>RTCSessionDescription()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSessionDescription/RTCSessionDescription",
           "support": {
             "webview_android": {

--- a/api/ServiceWorkerMessageEvent.json
+++ b/api/ServiceWorkerMessageEvent.json
@@ -69,7 +69,7 @@
       },
       "ServiceWorkerMessageEvent": {
         "__compat": {
-          "description": "<code>ServiceWorkerMessageEvent</code> constructor",
+          "description": "<code>ServiceWorkerMessageEvent()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerMessageEvent/ServiceWorkerMessageEvent",
           "support": {
             "webview_android": {

--- a/api/SpeechGrammar.json
+++ b/api/SpeechGrammar.json
@@ -63,7 +63,7 @@
       "SpeechGrammar": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechGrammar",
-          "description": "<code>SpeechGrammar</code> constructor",
+          "description": "<code>SpeechGrammar()</code> constructor",
           "support": {
             "webview_android": {
               "version_added": false

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -54,7 +54,7 @@
       "SpeechRecognition": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/SpeechRecognition",
-          "description": "<code>SpeechRecognition</code> constructor",
+          "description": "<code>SpeechRecognition()</code> constructor",
           "support": {
             "chrome": {
               "prefix": "webkit",

--- a/api/SpeechSynthesisUtterance.json
+++ b/api/SpeechSynthesisUtterance.json
@@ -63,7 +63,7 @@
       "SpeechSynthesisUtterance": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/SpeechSynthesisUtterance",
-          "description": "<code>SpeechSynthesisUtterance</code> constructor",
+          "description": "<code>SpeechSynthesisUtterance()</code> constructor",
           "support": {
             "chrome": {
               "version_added": "33"

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -60,6 +60,16 @@ function testStyle(filename) {
       mdnUrlMatch[2]);
   }
 
+  let constructorMatch = actual.match(String.raw`"<code>([^)]*?)</code> constructor"`)
+  if (constructorMatch) {
+    hasErrors = true;
+    console.error(
+      '\x1b[33m  Style – Use parentheses in constructor description: %s → %s()\x1b[0m',
+      constructorMatch[1],
+      constructorMatch[1]
+    );
+  }
+
   if (actual.includes("href=\\\"")) {
     hasErrors = true;
     console.error('\x1b[33m  Style – Found \\" but expected \' for <a href>.\x1b[0m');


### PR DESCRIPTION
:x: `"description": "<code>MyExample</code> constructor"`
:heavy_check_mark: `"description": "<code>MyExample()</code> constructor"`

```
$ yarn run lint > /dev/null
  Style – Use parentheses in constructor description: DocumentTimeline → DocumentTimeline()
  Style – Use parentheses in constructor description: FocusEvent → FocusEvent()
  Style – Use parentheses in constructor description: KeyframeEffectReadOnly → KeyframeEffectReadOnly()
  Style – Use parentheses in constructor description: MediaStreamTrackEvent → MediaStreamTrackEvent()
  Style – Use parentheses in constructor description: NotificationEvent → NotificationEvent()
  Style – Use parentheses in constructor description: PaymentRequest → PaymentRequest()
  Style – Use parentheses in constructor description: PresentationConnectionAvailableEvent → PresentationConnectionAvailableEvent()
  Style – Use parentheses in constructor description: PresentationConnectionCloseEvent → PresentationConnectionCloseEvent()
  Style – Use parentheses in constructor description: PresentationRequest → PresentationRequest()
  Style – Use parentheses in constructor description: RTCDataChannelEvent → RTCDataChannelEvent()
  Style – Use parentheses in constructor description: RTCSessionDescription → RTCSessionDescription()
  Style – Use parentheses in constructor description: ServiceWorkerMessageEvent → ServiceWorkerMessageEvent()
  Style – Use parentheses in constructor description: SpeechGrammar → SpeechGrammar()
  Style – Use parentheses in constructor description: SpeechRecognition → SpeechRecognition()
  Style – Use parentheses in constructor description: SpeechSynthesisUtterance → SpeechSynthesisUtterance()
Problems in 1609 files:
  Style – Use parentheses in constructor description: DocumentTimeline → DocumentTimeline()
  Style – Use parentheses in constructor description: FocusEvent → FocusEvent()
  Style – Use parentheses in constructor description: KeyframeEffectReadOnly → KeyframeEffectReadOnly()
  Style – Use parentheses in constructor description: MediaStreamTrackEvent → MediaStreamTrackEvent()
  Style – Use parentheses in constructor description: NotificationEvent → NotificationEvent()
  Style – Use parentheses in constructor description: PaymentRequest → PaymentRequest()
  Style – Use parentheses in constructor description: PresentationConnectionAvailableEvent → PresentationConnectionAvailableEvent()
  Style – Use parentheses in constructor description: PresentationConnectionCloseEvent → PresentationConnectionCloseEvent()
  Style – Use parentheses in constructor description: PresentationRequest → PresentationRequest()
  Style – Use parentheses in constructor description: RTCDataChannelEvent → RTCDataChannelEvent()
  Style – Use parentheses in constructor description: RTCSessionDescription → RTCSessionDescription()
  Style – Use parentheses in constructor description: ServiceWorkerMessageEvent → ServiceWorkerMessageEvent()
  Style – Use parentheses in constructor description: SpeechGrammar → SpeechGrammar()
  Style – Use parentheses in constructor description: SpeechRecognition → SpeechRecognition()
  Style – Use parentheses in constructor description: SpeechSynthesisUtterance → SpeechSynthesisUtterance()
```