### PR TITLE
lint/style: fix number of files with problems

### DIFF
--- a/test/test-style.js
+++ b/test/test-style.js
@@ -1,6 +1,5 @@
 'use strict';
 const fs = require('fs');
-let hasErrors = false;
 
 function jsonDiff(actual, expected) {
   var actualLines = actual.split(/\n/);
@@ -18,6 +17,7 @@ function jsonDiff(actual, expected) {
 }
 
 function testStyle(filename) {
+  let hasErrors = false;
   let actual = fs.readFileSync(filename, 'utf-8').trim();
   let expected = JSON.stringify(JSON.parse(actual), null, 2);
 


### PR DESCRIPTION
Observed in #2458:

Before:
``` 
Problems in 1609 files:
  Style – Use parentheses in constructor description: DocumentTimeline → DocumentTimeline()
  ... (13 lines)
  Style – Use parentheses in constructor description: SpeechSynthesisUtterance → SpeechSynthesisUtterance()
```

After:
``` 
Problems in 15 files:
  Style – Use parentheses in constructor description: DocumentTimeline → DocumentTimeline()
  ... (13 lines)
  Style – Use parentheses in constructor description: SpeechSynthesisUtterance → SpeechSynthesisUtterance()
```