### PR TITLE
Update Safari iOS versions

### DIFF
--- a/api/RTCIceTransport.json
+++ b/api/RTCIceTransport.json
@@ -5,43 +5,43 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport",
         "support": {
           "webview_android": {
-            "version_added": null
+            "version_added": false
           },
           "chrome": {
-            "version_added": null
+            "version_added": false
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": false
           },
           "edge": {
-            "version_added": null
+            "version_added": "15"
           },
           "edge_mobile": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
           },
           "opera_android": {
-            "version_added": null
+            "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           }
         },
         "status": {
@@ -55,43 +55,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/component",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -106,43 +106,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/gatheringState",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -157,43 +157,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/ongatheringstatechange",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -208,43 +208,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/onselectedcandidatepairchange",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -259,43 +259,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/onstatechange",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -310,43 +310,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/role",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -361,43 +361,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/state",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -412,43 +412,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getLocalCandidates",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -463,43 +463,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getLocalParameters",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -514,43 +514,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getRemoteCandidates",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -565,43 +565,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getRemoteParameters",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -616,43 +616,44 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getSelectedCandidatePair",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": "13",
+              "notes": "As <code>getNominatedCandidatePair()</code>"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/api/RTCIceTransport.json
+++ b/api/RTCIceTransport.json
@@ -5,43 +5,43 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport",
         "support": {
           "webview_android": {
-            "version_added": false
+            "version_added": null
           },
           "chrome": {
-            "version_added": false
+            "version_added": null
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": null
           },
           "edge": {
-            "version_added": "15"
+            "version_added": null
           },
           "edge_mobile": {
-            "version_added": false
+            "version_added": null
           },
           "firefox": {
-            "version_added": false
+            "version_added": null
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": null
           },
           "ie": {
-            "version_added": false
+            "version_added": null
           },
           "opera": {
-            "version_added": false
+            "version_added": null
           },
           "opera_android": {
-            "version_added": false
+            "version_added": null
           },
           "safari": {
-            "version_added": false
+            "version_added": null
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": null
           }
         },
         "status": {
@@ -55,43 +55,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/component",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": null
             },
             "chrome": {
-              "version_added": false
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": null
             },
             "ie": {
-              "version_added": false
+              "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {
@@ -106,43 +106,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/gatheringState",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": null
             },
             "chrome": {
-              "version_added": false
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
-              "version_added": false
+              "version_added": null
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": null
             },
             "ie": {
-              "version_added": false
+              "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {
@@ -157,43 +157,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/ongatheringstatechange",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": null
             },
             "chrome": {
-              "version_added": false
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
-              "version_added": false
+              "version_added": null
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": null
             },
             "ie": {
-              "version_added": false
+              "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {
@@ -208,43 +208,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/onselectedcandidatepairchange",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": null
             },
             "chrome": {
-              "version_added": false
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
-              "version_added": false
+              "version_added": null
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": null
             },
             "ie": {
-              "version_added": false
+              "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {
@@ -259,43 +259,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/onstatechange",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": null
             },
             "chrome": {
-              "version_added": false
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
-              "version_added": false
+              "version_added": null
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": null
             },
             "ie": {
-              "version_added": false
+              "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {
@@ -310,43 +310,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/role",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": null
             },
             "chrome": {
-              "version_added": false
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": null
             },
             "ie": {
-              "version_added": false
+              "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {
@@ -361,43 +361,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/state",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": null
             },
             "chrome": {
-              "version_added": false
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": null
             },
             "ie": {
-              "version_added": false
+              "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {
@@ -412,43 +412,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getLocalCandidates",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": null
             },
             "chrome": {
-              "version_added": false
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
-              "version_added": false
+              "version_added": null
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": null
             },
             "ie": {
-              "version_added": false
+              "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {
@@ -463,43 +463,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getLocalParameters",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": null
             },
             "chrome": {
-              "version_added": false
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
-              "version_added": false
+              "version_added": null
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": null
             },
             "ie": {
-              "version_added": false
+              "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {
@@ -514,43 +514,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getRemoteCandidates",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": null
             },
             "chrome": {
-              "version_added": false
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": null
             },
             "ie": {
-              "version_added": false
+              "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {
@@ -565,43 +565,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getRemoteParameters",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": null
             },
             "chrome": {
-              "version_added": false
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": null
             },
             "ie": {
-              "version_added": false
+              "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {
@@ -616,44 +616,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getSelectedCandidatePair",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": null
             },
             "chrome": {
-              "version_added": false
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
-              "version_added": "13",
-              "notes": "As <code>getNominatedCandidatePair()</code>"
+              "version_added": null
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": null
             },
             "ie": {
-              "version_added": false
+              "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -82,6 +82,15 @@
           "status": "retired"
         },
         "11.1": {
+          "status": "retired"
+        },
+        "11.2": {
+          "status": "retired"
+        },
+        "11.3": {
+          "status": "retired"
+        },
+        "11.4": {
           "status": "current"
         }
       }


### PR DESCRIPTION
Added Safari iOS versions 11.2, 11.3, and 11.4.