### PR TITLE
Update support info for RTCIceTransport

### DIFF
--- a/api/RTCIceTransport.json
+++ b/api/RTCIceTransport.json
@@ -5,43 +5,43 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport",
         "support": {
           "webview_android": {
-            "version_added": null
+            "version_added": false
           },
           "chrome": {
-            "version_added": null
+            "version_added": false
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": false
           },
           "edge": {
-            "version_added": null
+            "version_added": "15"
           },
           "edge_mobile": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
           },
           "opera_android": {
-            "version_added": null
+            "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           }
         },
         "status": {
@@ -55,43 +55,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/component",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -106,43 +106,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/gatheringState",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -157,43 +157,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/ongatheringstatechange",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -208,43 +208,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/onselectedcandidatepairchange",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -259,43 +259,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/onstatechange",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -310,43 +310,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/role",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -361,43 +361,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/state",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -412,43 +412,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getLocalCandidates",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -463,43 +463,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getLocalParameters",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -514,43 +514,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getRemoteCandidates",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -565,43 +565,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getRemoteParameters",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -616,43 +616,44 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getSelectedCandidatePair",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": "13",
+              "notes": "As <code>getNominatedCandidatePair()</code>"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/api/RTCIceTransport.json
+++ b/api/RTCIceTransport.json
@@ -35,10 +35,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11.2"
           },
           "samsunginternet_android": {
             "version_added": false
@@ -136,10 +136,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -391,10 +391,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.2"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/RTCIceTransport.json
+++ b/api/RTCIceTransport.json
@@ -17,7 +17,7 @@
             "version_added": "15"
           },
           "edge_mobile": {
-            "version_added": false
+            "version_added": null
           },
           "firefox": {
             "version_added": false
@@ -38,7 +38,7 @@
             "version_added": "11"
           },
           "safari_ios": {
-            "version_added": "11.2"
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": false
@@ -67,7 +67,7 @@
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
               "version_added": false
@@ -118,7 +118,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
               "version_added": false
@@ -139,7 +139,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11.2"
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -169,7 +169,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
               "version_added": false
@@ -220,7 +220,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
               "version_added": false
@@ -271,7 +271,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
               "version_added": false
@@ -322,7 +322,7 @@
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
               "version_added": false
@@ -373,7 +373,7 @@
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
               "version_added": false
@@ -394,7 +394,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11.2"
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -424,7 +424,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
               "version_added": false
@@ -475,7 +475,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
               "version_added": false
@@ -526,7 +526,7 @@
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
               "version_added": false
@@ -577,7 +577,7 @@
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
               "version_added": false
@@ -625,11 +625,11 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "13",
-              "notes": "As <code>getNominatedCandidatePair()</code>"
+              "alternative_name": "getNominatedCandidatePair",
+              "version_added": "13"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
Only two browsers offer any support for `RTCIceTransport`: Edge, which supports a sizeable chunk of it (but not all of it), and Safari, which supports only two properties.