### PR TITLE
lint: print relative filepath

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -25,7 +25,8 @@ function load(...files) {
     if (fs.statSync(file).isFile()) {
       if (path.extname(file) === '.json') {
         let hasStyleErrors, hasSchemaErrors, hasVersionErrors = false;
-        console.log(file.replace(path.resolve(__dirname, '..') + path.sep, ''));
+        const relativeFilePath = path.relative(process.cwd(), file);
+        console.log(relativeFilePath);
         if (file.indexOf('browsers' + path.sep) !== -1) {
           hasSchemaErrors = testSchema(file, './../schemas/browsers.schema.json');
         } else {
@@ -35,8 +36,7 @@ function load(...files) {
         }
         if (hasStyleErrors || hasSchemaErrors || hasVersionErrors) {
           hasErrors = true;
-          const fileName = file.replace(path.resolve(__dirname, '..') + path.sep, '');
-          filesWithErrors.set(fileName, file);
+          filesWithErrors.set(relativeFilePath, file);
         }
       }
 

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -1,5 +1,6 @@
 'use strict';
 const Ajv = require('ajv');
+const path = require('path');
 const ajv = new Ajv({ allErrors: true });
 
 function testSchema(dataFilename, schemaFilename = './../schemas/compat-data.schema.json') {
@@ -12,7 +13,7 @@ function testSchema(dataFilename, schemaFilename = './../schemas/compat-data.sch
     console.log('\x1b[32m  JSON schema – OK \x1b[0m');
     return false;
   } else {
-    console.error('\x1b[31m  File : ' + dataFilename);
+    console.error('\x1b[31m  File : ' + path.relative(process.cwd(), dataFilename));
     console.error('\x1b[31m  JSON schema – ' + ajv.errors.length + ' error(s)\x1b[0m');
     console.error('   ' + ajv.errorsText(ajv.errors, {
       separator: '\n    ',

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -1,5 +1,6 @@
 'use strict';
 const fs = require('fs');
+const path = require('path');
 
 function jsonDiff(actual, expected) {
   var actualLines = actual.split(/\n/);
@@ -31,7 +32,7 @@ function testStyle(filename) {
     console.log('\x1b[32m  Style – OK \x1b[0m');
   } else {
     hasErrors = true;
-    console.error('\x1b[31m  File : ' + filename);
+    console.error('\x1b[31m  File : ' + path.relative(process.cwd(), filename));
     console.error('\x1b[31m  Style – Error on line ' + jsonDiff(actual, expected));
   }
 

--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -1,4 +1,5 @@
 'use strict';
+const path = require('path');
 const {browsers} = require('..');
 
 const validBrowserVersions = {};
@@ -67,7 +68,7 @@ function testVersions(dataFilename) {
   findSupport(data);
 
   if (hasErrors) {
-    console.error('\x1b[31m  File : ' + dataFilename);
+    console.error('\x1b[31m  File : ' + path.relative(process.cwd(), dataFilename));
     console.error('\x1b[31m  Browser version error(s)\x1b[0m');
     return true;
   } else {


### PR DESCRIPTION
So far, problem output from *JSON schema*, *Style* and *Browser versions* check were preceded with absolute paths to the file containing problems (e.g. `/home/user/git/mozilla/browser-compat-data/api/Example.json`), which is harder to read than relative paths (e.g. `api/Example.json`).

This PR changes that so that relative paths are printed.