### PR TITLE
Fix MDN URL for TrackDefaultList's constructor.

### DIFF
--- a/api/TrackDefaultList.json
+++ b/api/TrackDefaultList.json
@@ -49,7 +49,7 @@
       },
       "TrackDefaultList": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrackDefault/TrackDefaultList",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrackDefaultList/TrackDefaultList",
           "description": "<code>TrackDefaultList()</code> constructor",
           "support": {
             "chrome": {


### PR DESCRIPTION
The `TrackDefaultList()` constructor was linking to a page that didn't exist. This was added in #2122.