### PR TITLE
Opera for Android switched to Chromium in version 14

### DIFF
--- a/api/HTMLTimeElement.json
+++ b/api/HTMLTimeElement.json
@@ -40,7 +40,7 @@
             },
             {
               "version_added": "11.5",
-              "version_removed": "15"
+              "version_removed": "14"
             }
           ],
           "safari": {
@@ -99,7 +99,7 @@
               },
               {
                 "version_added": "11.5",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": {

--- a/api/PositionOptions.json
+++ b/api/PositionOptions.json
@@ -92,7 +92,7 @@
             },
             {
               "version_added": "10",
-              "version_removed": "15",
+              "version_removed": "14",
               "notes": "Secure context not required"
             }
           ],
@@ -159,7 +159,7 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": {
@@ -219,7 +219,7 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": {
@@ -279,7 +279,7 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": {

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -117,7 +117,7 @@
               {
                 "prefix": "-o-",
                 "version_added": "12",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": [

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -144,7 +144,7 @@
                 },
                 {
                   "version_added": "11.1",
-                  "version_removed": "15"
+                  "version_removed": "14"
                 }
               ],
               "safari": {
@@ -209,7 +209,7 @@
                 },
                 {
                   "version_added": "11.1",
-                  "version_removed": "15"
+                  "version_removed": "14"
                 }
               ],
               "safari": {
@@ -274,7 +274,7 @@
                 },
                 {
                   "version_added": "11.1",
-                  "version_removed": "15"
+                  "version_removed": "14"
                 }
               ],
               "safari": {
@@ -394,7 +394,7 @@
                 },
                 {
                   "version_added": "11.1",
-                  "version_removed": "15"
+                  "version_removed": "14"
                 }
               ],
               "safari": {
@@ -701,7 +701,7 @@
                 },
                 {
                   "version_added": "11.1",
-                  "version_removed": "15"
+                  "version_removed": "14"
                 }
               ],
               "safari": {

--- a/css/properties/animation-delay.json
+++ b/css/properties/animation-delay.json
@@ -118,12 +118,12 @@
               },
               {
                 "version_added": "12.1",
-                "version_removed": "15"
+                "version_removed": "14"
               },
               {
                 "prefix": "-o-",
                 "version_added": "12",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": [

--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -129,12 +129,12 @@
               },
               {
                 "version_added": "12.1",
-                "version_removed": "15"
+                "version_removed": "14"
               },
               {
                 "prefix": "-o-",
                 "version_added": "12",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": [

--- a/css/properties/animation-duration.json
+++ b/css/properties/animation-duration.json
@@ -129,12 +129,12 @@
               },
               {
                 "version_added": "12.1",
-                "version_removed": "15"
+                "version_removed": "14"
               },
               {
                 "prefix": "-o-",
                 "version_added": "12",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": {

--- a/css/properties/animation-fill-mode.json
+++ b/css/properties/animation-fill-mode.json
@@ -129,12 +129,12 @@
               },
               {
                 "version_added": "12.1",
-                "version_removed": "15"
+                "version_removed": "14"
               },
               {
                 "prefix": "-o-",
                 "version_added": "12",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": [

--- a/css/properties/animation-iteration-count.json
+++ b/css/properties/animation-iteration-count.json
@@ -129,12 +129,12 @@
               },
               {
                 "version_added": "12.1",
-                "version_removed": "15"
+                "version_removed": "14"
               },
               {
                 "prefix": "-o-",
                 "version_added": "12",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": [

--- a/css/properties/animation-name.json
+++ b/css/properties/animation-name.json
@@ -129,12 +129,12 @@
               },
               {
                 "version_added": "12.1",
-                "version_removed": "15"
+                "version_removed": "14"
               },
               {
                 "prefix": "-o-",
                 "version_added": "12",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": [

--- a/css/properties/animation-play-state.json
+++ b/css/properties/animation-play-state.json
@@ -129,12 +129,12 @@
               },
               {
                 "version_added": "12.1",
-                "version_removed": "15"
+                "version_removed": "14"
               },
               {
                 "prefix": "-o-",
                 "version_added": "12",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": [

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -129,12 +129,12 @@
               },
               {
                 "version_added": "12.1",
-                "version_removed": "15"
+                "version_removed": "14"
               },
               {
                 "prefix": "-o-",
                 "version_added": "12",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": [

--- a/css/properties/animation.json
+++ b/css/properties/animation.json
@@ -130,12 +130,12 @@
               },
               {
                 "version_added": "12.1",
-                "version_removed": "15"
+                "version_removed": "14"
               },
               {
                 "prefix": "-o-",
                 "version_added": "12",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": [

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -65,7 +65,7 @@
               },
               {
                 "version_added": "11.5",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": {

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -302,7 +302,7 @@
                 },
                 {
                   "version_added": "11.1",
-                  "version_removed": "15"
+                  "version_removed": "14"
                 }
               ],
               "safari": [

--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -126,7 +126,7 @@
               {
                 "prefix": "-o-",
                 "version_added": "10",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": [

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -126,7 +126,7 @@
               {
                 "prefix": "-o-",
                 "version_added": "10",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": [

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -136,7 +136,7 @@
               {
                 "prefix": "-o-",
                 "version_added": "10.1",
-                "version_removed": "15"
+                "version_removed": "14"
               }
             ],
             "safari": [

--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -454,7 +454,7 @@
                 {
                   "alternative_name": "autobuffer",
                   "version_added": true,
-                  "version_removed": "15"
+                  "version_removed": "14"
                 }
               ],
               "safari": {

--- a/html/elements/blink.json
+++ b/html/elements/blink.json
@@ -37,7 +37,7 @@
             },
             "opera_android": {
               "version_added": "2",
-              "version_removed": "15"
+              "version_removed": "14"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
See the relevant blog post on [Dev.Opera](https://dev.opera.com/blog/opera-14-for-android-is-out/ "Dev.Opera — Opera 14 for Android is Out!").

See also #1712.