### PR TITLE
Mark properties defined in Ecma-262 Annex B as deprecated

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -326,7 +326,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -2550,7 +2550,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
The introduction of <a href="https://www.ecma-international.org/ecma-262/9.0/index.html#sec-additional-ecmascript-features-for-web-browsers">Annex B</a> of the ECMA-262 standard says:

> … All of the language features and behaviours specified in this annex have one or more undesirable characteristics and in the absence of legacy usage would be removed from this specification. …
… Programmers should not use or assume the existence of these features and behaviours when writing new ECMAScript code. …

This absolutely sounds like "deprecated" to me.

`Object.prototype.__proto__` is defined at [B.2.2.1](https://www.ecma-international.org/ecma-262/9.0/index.html#sec-object.prototype.__proto__)     
`String.prototype.substr ( start, length )` is defined at [B.2.3.1](https://www.ecma-international.org/ecma-262/9.0/index.html#sec-string.prototype.substr)