### PR TITLE
Complete XMLDocument

### DIFF
--- a/api/XMLDocument.json
+++ b/api/XMLDocument.json
@@ -14,16 +14,16 @@
             "version_added": false
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
-            "version_added": null
+            "version_added": true
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": false
@@ -64,16 +64,25 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
-            "firefox": {
-              "version_added": null
-            },
+            "firefox": [
+              {
+                "version_added": "3",
+                "notes": "See <a href='https://bugzil.la/332175' title='Drop document.load() support'>bug 332175</a> for removal."
+              },
+              {
+                "version_added": "1",
+                "version_removed": "3",
+                "notes": "Before version 3, Firefox supported cross‑origin loads, even in cases where this would violate CORS"
+              }
+            ],
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "notes": "See <a href='https://bugzil.la/332175' title='Drop document.load() support'>bug 332175</a> for removal."
             },
             "ie": {
               "version_added": false
@@ -95,7 +104,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": true
           }

--- a/api/XMLDocument.json
+++ b/api/XMLDocument.json
@@ -77,7 +77,7 @@
               {
                 "version_added": "1",
                 "version_removed": "3",
-                "notes": "Before version 3, Firefox supported cross‑origin loads, even in cases where this would violate CORS"
+                "notes": "Before version 3, Firefox supported cross‑origin loads, even in cases where this would violate CORS."
               }
             ],
             "firefox_android": {


### PR DESCRIPTION
## Bugzilla links:
- [bug 332175](https://bugzil.la/332175) (Tracking XMLDocument.load removal)
- [bug 1310275](https://bugzil.la/1310275) (XMLDocument.load deprecation warning was fixed)
- [bug 494705](https://bugzil.la/494705) (XMLDocument.load was deprecated here)
- [bug 86982](https://bugzil.la/86982)
- [bug 45377](https://bugzil.la/45377) (the earliest XMLDocument.load bug I could find, was resolved way before Firefox 1, or even Phoenix¹ 0.1 was anywhere close to release)

¹ For those who don’t know, Phoenix was the name of the first ever Firefox public alpha release before version 0.7, when it was renamed to Firebird, and it was finally renamed to Firefox with version 0.8.