### PR TITLE
Sort Geolocation's Opera support entries by most-relevant first

### DIFF
--- a/api/Geolocation.json
+++ b/api/Geolocation.json
@@ -27,11 +27,11 @@
           },
           "opera": [
             {
-              "version_added": "10.6",
-              "version_removed": "15"
+              "version_added": "16"
             },
             {
-              "version_added": "16"
+              "version_added": "10.6",
+              "version_removed": "15"
             }
           ],
           "opera_android": {
@@ -134,11 +134,11 @@
             },
             "opera": [
               {
-                "version_added": "10.6",
-                "version_removed": "15"
+                "version_added": "16"
               },
               {
-                "version_added": "16"
+                "version_added": "10.6",
+                "version_removed": "15"
               }
             ],
             "opera_android": {
@@ -191,11 +191,11 @@
             },
             "opera": [
               {
-                "version_added": "10.6",
-                "version_removed": "15"
+                "version_added": "16"
               },
               {
-                "version_added": "16"
+                "version_added": "10.6",
+                "version_removed": "15"
               }
             ],
             "opera_android": {
@@ -248,11 +248,11 @@
             },
             "opera": [
               {
-                "version_added": "10.6",
-                "version_removed": "15"
+                "version_added": "16"
               },
               {
-                "version_added": "16"
+                "version_added": "10.6",
+                "version_removed": "15"
               }
             ],
             "opera_android": {


### PR DESCRIPTION
The Opera entries for `Geolocation` had the removed entries before the current support, so the table looked a bit off. This PR fixes it.