### PR TITLE
Update Geolocation secure context data for Chrome, WebView, and Opera

### DIFF
--- a/api/Geolocation.json
+++ b/api/Geolocation.json
@@ -61,10 +61,10 @@
           "description": "Secure context required",
           "support": {
             "chrome": {
-              "version_added": "47"
+              "version_added": "50"
             },
             "chrome_android": {
-              "version_added": "47"
+              "version_added": "50"
             },
             "edge": {
               "version_added": null
@@ -82,10 +82,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "37"
             },
             "safari": {
               "version_added": true
@@ -97,7 +97,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "51",
+              "notes": "Secure context is only required for applications targeting Android Nougat (7) and higher. See <a href='https://crbug.com/603574'>bug 603574</a>."
             }
           },
           "status": {

--- a/api/PositionOptions.json
+++ b/api/PositionOptions.json
@@ -67,10 +67,10 @@
           "description": "Secure context required",
           "support": {
             "chrome": {
-              "version_added": "47"
+              "version_added": "50"
             },
             "chrome_android": {
-              "version_added": "47"
+              "version_added": "50"
             },
             "edge": {
               "version_added": null
@@ -88,10 +88,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "37"
             },
             "safari": {
               "version_added": true
@@ -103,7 +103,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "51",
+              "notes": "Secure context is only required for applications targeting Android Nougat (7) and higher. See <a href='https://crbug.com/603574'>bug 603574</a>."
             }
           },
           "status": {


### PR DESCRIPTION
Because of #2447 and #2473, I got curious about Geolocation's secure context restrictions. This updates some Chromium-derived browser data.

Sources:
- https://developers.google.com/web/updates/2016/04/geolocation-on-secure-contexts-only
- https://bugs.chromium.org/p/chromium/issues/detail?id=603574
- Assumed that Opera 37 is Chromium 50