### PR TITLE
api/HTMLTableRowElement.json: add missing status data

### DIFF
--- a/api/HTMLTableRowElement.json
+++ b/api/HTMLTableRowElement.json
@@ -653,6 +653,11 @@
               "webview_android": {
                 "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }


### PR DESCRIPTION
There was a missing `"status"` property in `api/HTMLTableRowElement.json`.