### PR TITLE
Rename the AnimationEffectTimingProperties to EffectTiming

### DIFF
--- a/api/EffectTiming.json
+++ b/api/EffectTiming.json
@@ -1,8 +1,8 @@
 {
   "api": {
-    "AnimationEffectTimingProperties": {
+    "EffectTiming": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEffectTimingProperties",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming",
         "support": {
           "webview_android": {
             "version_added": null
@@ -20,26 +20,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": "45",
-            "notes": "The preference is set to <code>true</code> by default on Firefox Nightly and on Firefox Developer Edition, but not on the official release.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.animations-api.core.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "63"
           },
           "firefox_android": {
-            "version_added": "45",
-            "notes": "The preference is set to <code>true</code> by default on Firefox Nightly and on Firefox Developer Edition, but not on the official release.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.animations-api.core.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "63"
           },
           "ie": {
             "version_added": null
@@ -68,7 +52,7 @@
       },
       "delay": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEffectTimingProperties/delay",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming/delay",
           "support": {
             "webview_android": {
               "version_added": null
@@ -86,26 +70,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "45",
-              "notes": "The preference is set to <code>true</code> by default on Firefox Nightly and on Firefox Developer Edition, but not on the official release.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": "45",
-              "notes": "The preference is set to <code>true</code> by default on Firefox Nightly and on Firefox Developer Edition, but not on the official release.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "63"
             },
             "ie": {
               "version_added": false
@@ -135,7 +103,7 @@
       },
       "direction": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEffectTimingProperties/direction",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming/direction",
           "support": {
             "webview_android": {
               "version_added": null
@@ -153,26 +121,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "48",
-              "notes": "The preference is set to <code>true</code> by default on Firefox Nightly and on Firefox Developer Edition, but not on the official release.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": "48",
-              "notes": "The preference is set to <code>true</code> by default on Firefox Nightly and on Firefox Developer Edition, but not on the official release.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "63"
             },
             "ie": {
               "version_added": false
@@ -202,7 +154,7 @@
       },
       "duration": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEffectTimingProperties/duration",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming/duration",
           "support": {
             "webview_android": {
               "version_added": null
@@ -220,18 +172,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "48",
-              "notes": "The preference is set to <code>true</code> by default on Firefox Nightly and on Firefox Developer Edition, but not on the official release.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "ie": {
               "version_added": false
@@ -261,7 +205,7 @@
       },
       "easing": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEffectTimingProperties/easing",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming/easing",
           "support": {
             "webview_android": {
               "version_added": null
@@ -279,26 +223,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "48",
-              "notes": "The preference is set to <code>true</code> by default on Firefox Nightly and on Firefox Developer Edition, but not on the official release.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": "48",
-              "notes": "The preference is set to <code>true</code> by default on Firefox Nightly and on Firefox Developer Edition, but not on the official release.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "63"
             },
             "ie": {
               "version_added": false
@@ -324,78 +252,11 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "frames": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEffectTimingProperties/easing",
-            "support": {
-              "webview_android": {
-                "version_added": null
-              },
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "48",
-                "notes": "The preference is set to <code>true</code> by default on Firefox Nightly and on Firefox Developer Edition, but not on the official release.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "firefox_android": {
-                "version_added": "48",
-                "notes": "The preference is set to <code>true</code> by default on Firefox Nightly and on Firefox Developer Edition, but not on the official release.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "endDelay": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEffectTimingProperties/endDelay",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming/endDelay",
           "support": {
             "webview_android": {
               "version_added": null
@@ -413,10 +274,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "48"
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "ie": {
               "version_added": false
@@ -446,7 +307,7 @@
       },
       "fill": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEffectTimingProperties/fill",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming/fill",
           "support": {
             "webview_android": {
               "version_added": null
@@ -464,10 +325,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "48"
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "ie": {
               "version_added": false
@@ -497,7 +358,7 @@
       },
       "iterations": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEffectTimingProperties/iterations",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming/iterations",
           "support": {
             "webview_android": {
               "version_added": null
@@ -515,26 +376,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "48",
-              "notes": "The preference is set to <code>true</code> by default on Firefox Nightly and on Firefox Developer Edition, but not on the official release.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": "48",
-              "notes": "The preference is set to <code>true</code> by default on Firefox Nightly and on Firefox Developer Edition, but not on the official release.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "63"
             },
             "ie": {
               "version_added": false
@@ -564,7 +409,7 @@
       },
       "iterationStart": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEffectTimingProperties/iterationStart",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming/iterationStart",
           "support": {
             "webview_android": {
               "version_added": null
@@ -582,26 +427,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "45",
-              "notes": "The preference is set to <code>true</code> by default on Firefox Nightly and on Firefox Developer Edition, but not on the official release.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": "45",
-              "notes": "The preference is set to <code>true</code> by default on Firefox Nightly and on Firefox Developer Edition, but not on the official release.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "63"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Another PR to deal with some Web Animation changes, see https://bugzilla.mozilla.org/show_bug.cgi?id=1456394

As part of this PR, I will move these MDN pages
https://developer.mozilla.org/en-US/docs/Web/API/AnimationEffectTimingProperties
https://developer.mozilla.org/en-US/docs/Web/API/AnimationEffectTimingProperties/delay
https://developer.mozilla.org/en-US/docs/Web/API/AnimationEffectTimingProperties/direction
https://developer.mozilla.org/en-US/docs/Web/API/AnimationEffectTimingProperties/duration
https://developer.mozilla.org/en-US/docs/Web/API/AnimationEffectTimingProperties/easing
https://developer.mozilla.org/en-US/docs/Web/API/AnimationEffectTimingProperties/endDelay
https://developer.mozilla.org/en-US/docs/Web/API/AnimationEffectTimingProperties/fill
https://developer.mozilla.org/en-US/docs/Web/API/AnimationEffectTimingProperties/iterations
https://developer.mozilla.org/en-US/docs/Web/API/AnimationEffectTimingProperties/iterationStart
to
https://developer.mozilla.org/en-US/docs/Web/API/EffectTiming
https://developer.mozilla.org/en-US/docs/Web/API/EffectTiming/delay
https://developer.mozilla.org/en-US/docs/Web/API/EffectTiming/direction
https://developer.mozilla.org/en-US/docs/Web/API/EffectTiming/duration
https://developer.mozilla.org/en-US/docs/Web/API/EffectTiming/easing
https://developer.mozilla.org/en-US/docs/Web/API/EffectTiming/endDelay
https://developer.mozilla.org/en-US/docs/Web/API/EffectTiming/fill
https://developer.mozilla.org/en-US/docs/Web/API/EffectTiming/iterations
https://developer.mozilla.org/en-US/docs/Web/API/EffectTiming/iterationStart

r? @birtles 