### PR TITLE
Mark spellcheck global attribute as not-experimental.

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1102,7 +1102,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
The `spellcheck` attribute shouldn't be marked as `experimental`, it's standardized and widely supported.