### PR TITLE
Node.js early versions

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -3,13 +3,11 @@
     "nodejs": {
       "name": "Node.js",
       "releases": {
-        "0.10.0": {
-          "release_date": "2013-03-11",
-          "release_notes": "https://nodejs.org/en/blog/release/v0.10.0/"
+        "0.10": {
+          "release_notes": "https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V010.md"
         },
-        "0.12.0": {
-          "release_date": "2015-02-06",
-          "release_notes": "https://nodejs.org/en/blog/release/v0.12.0/"
+        "0.12": {
+          "release_notes": "https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V012.md"
         },
         "4.0.0": {
           "release_date": "2015-09-08",

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -27,7 +27,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": "0.12.0"
+              "version_added": "0.12"
             },
             "opera": {
               "version_added": "19"
@@ -86,7 +86,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12.0",
+                "version_added": "0.12",
                 "notes": "Constructor requires a new operator since version 4."
               },
               "opera": {
@@ -143,7 +143,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12.0"
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": "19"
@@ -197,7 +197,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12.0"
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": "19"
@@ -251,7 +251,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12.0"
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": "19"
@@ -359,7 +359,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12.0"
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": "19"
@@ -413,7 +413,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12.0"
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": "19"
@@ -467,7 +467,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12.0"
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": "19"
@@ -521,7 +521,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12.0"
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": "19"

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -59,7 +59,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12.0"
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": false


### PR DESCRIPTION
### Summary

In [browsers/nodejs.json](/mdn/browser-compat-data/blob/master/browsers/nodejs.json), I changed `0.10.0` and `0.12.0` back to `0.10` and `0.12`, removed the `release_date` values, and changed the `release_notes` URLs to generic pages about 0.10.x and 0.12.x.

But I'm open to other suggestions, e.g. including specific 0.10.x and 0.12.x versions. Let me know what you think.

### Details

I'd like to add more data about early Node.js versions, i.e. 0.10.x and 0.12.x.

I wrote a tool [nct2bcd](/jcsahnwaldt/nct2bcd) that reads data from [node-compat-table](/williamkapke/node-compat-table) (NCT), transforms it into the format needed by [browser-compat-data](/mdn/browser-compat-data) (BCD), and copies it to the appropriate files.

While working on this tool, I noticed two things:
- According to NCT, features were added in many different 0.x versions: 0.10.45, 0.10.46, 0.10.48, 0.12.13, 0.12.14, 0.12.15 and 0.12.18, and maybe 0.12.8 and 0.12.12 as well.
  - Adding all these versions to BCD would be a bit of a nuisance.
- The NCT data about Node.js 0.10.x and 0.12.x is flaky.
  - e.g. data about features available with the `--harmony` flag is incomplete, feature data is less detailed than for later versions, features are identified by different keys, etc.

For these two reasons, it would probably be better for BCD to simply state that a feature was added in `"0.10.x"` or `"0.12.x"` instead of giving a precise version which may be incorrect anyway. In addition, hardly anyone uses these versions anymore, so users probably don't care about the exact version.

Downsides of this approach:
- This is in contradiction to what we agreed on (and I was strongly in favor of) in #2294: always use full version numbers for Node.js.
- If we don't use specific versions, we can't declare a proper `release_date` in [browsers/nodejs.json](/mdn/browser-compat-data/blob/master/browsers/nodejs.json).
  - 0.10.x versions were released between 2013 and 2016, 0.12.x versions between 2015 and 2017. Giving a specific `release_date` would be misleading.
- There is no release note page for all 0.10.x or 0.12.x versions.
  - Pointing to pages for specific releases - e.g. [nodejs.org/en/blog/release/v0.10.0/](https://nodejs.org/en/blog/release/v0.10.0/) or [nodejs.org/en/blog/release/v0.12.0/](https://nodejs.org/en/blog/release/v0.12.0/) - would be misleading.

I guess these disadvantages are rather minor though.

I changed all occurrences of `0.10.0` and `0.12.0` to `0.10` and `0.12`, dropped the `release_date` in [browsers/nodejs.json](/mdn/browser-compat-data/blob/master/browsers/nodejs.json) and set `release_notes` to pages listing all change logs for [0.10.x](/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V010.md) and [0.12.x](/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V012.md). (These pages are also linked to from [nodejs.org/en/download/releases/](https://nodejs.org/en/download/releases/), so I guess they're "official").

Another little thing: In a way, it would be better to use the strings `"0.10.x"` and `"0.12.x"` instead of `"0.10"` and `"0.12"`, because that syntax would make it more obvious that it's unclear in which exact version a feature was introduced. On the other hand, some tools may have trouble dealing with a non-numeric patch version. In the end, I chose the `"0.10"` and `"0.12"` syntax.

