### PR TITLE
PerformanceNavigation is deprecated

### DIFF
--- a/api/PerformanceNavigation.json
+++ b/api/PerformanceNavigation.json
@@ -47,7 +47,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "type": {
@@ -97,7 +97,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -148,7 +148,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -198,8 +198,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": false
+            "standard_track": true,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
The Navigation Timing Level 2 specification deprecates this interface https://w3c.github.io/navigation-timing/#the-performancenavigation-interface