### PR TITLE
js/builtins/JSON.json#json_superset: nodejs 10.0.0

### DIFF
--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -189,7 +189,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "10.0.0"
               },
               "opera": {
                 "version_added": "53"


### PR DESCRIPTION
It looks like [node.green](https://node.green/) does not track this feature, so here's a test file:

```
> cat test.js 
eval('"\u2028\u2029"'); console.log('OK');
```

With Node.js 9.11.2 (last version before 10.0.0):

```
> nvm run 9.11.2 test.js 
Running node v9.11.2 (npm v5.6.0)
undefined:1
"
^

SyntaxError: Invalid or unexpected token
> nvm run 9.11.2 --harmony test.js 
Running node v9.11.2 (npm v5.6.0)
undefined:1
"
^

SyntaxError: Invalid or unexpected token
> nvm run 9.11.2 --harmony-subsume-json test.js 
Running node v9.11.2 (npm v5.6.0)
node: bad option: --harmony-subsume-json
> nvm run 9.11.2 --no-harmony-subsume-json test.js 
Running node v9.11.2 (npm v5.6.0)
node: bad option: --no-harmony-subsume-json
```
Result: JS is not a superset of JSON, and there's no flag to change that.

With Node.js 10.0.0:
```
> nvm run 10.0.0 test.js 
Running node v10.0.0 (npm v5.6.0)
OK
> nvm run 10.0.0 --harmony test.js 
Running node v10.0.0 (npm v5.6.0)
OK
> nvm run 10.0.0 --harmony-subsume-json test.js 
Running node v10.0.0 (npm v5.6.0)
OK
> nvm run 10.0.0 --no-harmony-subsume-json test.js 
Running node v10.0.0 (npm v5.6.0)
undefined:1
"
^

SyntaxError: Invalid or unexpected token
```
Result: JS is a superset of JSON (unless switched off with `--no-harmony-subsume-json`).