### PR TITLE
Node.js: updates in js/builtins/*.json

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -677,7 +677,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": true
@@ -1229,7 +1229,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": true
@@ -2398,9 +2398,20 @@
               "ie": {
                 "version_added": null
               },
-              "nodejs": {
-                "version_added": null
-              },
+              "nodejs": [
+                {
+                  "version_added": "6.5.0"
+                },
+                {
+                  "version_added": "6.0.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": null
               },

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -137,7 +137,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "32"
@@ -299,7 +299,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": true
@@ -407,7 +407,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "32"
@@ -461,7 +461,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "32"

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -408,9 +408,20 @@
               "ie": {
                 "version_added": null
               },
-              "nodejs": {
-                "version_added": null
-              },
+              "nodejs": [
+                {
+                  "version_added": "6.5.0"
+                },
+                {
+                  "version_added": "6.0.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": null
               },

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -192,7 +192,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": false
@@ -301,7 +301,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": false
@@ -410,7 +410,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": false
@@ -519,7 +519,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": false
@@ -628,7 +628,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": false
@@ -737,7 +737,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": false
@@ -846,7 +846,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": false
@@ -955,7 +955,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": false
@@ -1064,7 +1064,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": false
@@ -1173,7 +1173,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": false
@@ -1282,7 +1282,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": false
@@ -1391,7 +1391,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": false

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -978,9 +978,20 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": false
-              },
+              "nodejs": [
+                {
+                  "version_added": "6.5.0"
+                },
+                {
+                  "version_added": "6.0.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": "38"
               },

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -305,7 +305,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "10.0.0"
               },
               "opera": {
                 "version_added": "50"

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -191,7 +191,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "6.0.0"
               },
               "opera": {
                 "version_added": true
@@ -1925,9 +1925,20 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": true
-              },
+              "nodejs": [
+                {
+                  "version_added": "6.5.0"
+                },
+                {
+                  "version_added": "6.0.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": true
               },

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -870,9 +870,20 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": false
-              },
+              "nodejs": [
+                {
+                  "version_added": "6.5.0"
+                },
+                {
+                  "version_added": "6.0.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": "38"
               },

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -84,7 +84,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "8.10.0"
             },
             "opera": {
               "version_added": false
@@ -410,7 +410,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": false
@@ -519,7 +519,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": false

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -924,7 +924,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "28"
@@ -992,7 +992,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": true
@@ -3196,7 +3196,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "10.0.0"
               },
               "opera": {
                 "version_added": "53"
@@ -3280,7 +3280,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "10.0.0"
               },
               "opera": {
                 "version_added": "53"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -574,7 +574,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "36"
@@ -682,7 +682,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "36"
@@ -736,7 +736,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "36"
@@ -790,7 +790,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": false
@@ -844,7 +844,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": false
@@ -898,7 +898,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": false
@@ -952,7 +952,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": null
@@ -1006,7 +1006,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": false
@@ -1116,7 +1116,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "32"
@@ -1170,7 +1170,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": false
@@ -1280,7 +1280,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": true
@@ -1388,7 +1388,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": false
@@ -1554,7 +1554,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": false
@@ -1662,7 +1662,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "32"
@@ -1716,7 +1716,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "32"
@@ -1770,7 +1770,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "32"
@@ -1878,7 +1878,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": null
@@ -1932,7 +1932,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "32"
@@ -1986,7 +1986,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": true
@@ -2337,9 +2337,20 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": null
-              },
+              "nodejs": [
+                {
+                  "version_added": "6.5.0"
+                },
+                {
+                  "version_added": "6.0.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": null
               },


### PR DESCRIPTION
Data generated by automatic tests in [node-compat-table](/williamkapke/node-compat-table), transformed by [nct2bcd](/jcsahnwaldt/nct2bcd).

The data in this commit was transformed using [these](https://github.com/jcsahnwaldt/nct2bcd/commit/058beff1724be1a2d4a069f7009e448b2b77082c) and [these](https://github.com/jcsahnwaldt/nct2bcd/commit/e462aba5daa4bf2e60703b897e072d5c5ee8dabd#diff-2f2430b9702f91cf94b6a77bf8d4af78) new mappings in [nct2bcd/nct.json](/jcsahnwaldt/nct2bcd/blob/master/nct.json).

(The data generated by [node-compat-table](/williamkapke/node-compat-table) is also available at [node.green](https://node.green/).)