### PR TITLE
fix(css): fix edge support table for gap, row-gap and column-gap

### DIFF
--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -17,7 +17,7 @@
                 "version_added": null
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "63"
@@ -115,15 +115,9 @@
                   "alternative_name": "grid-gap"
                 }
               ],
-              "edge_mobile": [
-                {
-                  "version_added": "16"
-                },
-                {
-                  "version_added": "16",
-                  "alternative_name": "grid-gap"
-                }
-              ],
+              "edge_mobile": {
+                "version_added": false
+              },
               "firefox": [
                 {
                   "version_added": "61"
@@ -275,15 +269,9 @@
                   "version_added": "12"
                 }
               ],
-              "edge_mobile": [
-                {
-                  "version_added": "12"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "12"
-                }
-              ],
+              "edge_mobile": {
+                "version_added": false
+              },
               "firefox": [
                 {
                   "version_added": "52"
@@ -398,7 +386,7 @@
                   "version_added": "16"
                 },
                 "edge_mobile": {
-                  "version_added": "16"
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "61"
@@ -458,7 +446,7 @@
                   "version_added": "16"
                 },
                 "edge_mobile": {
-                  "version_added": "16"
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "61"

--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -17,7 +17,7 @@
                 "version_added": null
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "63"
@@ -115,15 +115,9 @@
                   "alternative_name": "grid-gap"
                 }
               ],
-              "edge_mobile": [
-                {
-                  "version_added": "16"
-                },
-                {
-                  "version_added": "16",
-                  "alternative_name": "grid-gap"
-                }
-              ],
+              "edge_mobile": {
+                "version_added": false
+              },
               "firefox": [
                 {
                   "version_added": "61"
@@ -246,7 +240,7 @@
                   "version_added": "16"
                 },
                 "edge_mobile": {
-                  "version_added": "16"
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "52"
@@ -306,7 +300,7 @@
                   "version_added": null
                 },
                 "edge_mobile": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "52"

--- a/css/properties/row-gap.json
+++ b/css/properties/row-gap.json
@@ -17,7 +17,7 @@
                 "version_added": null
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "63"
@@ -114,15 +114,9 @@
                   "alternative_name": "grid-row-gap"
                 }
               ],
-              "edge_mobile": [
-                {
-                  "version_added": "16"
-                },
-                {
-                  "version_added": "16",
-                  "alternative_name": "grid-row-gap"
-                }
-              ],
+              "edge_mobile": {
+                "version_added": false
+              },
               "firefox": [
                 {
                   "version_added": "61"


### PR DESCRIPTION
- edge version 17 supports unprefixed gap* properties
see https://codepen.io/anon/pen/zLKbvJ
- there *was* no edge mobile v16 so I've removed all mention of v16 for edge mobile