### PR TITLE
Mark CSSKeyframesRule and CSSKeyframeRule as standard.

### DIFF
--- a/api/CSSKeyframeRule.json
+++ b/api/CSSKeyframeRule.json
@@ -56,7 +56,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -103,7 +103,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -151,7 +151,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -57,7 +57,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },


### PR DESCRIPTION
As I mentioned in https://github.com/mdn/browser-compat-data/pull/1657#pullrequestreview-138749436 and https://github.com/mdn/browser-compat-data/pull/1656#pullrequestreview-138749119, these should be marked as standard per their MDN articles and linked standards info.

https://developer.mozilla.org/en-US/docs/Web/API/CSSKeyframeRule#Specification

https://developer.mozilla.org/en-US/docs/Web/API/CSSKeyframesRule#Specification