### PR TITLE
builtins: Date, Number, String: fix hierarchy

### DIFF
--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -56,59 +56,57 @@
             }
           }
         },
-        "Date": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date",
-            "support": {
-              "webview_android": {
-                "version_added": true
-              },
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": true,
-                "notes": "The <a href='https://docs.microsoft.com/en-us/scripting/javascript/date-and-time-strings-javascript'>ISO8601 Date Format</a> is not supported in Internet Explorer 8."
-              },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              }
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date",
+          "support": {
+            "webview_android": {
+              "version_added": true
             },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": true,
+              "notes": "The <a href='https://docs.microsoft.com/en-us/scripting/javascript/date-and-time-strings-javascript'>ISO8601 Date Format</a> is not supported in Internet Explorer 8."
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
         "UTC": {

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2,6 +2,59 @@
   "javascript": {
     "builtins": {
       "Date": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": true,
+              "notes": "The <a href='https://docs.microsoft.com/en-us/scripting/javascript/date-and-time-strings-javascript'>ISO8601 Date Format</a> is not supported in Internet Explorer 8."
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "@@toPrimitive": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/@@toPrimitive",
@@ -54,59 +107,6 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date",
-          "support": {
-            "webview_android": {
-              "version_added": true
-            },
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": "1"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
-            "ie": {
-              "version_added": true,
-              "notes": "The <a href='https://docs.microsoft.com/en-us/scripting/javascript/date-and-time-strings-javascript'>ISO8601 Date Format</a> is not supported in Internet Explorer 8."
-            },
-            "nodejs": {
-              "version_added": true
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": true
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
           }
         },
         "UTC": {

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -2,6 +2,58 @@
   "javascript": {
     "builtins": {
       "Number": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "EPSILON": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/EPSILON",
@@ -378,58 +430,6 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
-          "support": {
-            "webview_android": {
-              "version_added": true
-            },
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": "1"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
-            "ie": {
-              "version_added": true
-            },
-            "nodejs": {
-              "version_added": true
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": true
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
           }
         },
         "POSITIVE_INFINITY": {

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -380,58 +380,56 @@
             }
           }
         },
-        "Number": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
-            "support": {
-              "webview_android": {
-                "version_added": true
-              },
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": true
-              },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              }
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "support": {
+            "webview_android": {
+              "version_added": true
             },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
         "POSITIVE_INFINITY": {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -2,6 +2,58 @@
   "javascript": {
     "builtins": {
       "String": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "@@iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/@@iterator",
@@ -82,58 +134,6 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
-          "support": {
-            "webview_android": {
-              "version_added": true
-            },
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": "1"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
-            "ie": {
-              "version_added": true
-            },
-            "nodejs": {
-              "version_added": true
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": true
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
           }
         },
         "unicode_code_point_escapes": {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -84,9 +84,61 @@
             }
           }
         },
-        "String": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "support": {
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "unicode_code_point_escapes": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
+            "description": "Unicode code point escapes \\u{xxxxxx}",
             "support": {
               "webview_android": {
                 "version_added": true
@@ -98,19 +150,19 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": null
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "40"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": "40"
               },
               "ie": {
-                "version_added": true
+                "version_added": null
               },
               "nodejs": {
                 "version_added": true
@@ -135,60 +187,6 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
-            }
-          },
-          "unicode_code_point_escapes": {
-            "__compat": {
-              "description": "Unicode code point escapes \\u{xxxxxx}",
-              "support": {
-                "webview_android": {
-                  "version_added": true
-                },
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox": {
-                  "version_added": "40"
-                },
-                "firefox_android": {
-                  "version_added": "40"
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "nodejs": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                },
-                "samsunginternet_android": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
             }
           }
         },


### PR DESCRIPTION
### Summary

[Date.json](https://github.com/mdn/browser-compat-data/blob/master/javascript/builtins/Date.json), [Number.json](https://github.com/mdn/browser-compat-data/blob/master/javascript/builtins/Number.json) and [String.json](https://github.com/mdn/browser-compat-data/blob/master/javascript/builtins/String.json) have a slightly different hierarchy than almost all other files in `javascript/builtins`: They have nested `Date.Date`, `Number.Number` and `String.String` properties. This PR fixes that.

**Note:** In the first commit, I only removed two lines from each file, but I also fixed indentation, so the diff looks like a lot has changed. To see what actually changed, use a diff that ignores whitespace.

### Details

Almost all files in `javascript/builtins` have a structure like the following (example from [Array.json](/mdn/browser-compat-data/blob/master/javascript/builtins/Array.json)):

```
{
  "javascript": {
    "builtins": {
      "Array": {
        "__compat": {
          ...
        },
        "concat": {
          "__compat": {
          }
        },
        ...
```
There is a top-level object (directly under `javascript.builtins`) with the same name as the file (in this case `Array`). This object contains a `__compat` object that describes the basic support for this class, and several sub-objects that describe support for methods and other sub-features (e.g. `Array.concat`).

In MDN compatibility tables, this structure is rendered like this (example from [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Browser_compatibility)):

![screenshot 2018-07-19 18 33 15](https://user-images.githubusercontent.com/607468/42957225-45a3984a-8b82-11e8-99a5-31efe7b767e3.png)

`Date.json`, `Number.json` and `String.json` are different: They _do_ contain a top-level object with the same name as the file, but this top-level element does _not_ contain a `__compat` object. Instead, there is _another_ sub-object with the same name as the file. Example from [Date.json](/mdn/browser-compat-data/blob/master/javascript/builtins/Date.json):

```
{
  "javascript": {
    "builtins": {
      "Date": {
        "@@toPrimitive": {
          ...
        },
        "Date": {
          "__compat": {
            ...
```

This will probably be confusing for users. For example:
- to access `Array` compatibility data, they'd use `javascript.builtins.Array.__compat...`
- but for `Date`, they would have to use `javascript.builtins.Date.Date.__compat...`

The MDN pages for `Date`, `Number` and `String` also look different. Example from [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#Browser_compatibility):

![screenshot 2018-07-19 18 48 09](https://user-images.githubusercontent.com/607468/42957930-4ed5fb68-8b84-11e8-8a80-98a0b0ca2625.png)

In the case of `Number`, it seems that the MDN wiki can't handle the hierarchy at all - the [compatibility table](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#Browser_compatibility) is almost empty, all the sub-features are missing.

**Note:** [Promise.json](https://github.com/mdn/browser-compat-data/blob/master/javascript/builtins/Promise.json) has a similar nested structure, but in this case, it makes good sense: There is a nested `Promise.Promise` object which describes the `Promise` constructor, but there is also a top-level `Promise.__compat` object which describes the basic support for the `Promise` class. 