### PR TITLE
update server-timing browser support

### DIFF
--- a/http/headers/server-timing.json
+++ b/http/headers/server-timing.json
@@ -18,10 +18,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "59"
+              "version_added": "61"
             },
             "firefox_android": {
-              "version_added": "59"
+              "version_added": "61"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
You can go to http://server-timing.netlify.com/ to test if server-timing is supported. 

Firefox: [Intent to ship: PerformanceServerTiming](https://groups.google.com/forum/#!msg/mozilla.dev.platform/MSzaY7_4mvg/hGpUlTzxAgAJ)

I manually tested Firefox 61 on android, and it doesn't have the `PerformanceServerTiming` interface. 