### PR TITLE
lint: check bugzil.la link format

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -128,7 +128,7 @@
             },
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/928150'>bug (928150)</a>. Firefox also supports the experimental and prefixed properties mozCurrentTransform and mozCurrentTransformInverse which set or get the current (inverse) transformation matrix."
+              "notes": "See <a href='https://bugzil.la/928150'>bug 928150</a>. Firefox also supports the experimental and prefixed properties mozCurrentTransform and mozCurrentTransformInverse which set or get the current (inverse) transformation matrix."
             },
             "firefox_android": {
               "version_added": false

--- a/api/DeviceLightEvent.json
+++ b/api/DeviceLightEvent.json
@@ -34,7 +34,7 @@
             {
               "version_added": "22",
               "version_removed": "61",
-              "notes": "Not supported for macbook with touchbar and <a href='https://bugzil.la/754199'>Windows 7</a>."
+              "notes": "Not supported for MacBook with Touchbar and Windows 7 (see <a href='https://bugzil.la/754199'>bug 754199</a>)."
             }
           ],
           "firefox_android": [
@@ -113,7 +113,7 @@
               {
                 "version_added": "22",
                 "version_removed": "61",
-                "notes": "Not supported for macbook with touchbar and <a href='https://bugzil.la/754199'>Windows 7</a>."
+                "notes": "Not supported for MacBook with Touchbar and Windows 7 (see <a href='https://bugzil.la/754199'>bug 754199</a>)."
               }
             ],
             "firefox_android": [

--- a/api/DeviceLightEvent.json
+++ b/api/DeviceLightEvent.json
@@ -34,7 +34,7 @@
             {
               "version_added": "22",
               "version_removed": "61",
-              "notes": "Not supported for MacBook with Touchbar and Windows 7 (see <a href='https://bugzil.la/754199'>bug 754199</a>)."
+              "notes": "Not supported for MacBook with Touch Bar and Windows 7 (see <a href='https://bugzil.la/754199'>bug 754199</a>)."
             }
           ],
           "firefox_android": [
@@ -113,7 +113,7 @@
               {
                 "version_added": "22",
                 "version_removed": "61",
-                "notes": "Not supported for MacBook with Touchbar and Windows 7 (see <a href='https://bugzil.la/754199'>bug 754199</a>)."
+                "notes": "Not supported for MacBook with Touch Bar and Windows 7 (see <a href='https://bugzil.la/754199'>bug 754199</a>)."
               }
             ],
             "firefox_android": [

--- a/api/HTMLKeygenElement.json
+++ b/api/HTMLKeygenElement.json
@@ -26,12 +26,12 @@
           "firefox": {
             "version_added": true,
             "partial_implementation": true,
-            "notes": "See <a href='https://bugzil.la/1315460'>Bug 1315460</a>."
+            "notes": "See <a href='https://bugzil.la/1315460'>bug 1315460</a>."
           },
           "firefox_android": {
             "version_added": true,
             "partial_implementation": true,
-            "notes": "See <a href='https://bugzil.la/1315460'>Bug 1315460</a>."
+            "notes": "See <a href='https://bugzil.la/1315460'>bug 1315460</a>."
           },
           "ie": {
             "version_added": null

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -923,13 +923,13 @@
             "firefox": {
               "version_added": false,
               "notes": [
-                "Firefox doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>bug 847377</a>."
+                "Firefox doesn't implement this yet. See <a href='https://bugzil.la/847377'>bug 847377</a>."
               ]
             },
             "firefox_android": {
               "version_added": false,
               "notes": [
-                "Firefox doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>bug 847377</a>."
+                "Firefox doesn't implement this yet. See <a href='https://bugzil.la/847377'>bug 847377</a>."
               ]
             }
           },

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -297,13 +297,13 @@
             "firefox": {
               "version_added": false,
               "notes": [
-                "Firefox doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>847377</a>."
+                "Firefox doesn't implement this yet. See <a href='https://bugzil.la/847377'>bug 847377</a>."
               ]
             },
             "firefox_android": {
               "version_added": false,
               "notes": [
-                "Firefox doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>847377</a>."
+                "Firefox doesn't implement this yet. See <a href='https://bugzil.la/847377'>bug 847377</a>."
               ]
             }
           },
@@ -923,13 +923,13 @@
             "firefox": {
               "version_added": false,
               "notes": [
-                "Firefox doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>847377</a>."
+                "Firefox doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>bug 847377</a>."
               ]
             },
             "firefox_android": {
               "version_added": false,
               "notes": [
-                "Firefox doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>847377</a>."
+                "Firefox doesn't implement this yet. See bug <a href='https://bugzil.la/847377'>bug 847377</a>."
               ]
             }
           },

--- a/api/SVGUnknownElement.json
+++ b/api/SVGUnknownElement.json
@@ -22,23 +22,23 @@
           "firefox": [
             {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1239218'>Bug 1239218</a>.'"
+              "notes": "See <a href='https://bugzil.la/1239218'>bug 1239218</a>.'"
             },
             {
               "version_added": "11",
               "version_removed": "22",
-              "notes": "See <a href='https://bugzil.la/589640'>Bug 589640</a> and <a href='https://bugzil.la/840417'>840417</a>.'"
+              "notes": "See <a href='https://bugzil.la/589640'>bug 589640</a> and <a href='https://bugzil.la/840417'>bug 840417</a>.'"
             }
           ],
           "firefox_android": [
             {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1239218'>Bug 1239218</a>.'"
+              "notes": "See <a href='https://bugzil.la/1239218'>bug 1239218</a>.'"
             },
             {
               "version_added": "14",
               "version_removed": "22",
-              "notes": "See <a href='https://bugzil.la/589640'>Bug 589640</a> and <a href='https://bugzil.la/840417'>840417</a>.'"
+              "notes": "See <a href='https://bugzil.la/589640'>bug 589640</a> and <a href='https://bugzil.la/840417'>bug 840417</a>.'"
             }
           ],
           "ie": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -1619,11 +1619,11 @@
             },
             "firefox": {
               "version_added": true,
-              "notes": "Firefox has a <a href='https://bugzil.la/1386683'>bug</a> whereby single quotes contained in URLs are escaped when accessed via URL APIs. This has been fixed as of Firefox 57."
+              "notes": "Firefox has a <a href='https://bugzil.la/1386683'>bug 1386683</a> whereby single quotes contained in URLs are escaped when accessed via URL APIs. This has been fixed as of Firefox 57."
             },
             "firefox_android": {
               "version_added": true,
-              "notes": "Firefox has a <a href='https://bugzil.la/1386683'>bug</a> whereby single quotes contained in URLs are escaped when accessed via URL APIs. This has been fixed as of Firefox 57."
+              "notes": "Firefox has a <a href='https://bugzil.la/1386683'>bug 1386683</a> whereby single quotes contained in URLs are escaped when accessed via URL APIs. This has been fixed as of Firefox 57."
             },
             "ie": {
               "version_added": true

--- a/api/Window.json
+++ b/api/Window.json
@@ -1619,11 +1619,11 @@
             },
             "firefox": {
               "version_added": true,
-              "notes": "Firefox has a <a href='https://bugzil.la/1386683'>bug 1386683</a> whereby single quotes contained in URLs are escaped when accessed via URL APIs. This has been fixed as of Firefox 57."
+              "notes": "Before Firefox 57, single quotes contained in URLs were escaped when accessed via URL APIs. See <a href='https://bugzil.la/1386683'>bug 1386683</a>."
             },
             "firefox_android": {
               "version_added": true,
-              "notes": "Firefox has a <a href='https://bugzil.la/1386683'>bug 1386683</a> whereby single quotes contained in URLs are escaped when accessed via URL APIs. This has been fixed as of Firefox 57."
+              "notes": "Before Firefox 57, single quotes contained in URLs were escaped when accessed via URL APIs. See <a href='https://bugzil.la/1386683'>bug 1386683</a>."
             },
             "ie": {
               "version_added": true

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -171,7 +171,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Firefox recognizes this value but does not yet implement layout support for tate-chū-yoko (see <a href='https://bugzil.la/1258635'> bug 1258635</a>)."
+                "notes": "Firefox recognizes this value but does not yet implement layout support for tate-chū-yoko (see <a href='https://bugzil.la/1258635'>bug 1258635</a>)."
               },
               "firefox_android": {
                 "version_added": "48",
@@ -182,7 +182,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Firefox recognizes this value but does not yet implement layout support for tate-chū-yoko (see <a href='https://bugzil.la/1258635'> bug 1258635</a>)."
+                "notes": "Firefox recognizes this value but does not yet implement layout support for tate-chū-yoko (see <a href='https://bugzil.la/1258635'>bug 1258635</a>)."
               },
               "ie": {
                 "version_added": true

--- a/css/types/global_keywords.json
+++ b/css/types/global_keywords.json
@@ -196,11 +196,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/1215878'>bug 1215878</a>."
+                "notes": "See <a href='https://bugzil.la/1215878'>bug 1215878</a>."
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/1215878'>bug 1215878</a>."
+                "notes": "See <a href='https://bugzil.la/1215878'>bug 1215878</a>."
               },
               "ie": {
                 "version_added": false

--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -71,11 +71,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>."
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>."
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>."
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>."
               },
               "ie": {
                 "version_added": true
@@ -173,11 +173,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>."
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>."
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>."
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>."
               },
               "ie": {
                 "version_added": true
@@ -225,11 +225,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>."
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>."
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>."
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>."
               },
               "ie": {
                 "version_added": true
@@ -327,11 +327,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>."
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>."
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>."
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>."
               },
               "ie": {
                 "version_added": true

--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -71,11 +71,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>."
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>."
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
               },
               "ie": {
                 "version_added": true
@@ -173,11 +173,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
               },
               "ie": {
                 "version_added": true
@@ -225,11 +225,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
               },
               "ie": {
                 "version_added": true
@@ -327,11 +327,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>."
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>."
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
               },
               "ie": {
                 "version_added": true

--- a/html/elements/colgroup.json
+++ b/html/elements/colgroup.json
@@ -71,11 +71,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true
@@ -173,11 +173,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -225,11 +225,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -327,11 +327,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/colgroup.json
+++ b/html/elements/colgroup.json
@@ -71,11 +71,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true
@@ -173,11 +173,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -225,11 +225,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -327,11 +327,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/tbody.json
+++ b/html/elements/tbody.json
@@ -71,11 +71,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true
@@ -173,11 +173,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -225,11 +225,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -277,11 +277,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/tbody.json
+++ b/html/elements/tbody.json
@@ -71,11 +71,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true
@@ -173,11 +173,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -225,11 +225,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -277,11 +277,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/td.json
+++ b/html/elements/td.json
@@ -121,11 +121,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true
@@ -273,11 +273,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -325,11 +325,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -628,11 +628,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/td.json
+++ b/html/elements/td.json
@@ -121,11 +121,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true
@@ -273,11 +273,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -325,11 +325,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -628,11 +628,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/tfoot.json
+++ b/html/elements/tfoot.json
@@ -71,11 +71,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true
@@ -173,11 +173,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -225,11 +225,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -277,11 +277,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/tfoot.json
+++ b/html/elements/tfoot.json
@@ -71,11 +71,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true
@@ -173,11 +173,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -225,11 +225,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -277,11 +277,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/th.json
+++ b/html/elements/th.json
@@ -121,11 +121,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true
@@ -273,11 +273,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -325,11 +325,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -628,11 +628,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/th.json
+++ b/html/elements/th.json
@@ -121,11 +121,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true
@@ -273,11 +273,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -325,11 +325,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -628,11 +628,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/thead.json
+++ b/html/elements/thead.json
@@ -71,11 +71,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true
@@ -173,11 +173,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -225,11 +225,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -277,11 +277,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/thead.json
+++ b/html/elements/thead.json
@@ -71,11 +71,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true
@@ -173,11 +173,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -225,11 +225,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -277,11 +277,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/tr.json
+++ b/html/elements/tr.json
@@ -71,11 +71,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true
@@ -173,11 +173,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -225,11 +225,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>2212</a>"
+                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -277,11 +277,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>915</a>"
+                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/tr.json
+++ b/html/elements/tr.json
@@ -71,11 +71,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true
@@ -173,11 +173,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -225,11 +225,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/2212'>bug 2212</a>"
+                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
               },
               "ie": {
                 "version_added": true
@@ -277,11 +277,11 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See bug <a href='https://bugzil.la/915'>bug 915</a>"
+                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>"
               },
               "ie": {
                 "version_added": true

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -947,7 +947,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1045899'>Bugzilla bug 1045899</a>."
+                "notes": "See <a href='https://bugzil.la/1045899'>bug 1045899</a>."
               },
               "firefox_android": {
                 "version_added": false

--- a/http/headers/public-key-pins-report-only.json
+++ b/http/headers/public-key-pins-report-only.json
@@ -23,7 +23,7 @@
             },
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1091177'>Bugzilla bug 1091177</a>."
+              "notes": "See <a href='https://bugzil.la/1091177'>bug 1091177</a>."
             },
             "firefox_android": {
               "version_added": false

--- a/http/headers/public-key-pins.json
+++ b/http/headers/public-key-pins.json
@@ -73,7 +73,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1091176'>Bugzilla bug 1091176</a>."
+                "notes": "See <a href='https://bugzil.la/1091176'>bug 1091176</a>."
               },
               "firefox_android": {
                 "version_added": false

--- a/http/headers/retry-after.json
+++ b/http/headers/retry-after.json
@@ -22,7 +22,7 @@
             },
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/230260'>Bug 230260</a>."
+              "notes": "See <a href='https://bugzil.la/230260'>bug 230260</a>."
             },
             "firefox_android": {
               "version_added": null

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -45,8 +45,8 @@ function testStyle(filename) {
   }
 
   {
-    // Bugzil.la links should use HTTS and have "bug ###" as link text ("Bug ###" only at the begin of notes/sentences).
-    const regexp = new RegExp("(..)<a href='(https?)://bugzil.la/(\\d+)'>(.*?)</a>", 'g');
+    // Bugzil.la links should use HTTPS and have "bug ###" as link text ("Bug ###" only at the begin of notes/sentences).
+    const regexp = new RegExp("(....)<a href='(https?)://bugzil.la/(\\d+)'>(.*?)</a>", 'g');
     let match;
     do {
       match = regexp.exec(actual);
@@ -61,8 +61,11 @@ function testStyle(filename) {
           console.error(`\x1b[33m  Style – Use HTTPS URL (http://bugzil.la/${bugId} → https://bugzil.la/${bugId}).\x1b[0m`);
         }
 
-        if (linkText === `Bug ${bugId}`) {
-          if (before !== '. ' && before[1] !== `"`) {
+        if (/^bug $/.test(before)) {
+          hasErrors = true;
+          console.error(`\x1b[33m  Style – Move word "bug" into link text ("${before}<a href='...'>${linkText}</a>" → "<a href='...'>${before}${bugId}</a>").\x1b[0m`);
+        } else if (linkText === `Bug ${bugId}`) {
+          if (!/(\. |")$/.test(before)) {
             hasErrors = true;
             console.error(`\x1b[33m  Style – Use lowercase "bug" word within sentence ("Bug ${bugId}" → "bug ${bugId}").\x1b[0m`);
           }

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -44,6 +44,36 @@ function testStyle(filename) {
       bugzillaMatch[1]);
   }
 
+  {
+    // Bugzil.la links should use HTTS and have "bug ###" as link text ("Bug ###" only at the begin of notes/sentences).
+    const regexp = new RegExp("(..)<a href='(https?)://bugzil.la/(\\d+)'>(.*?)</a>", 'g');
+    let match;
+    do {
+      match = regexp.exec(actual);
+      if (match) {
+        const before = match[1];
+        const protocol = match[2];
+        const bugId = match[3];
+        const linkText = match[4];
+
+        if (protocol !== 'https') {
+          hasErrors = true;
+          console.error(`\x1b[33m  Style – Use HTTPS URL (http://bugzil.la/${bugId} → https://bugzil.la/${bugId}).\x1b[0m`);
+        }
+
+        if (linkText === `Bug ${bugId}`) {
+          if (before !== '. ' && before[1] !== `"`) {
+            hasErrors = true;
+            console.error(`\x1b[33m  Style – Use lowercase "bug" word within sentence ("Bug ${bugId}" → "bug ${bugId}").\x1b[0m`);
+          }
+        } else if (linkText !== `bug ${bugId}`) {
+          hasErrors = true;
+          console.error(`\x1b[33m  Style – Use standard link text ("${linkText}" → "bug ${bugId}").\x1b[0m`);
+        }
+      }
+    } while (match != null);
+  }
+
   const crbugMatch = actual.match(String.raw`https?://bugs\.chromium\.org/p/chromium/issues/detail\?id=(\d+)`);
   if (crbugMatch) {
     // use https://crbug.com/100000 instead


### PR DESCRIPTION
Fixes #2509 


Result ([source](https://travis-ci.org/mdn/browser-compat-data/builds/406440497#L8158)) before applying fixes: 

```
Problems in 19 files:
api/CanvasRenderingContext2D.json
  JSON schema – OK 
  Style – OK 
  Style – Use standard link text ("bug (928150)" → "bug 928150").
  Browser versions – OK 
api/DeviceLightEvent.json
  JSON schema – OK 
  Style – OK 
  Style – Use standard link text ("Windows 7" → "bug 754199").
  Browser versions – OK 
api/HTMLKeygenElement.json
  JSON schema – OK 
  Style – OK 
  Style – Use lowercase "bug" word within sentence ("Bug 1315460" → "bug 1315460").
  Style – Use lowercase "bug" word within sentence ("Bug 1315460" → "bug 1315460").
  Browser versions – OK 
api/HTMLMediaElement.json
  JSON schema – OK 
  Style – OK 
  Style – Use standard link text ("847377" → "bug 847377").
  Style – Use standard link text ("847377" → "bug 847377").
  Style – Use standard link text ("847377" → "bug 847377").
  Style – Use standard link text ("847377" → "bug 847377").
  Browser versions – OK 
api/SVGUnknownElement.json
  JSON schema – OK 
  Style – OK 
  Style – Use lowercase "bug" word within sentence ("Bug 1239218" → "bug 1239218").
  Style – Use lowercase "bug" word within sentence ("Bug 589640" → "bug 589640").
  Style – Use standard link text ("840417" → "bug 840417").
  Style – Use lowercase "bug" word within sentence ("Bug 1239218" → "bug 1239218").
  Style – Use lowercase "bug" word within sentence ("Bug 589640" → "bug 589640").
  Style – Use standard link text ("840417" → "bug 840417").
  Browser versions – OK 
api/Window.json
  JSON schema – OK 
  Style – OK 
  Style – Use standard link text ("bug" → "bug 1386683").
  Style – Use standard link text ("bug" → "bug 1386683").
  Browser versions – OK 
css/properties/text-combine-upright.json
  JSON schema – OK 
  Style – OK 
  Style – Use standard link text (" bug 1258635" → "bug 1258635").
  Style – Use standard link text (" bug 1258635" → "bug 1258635").
  Browser versions – OK 
html/elements/col.json
  JSON schema – OK 
  Style – OK 
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("915" → "bug 915").
  Browser versions – OK 
html/elements/colgroup.json
  JSON schema – OK 
  Style – OK 
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("915" → "bug 915").
  Browser versions – OK 
html/elements/tbody.json
  JSON schema – OK 
  Style – OK 
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("915" → "bug 915").
  Browser versions – OK 
html/elements/td.json
  JSON schema – OK 
  Style – OK 
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("915" → "bug 915").
  Browser versions – OK 
html/elements/tfoot.json
  JSON schema – OK 
  Style – OK 
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("915" → "bug 915").
  Browser versions – OK 
html/elements/th.json
  JSON schema – OK 
  Style – OK 
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("915" → "bug 915").
  Browser versions – OK 
html/elements/thead.json
  JSON schema – OK 
  Style – OK 
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("915" ��� "bug 915").
  Style – Use standard link text ("915" → "bug 915").
  Browser versions – OK 
html/elements/tr.json
  JSON schema – OK 
  Style – OK 
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("2212" → "bug 2212").
  Style – Use standard link text ("915" → "bug 915").
  Style – Use standard link text ("915" → "bug 915").
  Browser versions – OK 
http/headers/content-security-policy.json
  JSON schema – OK 
  Style – OK 
  Style – Use standard link text ("Bugzilla bug 1045899" → "bug 1045899").
  Browser versions – OK 
http/headers/public-key-pins-report-only.json
  JSON schema – OK 
  Style – OK 
  Style – Use standard link text ("Bugzilla bug 1091177" → "bug 1091177").
  Browser versions – OK 
http/headers/public-key-pins.json
  JSON schema – OK 
  Style – OK 
  Style – Use standard link text ("Bugzilla bug 1091176" → "bug 1091176").
  Browser versions – OK 
http/headers/retry-after.json
  JSON schema – OK 
  Style – OK 
  Style – Use lowercase "bug" word within sentence ("Bug 230260" → "bug 230260").m
  Browser versions – OK 
```