### PR TITLE
update setIcon to include Edge notes

### DIFF
--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -389,7 +389,8 @@
                 "version_added": "14",
                 "notes": [
                   "This call is not persisted.",
-                  "The `imageData` paremeter is not accepted, `path` is requred"
+                  "The <code>imageData</code> parameter is not accepted.",
+                  "The <code>path</code> parameter is required."
                 ]
               },
               "firefox": [

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -386,7 +386,11 @@
                 ]
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "14",
+                "notes": [
+                  "This call is not persisted.",
+                  "The `imageData` paremeter is not accepted, `path` is requred"
+                ]
               },
               "firefox": [
                 {


### PR DESCRIPTION
Edge does not support ImageData parameters and insists on paths. This is documented in the [MSFT Edge Docs](https://docs.microsoft.com/en-us/microsoft-edge/extensions/api-support/supported-apis#browseraction) on the subject.

I wanted to make sure that Microsoft's notes match the MDN Notes. 