### PR TITLE
update FileReaderSync compat data to only show availability in Workers

### DIFF
--- a/api/FileReaderSync.json
+++ b/api/FileReaderSync.json
@@ -5,46 +5,94 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileReaderSync",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": false
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": false
           },
           "edge": {
-            "version_added": true
+            "version_added": false
           },
           "edge_mobile": {
-            "version_added": true
+            "version_added": false
           },
           "firefox": {
-            "version_added": "8"
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": "8"
+            "version_added": false
           },
           "ie": {
-            "version_added": true
+            "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": false
           },
           "opera_android": {
-            "version_added": true
+            "version_added": false
           },
           "safari": {
-            "version_added": true
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": false
           },
           "webview_android": {
-            "version_added": true
+            "version_added": false
           }
         },
         "status": {
           "experimental": false,
           "standard_track": true,
           "deprecated": false
+        }
+      },
+      "worker_support": {
+        "__compat": {
+          "description": "Only available in workers",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "8"
+            },
+            "firefox_android": {
+              "version_added": "8"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "readAsArrayBuffer": {

--- a/api/FileReaderSync.json
+++ b/api/FileReaderSync.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileReaderSync",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": true
           },
           "edge": {
-            "version_added": false
+            "version_added": true
           },
           "edge_mobile": {
-            "version_added": false
+            "version_added": true
           },
           "firefox": {
-            "version_added": false
+            "version_added": "8"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "8"
           },
           "ie": {
-            "version_added": false
+            "version_added": true
           },
           "opera": {
-            "version_added": false
+            "version_added": true
           },
           "opera_android": {
-            "version_added": false
+            "version_added": true
           },
           "safari": {
-            "version_added": false
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": true
           },
           "webview_android": {
-            "version_added": false
+            "version_added": true
           }
         },
         "status": {


### PR DESCRIPTION
I was looking at the `FileReaderSync` API earlier today and noticed that it is only available on Workers due to its synchronous nature.

After having a quick look at the [schema](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md) documentation. It seems that you have introduced a `worker_support` prop.

Keen to hear your feedback on this as it is a bit of an edge case as the API is ONLY available in workers...

https://developer.mozilla.org/en-US/docs/Web/API/FileReaderSync
> This interface is only available in workers as it enables synchronous I/O that could potentially block.