### PR TITLE
Update text-align-last support in IE

### DIFF
--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -81,8 +81,9 @@
             ],
             "ie": {
               "version_added": true,
+              "partial_implementation": true,
               "notes": [
-                "IE only supports text-align-last when text-align is set to justify.",
+                "IE only supports <code>text-align-last</code> when <code>text-align</code> is set to <code>justify</code>.",
                 "The <code>start</code> and <code>end</code> values are not supported."
               ]
             },

--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -80,7 +80,11 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": true,
+              "notes": [
+                "IE only supports text-align-last when text-align is set to justify.",
+                "The <code>start</code> and <code>end</code> values are not supported."
+              ]
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
IE does support `text-align-last`, but only when `text-align: justify` is applied.
It's something I learned while doing some experiments in IE. The only reference I could find is [caniuse](https://caniuse.com/#search=text-align-last).