### PR TITLE
update chrome browser versions data

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -336,13 +336,18 @@
         "67": {
           "release_date": "2018-05-29",
           "release_notes": "https://chromereleases.googleblog.com/2018/05/stable-channel-update-for-desktop_58.html",
-          "status": "current"
+          "status": "retired"
         },
         "68": {
           "release_date": "2018-07-24",
-          "status": "beta"
+          "release_notes": "https://chromereleases.googleblog.com/2018/07/stable-channel-update-for-desktop.html",
+          "status": "current"
         },
         "69": {
+          "release_date": "2018-09-04",
+          "status": "beta"
+        },
+        "70": {
           "status": "nightly"
         }
       }


### PR DESCRIPTION
Chrome 68 has been released!
Here's the update for MDN

The beta release data has been found on https://www.chromestatus.com/features/schedule

Thank you!