### PR TITLE
Add version for promise.finally in NJS

### DIFF
--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -305,7 +305,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "10.0.0"
               },
               "opera": {
                 "version_added": "50"


### PR DESCRIPTION
Added the first version to support promise.prototype.finally in Node.JS as 10.0.0 according to
https://node.green/#ES2018-features-Promise-prototype-finally

This does not yet seem to have made it's way on the Node.js blog.
I personally confirmed promise.prototype.finally to not be working with Node 9.9.0 and to be working with version 10.0.0 on my own PC.