### PR TITLE
Expand prefix usage in the schema documentation

### DIFF
--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -262,7 +262,7 @@ If applicable, leading and trailing `-` must be included.
 
 Examples:
 
-* Prefixed CSS sub-feature:
+* A CSS property with a standard name of `prop-name` and a vendor-prefixed name of `-moz-prop-name`:
 ```json
 {
   "prefix": "-moz-",
@@ -270,7 +270,7 @@ Examples:
 }
 ```
 
-* Prefixed API sub-feature:
+* An API with a standard name of `FeatureName` and a vendor-prefixed name of `webkitFeatureName`:
 ```json
 {
   "prefix": "webkit",

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -260,7 +260,7 @@ Examples:
 A prefix to add to the sub-feature name (defaults to empty string).
 If applicable, leading and trailing `-` must be included.
 
-Example:
+Examples:
 
 * Prefixed CSS sub-feature:
 ```json

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -258,13 +258,23 @@ Examples:
 
 #### `prefix`
 A prefix to add to the sub-feature name (defaults to empty string).
-Note that leading and trailing `-` must be included. Example:
+If applicable, leading and trailing `-` must be included.
 
-* Prefixed sub-feature:
+Example:
+
+* Prefixed CSS sub-feature:
 ```json
 {
   "prefix": "-moz-",
   "version_added": "3.5"
+}
+```
+
+* Prefixed API sub-feature:
+```json
+{
+  "prefix": "webkit",
+  "version_added": "9"
 }
 ```
 


### PR DESCRIPTION
This fills out the prefix usage documentation a little bit. I thought the previous version made it sound as if hyphens were obligatory for all prefixes, which isn't quite right.