### PR TITLE
Node.js: some 0.12 data

### DIFF
--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -311,7 +311,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "4.0.0"
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": "30"
@@ -981,7 +981,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "4.0.0"
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": true

--- a/javascript/operators/yield.json
+++ b/javascript/operators/yield.json
@@ -31,9 +31,20 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": "4.0.0"
-            },
+            "nodejs": [
+              {
+                "version_added": "4.0.0"
+              },
+              {
+                "version_added": "0.12",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--harmony"
+                  }
+                ]
+              }
+            ],
             "opera": {
               "version_added": true
             },

--- a/javascript/operators/yield_star.json
+++ b/javascript/operators/yield_star.json
@@ -32,9 +32,20 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": "4.0.0"
-            },
+            "nodejs": [
+              {
+                "version_added": "4.0.0"
+              },
+              {
+                "version_added": "0.12",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--harmony"
+                  }
+                ]
+              }
+            ],
             "opera": {
               "version_added": true
             },

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1378,9 +1378,20 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": "4.0.0"
-            },
+            "nodejs": [
+              {
+                "version_added": "4.0.0"
+              },
+              {
+                "version_added": "0.12",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--harmony"
+                  }
+                ]
+              }
+            ],
             "opera": {
               "version_added": "26"
             },


### PR DESCRIPTION
Data for some features that were introduced in Node.js 0.12, most of them behind the `--harmony` flag. 

Data was copied from [node-compat-table](/williamkapke/node-compat-table) (the basis for [node.green](https://node.green/)) using [nct2bcd](/jcsahnwaldt/nct2bcd).