### PR TITLE
Update Chrome support for cursor grab now that v68 unprefixes it.

### DIFF
--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -1351,10 +1351,15 @@
               "opera_android": {
                 "version_added": null
               },
-              "safari": {
-                "prefix": "-webkit-",
-                "version_added": "4"
-              },
+              "safari": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "4"
+                }
+              ],
               "safari_ios": {
                 "version_added": null
               },

--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -1310,11 +1310,17 @@
               "webview_android": {
                 "version_added": false
               },
-              "chrome": {
-                "prefix": "-webkit-",
-                "version_added": "1",
-                "notes": "Chrome 22 added Windows support."
-              },
+              "chrome": [
+                {
+                  "version_added": "68",
+                  "notes": "Chrome also continues to support the prefixed versions."
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1",
+                  "notes": "Chrome 22 added Windows support."
+                }
+              ],
               "chrome_android": {
                 "version_added": null
               },


### PR DESCRIPTION
Per Chrome Status: https://www.chromestatus.com/feature/5575087101050880

Both `-webkit-grab` and `grab` are supported now.

EDIT: Looks like Safari added the unprefixed version in Safari 11, according to https://trac.webkit.org/changeset/215146/webkit and https://caniuse.com/#feat=css3-cursors-grab