### PR TITLE
Updated support of Android WebView.

### DIFF
--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/datalist",
           "support": {
             "webview_android": {
-              "version_added": "33"
+              "version_added": false
             },
             "chrome": {
               "version_added": "20"


### PR DESCRIPTION
The `datalist` does not work on Android WebView.

The full explanation is described in the "datalist-polyfill" issue: https://github.com/mfranzke/datalist-polyfill/issues/33