### PR TITLE
"ExperimentalCanvasFeatures" -> "Experimental Web Platform Features"

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -113,7 +113,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "ExperimentalCanvasFeatures"
+                  "name": "Experimental Web Platform Features"
                 }
               ]
             },
@@ -227,7 +227,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "ExperimentalCanvasFeatures"
+                  "name": "Experimental Web Platform Features"
                 }
               ]
             },
@@ -1312,7 +1312,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "ExperimentalCanvasFeatures"
+                  "name": "Experimental Web Platform Features"
                 }
               ]
             },
@@ -1379,7 +1379,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "ExperimentalCanvasFeatures"
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               },
@@ -1503,7 +1503,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "ExperimentalCanvasFeatures"
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               },
@@ -1565,7 +1565,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "ExperimentalCanvasFeatures"
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               },
@@ -1878,7 +1878,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "ExperimentalCanvasFeatures"
+                  "name": "Experimental Web Platform Features"
                 }
               ]
             },
@@ -3674,7 +3674,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "ExperimentalCanvasFeatures"
+                  "name": "Experimental Web Platform Features"
                 }
               ]
             },
@@ -3998,7 +3998,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "ExperimentalCanvasFeatures"
+                  "name": "Experimental Web Platform Features"
                 }
               ]
             },

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -114,7 +114,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "ExperimentalCanvasFeatures",
+                    "name": "Experimental Web Platform Features",
                     "value_to_set": "true"
                   }
                 ]
@@ -1409,7 +1409,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "ExperimentalCanvasFeatures",
+                  "name": "Experimental Web Platform Features",
                   "value_to_set": "true"
                 }
               ]

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -113,7 +113,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "ExperimentalCanvasFeatures"
+                  "name": "Experimental Web Platform Features"
                 }
               ]
             },


### PR DESCRIPTION
In a recent update of Chrome, the ExperimentalCanvasFeatures flag was merged into the ExperimentalWebPlatformFeatures flag.

https://groups.google.com/a/chromium.org/forum/?utm_medium=email&utm_source=footer#!msg/blink-dev/14WpfTddUDI/HNlrrpZxBQAJ

All that needs to be done is replace "ExperimentalCanvasFeatures" with "Experimental Web Platform Features".