### PR TITLE
update SVG <use> browser support - safari has no support for "href"

### DIFF
--- a/svg/elements/use.json
+++ b/svg/elements/use.json
@@ -184,7 +184,7 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": false
               },
               "safari_ios": {
                 "version_added": true


### PR DESCRIPTION
("deprecated" xlink:href is the only option)