### PR TITLE
proxy.settings is not supported on android

### DIFF
--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -153,10 +153,7 @@
                 "version_added": "60"
               },
               "firefox_android": {
-                "notes": [
-                  "In version 59, this property was listed as <code>proxyConfig</code> in the <code>browserSettings</code> namespace, but had a bug that made it mostly unusable."
-                ],
-                "version_added": "60"
+                "version_added": false
               },
               "opera": {
                 "version_added": false


### PR DESCRIPTION
See https://dxr.mozilla.org/mozilla-central/source/toolkit/components/extensions/parent/ext-proxy.js#209