### PR TITLE
Bug 1152401 - enumerateDevices() and outputs

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -133,9 +133,15 @@
             "edge_mobile": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "39"
-            },
+            "firefox": [
+              {
+                "version_added": "63",
+                "notes": "Prior to Firefox 63, <code>enumerateDevices()</code> only returned input devices. Starting with Firefox 63, output devices are also included."
+              },
+              {
+                "version_added": "39"
+              }
+            ],
             "firefox_android": {
               "version_added": "39"
             },


### PR DESCRIPTION
Updated entry for MediaDevices.enumerateDevices() to
note that starting in Firefox 63, enumerateDevices()
includes outputs as well as inputs in its list of
available media devices.