### PR TITLE
Fix two incorrect MDN URLs.

### DIFF
--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -297,7 +297,7 @@
       },
       "clearTimeout": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/WindowOrWorkerGlobalScope/clearTimeout",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/clearTimeout",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -357,7 +357,7 @@
       },
       "createImageBitmap": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/WindowOrWorkerGlobalScope/createImageBitmap",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap",
           "support": {
             "chrome": {
               "version_added": "50"


### PR DESCRIPTION
I guess this was introduced with #1296? The URLs were missing `API` so they linked to a 404 page.

- https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearTimeout
- https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap