### PR TITLE
Remove incorrect supported reference for chrome_url_overrides in Edge

### DIFF
--- a/webextensions/manifest/chrome_url_overrides.json
+++ b/webextensions/manifest/chrome_url_overrides.json
@@ -3,13 +3,14 @@
     "manifest": {
       "chrome_url_overrides": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_url_overrides",
+          "mdn_url":
+            "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_url_overrides",
           "support": {
             "chrome": {
               "version_added": true
             },
             "edge": {
-              "version_added": "15"
+              "version_added": false
             },
             "firefox": {
               "version_added": "54"
@@ -32,7 +33,7 @@
                 ]
               },
               "edge": {
-                "version_added": "15"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "54",


### PR DESCRIPTION
This corrects a previous update that marked chrome_url_overrides as supported in manifest in Edge.

Also, this is the first pull request I've ever done. :smiley:

Closes #2524 