### PR TITLE
Bug 1471613 - EXT_disjoint_timer_query disabled

### DIFF
--- a/api/EXT_disjoint_timer_query.json
+++ b/api/EXT_disjoint_timer_query.json
@@ -8,10 +8,14 @@
             "version_added": null
           },
           "chrome": {
-            "version_added": "47"
+            "version_added": "47",
+            "version_removed": "65",
+            "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
           },
           "chrome_android": {
-            "version_added": "47"
+            "version_added": "47",
+            "version_removed": "65",
+            "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
           },
           "edge": {
             "version_added": false
@@ -20,7 +24,9 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "51"
+            "version_added": "51",
+            "version_removed": "63",
+            "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
           },
           "firefox_android": {
             "version_added": false
@@ -58,10 +64,14 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": "47"
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "chrome_android": {
-              "version_added": "47"
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
               "version_added": false
@@ -70,7 +80,9 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51"
+              "version_added": "51",
+              "version_removed": "63",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "firefox_android": {
               "version_added": false
@@ -109,10 +121,14 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": "47"
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "chrome_android": {
-              "version_added": "47"
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
               "version_added": false
@@ -121,7 +137,9 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51"
+              "version_added": "51",
+              "version_removed": "63",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "firefox_android": {
               "version_added": false
@@ -160,10 +178,14 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": "47"
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "chrome_android": {
-              "version_added": "47"
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
               "version_added": false
@@ -172,7 +194,9 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51"
+              "version_added": "51",
+              "version_removed": "63",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "firefox_android": {
               "version_added": false
@@ -211,10 +235,14 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": "47"
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "chrome_android": {
-              "version_added": "47"
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
               "version_added": false
@@ -223,7 +251,9 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51"
+              "version_added": "51",
+              "version_removed": "63",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "firefox_android": {
               "version_added": false
@@ -262,10 +292,14 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": "47"
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "chrome_android": {
-              "version_added": "47"
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
               "version_added": false
@@ -274,7 +308,9 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51"
+              "version_added": "51",
+              "version_removed": "63",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "firefox_android": {
               "version_added": false
@@ -313,10 +349,14 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": "47"
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "chrome_android": {
-              "version_added": "47"
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
               "version_added": false
@@ -325,7 +365,9 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51"
+              "version_added": "51",
+              "version_removed": "63",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "firefox_android": {
               "version_added": false
@@ -364,10 +406,14 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": "47"
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "chrome_android": {
-              "version_added": "47"
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
               "version_added": false
@@ -376,7 +422,9 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51"
+              "version_added": "51",
+              "version_removed": "63",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "firefox_android": {
               "version_added": false
@@ -415,10 +463,14 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": "47"
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "chrome_android": {
-              "version_added": "47"
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
               "version_added": false
@@ -427,7 +479,9 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51"
+              "version_added": "51",
+              "version_removed": "63",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
Updated BCD for this API to note it's been removed
from Firefox and Chrome, with the version numbers for
each.