### PR TITLE
Added data for window.cancelAnimationFrame

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -54,26 +54,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/cancelAnimationFrame",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "21",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "21",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
             "edge": {
               "version_added": true
             },

--- a/api/Window.json
+++ b/api/Window.json
@@ -50,6 +50,92 @@
           "deprecated": false
         }
       },
+      "cancelAnimationFrame": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/cancelAnimationFrame",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "21",
+                "version_removed": "24",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "21",
+                "version_removed": "24",
+                "prefix": "webkit"
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "23"
+              },
+              {
+                "version_added": "11",
+                "version_removed": "23",
+                "prefix": "moz"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "23"
+              },
+              {
+                "version_added": true,
+                "version_removed": "23",
+                "prefix": "moz"
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "33"
+            },
+            "safari": [
+              {
+                "version_added": "6.1"
+              },
+              {
+                "version_added": "6",
+                "version_removed": "6.1",
+                "prefix": "webkit"
+              }
+            ],
+            "safari_ios": {
+              "version_added": "7.1"
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "cancelIdleCallback": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/cancelIdleCallback",

--- a/api/Window.json
+++ b/api/Window.json
@@ -126,7 +126,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -95,7 +95,7 @@
                 "version_added": "23"
               },
               {
-                "version_added": true,
+                "version_added": "14",
                 "version_removed": "23",
                 "prefix": "moz"
               }


### PR DESCRIPTION
This adds data for [`window.cancelAnimationFrame()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/cancelAnimationFrame), which I think was missed in the work for https://github.com/mdn/browser-compat-data/issues/2011.

I've mostly copied data from the original table.

* Firefox for Android 11 doesn't exist, apparently, so I changed that to `true`.

* For "Android" I wasn't sure whether to make it the same as Chrome or use the data from the table. I went with the vaguer `true` in the end.

