### PR TITLE
Update InputEvent.getTargetRanges() support since Safari has already supported

### DIFF
--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -215,10 +215,10 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -236,10 +236,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": null


### PR DESCRIPTION
Safari has already supported InputEvent.getTargetRanges() by
https://bugs.webkit.org/show_bug.cgi?id=162947, and Edge doesn't support this
yet.

But this table says that safari is unsupported and edge is unknown.  So we should update this table correctly.