### PR TITLE
Update compat data for onbeforeunload on Edge

### DIFF
--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -202,7 +202,7 @@
                 "version_added": "51"
               },
               "edge": {
-                "version_added": false
+                "version_added": true
               },
               "edge_mobile": {
                 "version_added": true


### PR DESCRIPTION
Edge removed support for custom messages on beforeunload
event.