### PR TITLE
Bug 1148354 - remove Doppler effect from PannerNode

### DIFF
--- a/api/AudioListener.json
+++ b/api/AudioListener.json
@@ -73,10 +73,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "25",
+              "version_removed": "63"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "26",
+              "version_removed": "63"
             },
             "ie": {
               "version_added": false
@@ -447,10 +449,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "25",
+              "version_removed": "63"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "26",
+              "version_removed": "63"
             },
             "ie": {
               "version_added": false

--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -944,10 +944,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "25",
+              "version_removed": "63"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "26",
+              "version_removed": "63"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Updated PannerNode.json and AudioListner.json to
deprecate the two properties and one method deprecated
by this change.