### PR TITLE
Estelle/webkit/1444139

### DIFF
--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -1,0 +1,147 @@
+{
+  "api": {
+    "MediaCapabilities": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities",
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": "66"
+          },
+          "chrome_android": {
+            "version_added": "66"
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "63"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "55"
+          },
+          "opera_android": {
+            "version_added": "55"
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": false,
+          "deprecated": false
+        }
+      }
+    },
+        "MediaEncodingConfiguration": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities",
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "63"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": false,
+          "deprecated": false
+        }
+      }
+    },    "MediaDecodingConfiguration": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities",
+        "support": {
+          "webview_android": {
+            "version_added": null
+          },
+          "chrome": {
+            "version_added": "66"
+          },
+          "chrome_android": {
+            "version_added": "66"
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "63"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "55"
+          },
+          "opera_android": {
+            "version_added": "55"
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": false,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -48,7 +48,7 @@
         }
       }
     },
-        "MediaEncodingConfiguration": {
+    "MediaEncodingConfiguration": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities",
         "support": {
@@ -95,7 +95,8 @@
           "deprecated": false
         }
       }
-    },    "MediaDecodingConfiguration": {
+    },
+    "MediaDecodingConfiguration": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities",
         "support": {

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1605,6 +1605,9 @@
               },
               "firefox": [
                 {
+                  "version_added": "63"
+                },
+                {
                   "version_added": "49",
                   "flags": [
                     {

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1608,26 +1608,8 @@
                   "version_added": "63"
                 },
                 {
-                  "version_added": "49",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": [
-                    "Implemented as an alias for for <code>-moz-device-pixel-ratio</code>."
-                  ]
-                },
-                {
                   "version_added": "45",
                   "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    },
                     {
                       "type": "preference",
                       "name": "layout.css.prefixes.device-pixel-ratio-webkit",


### PR DESCRIPTION
added the re-enabling of layout.css.prefixes.device-pixel-ratio-webkit (i.e. add back support for -webkit-min-device-pixel-ratio) in FF 63, with no flag.