### PR TITLE
Mark spelling-error and grammar-error as unsupported in all browsers.

### DIFF
--- a/css/selectors/grammar-error.json
+++ b/css/selectors/grammar-error.json
@@ -6,44 +6,44 @@
           "description": "<code>::grammar-error</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::grammar-error",
           "support": {
-            "webview_android": {
-              "version_added": null
-            },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
             }
           },
           "status": {

--- a/css/selectors/spelling-error.json
+++ b/css/selectors/spelling-error.json
@@ -6,44 +6,44 @@
           "description": "<code>::spelling-error</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::spelling-error",
           "support": {
-            "webview_android": {
-              "version_added": null
-            },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
It doesn't appear that [`::grammar-error`](https://developer.mozilla.org/en-US/docs/Web/CSS/::grammar-error) or [`::spelling-error`](https://developer.mozilla.org/en-US/docs/Web/CSS/::spelling-error) are implemented in any browsers (I couldn't find anything about them in the Firefox bug tracker, on Chrome Status, on WebKit Status, or on Edge Status).

I marked the features as false for all browsers since I'm fairly certain no browser has implemented them.

They're both defined in [the CSS Pseudo-Elements Module Level 4 spec](https://drafts.csswg.org/css-pseudo-4/#selectordef-grammar-error), so I'd say they should stay unless they get removed from the spec at some point in the future.