### PR TITLE
Bug 1439153 – Expose `Element.openOrClosedShadowRoot` to WebExtensions

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1423,6 +1423,73 @@
           }
         }
       },
+      "openOrClosedShadowRoot": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/openOrClosedShadowRoot",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "63",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "Available only to <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions'>WebExtensions</a>."
+            },
+            "firefox_android": {
+              "version_added": "63",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "Available only to <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions'>WebExtensions</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "prefix": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/prefix",


### PR DESCRIPTION
See [bug 1439153](https://bugzil.la/1439153) for reasoning.