### PR TITLE
Update -webkit-overflow-scrolling.json

### DIFF
--- a/css/properties/-webkit-overflow-scrolling.json
+++ b/css/properties/-webkit-overflow-scrolling.json
@@ -6,19 +6,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-overflow-scrolling",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -27,22 +27,22 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
-webkit-overflow-scrolling was removed from chromium-based browser back in 2013. It was never implemented in desktop browsers.