### PR TITLE
Update matches.json

### DIFF
--- a/css/selectors/matches.json
+++ b/css/selectors/matches.json
@@ -33,9 +33,15 @@
                 "alternative_name": ":-webkit-any"
               }
             ],
-            "edge": {
-              "version_added": false
-            },
+            "edge": [
+              {
+                "version_added": "15"
+              },
+              {
+                "version_added": "12",
+                "alternative_name": ":-ms-matches"
+              }
+            ],
             "edge_mobile": {
               "version_added": false
             },


### PR DESCRIPTION
The info that a prefixed version exists is from Can I Use (https://caniuse.com/#feat=matchesselector) they say it is “Partitial support with prefix -ms-” – Maybe it is not worth including the old version at all for clarity.

https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6524858-unprefix-and-update-msmatchesselector-to-matches