### PR TITLE
Update X-Frame-Options compatibility for Sarafi and Edge

### DIFF
--- a/http/headers/x-frame-options.json
+++ b/http/headers/x-frame-options.json
@@ -65,7 +65,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
                 "version_added": null
@@ -86,10 +86,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": true
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
Safari does not support the `ALLOW-FROM` directive for HTTP header `X-Frame-Options`. This was wrongly flagged as compatible. This applies to both desktop and mobile Safari.

Edge (desktop) does however support the directive, which was flagged as unknown. Not sure about Edge Mobile.