### PR TITLE
Add data for documentUrl

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -939,6 +939,27 @@
                 }
               }
             },
+            "documentUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "frameId": {
               "__compat": {
                 "support": {
@@ -1257,6 +1278,27 @@
             }
           },
           "details": {
+            "documentUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "frameId": {
               "__compat": {
                 "support": {
@@ -1632,6 +1674,27 @@
             }
           },
           "details": {
+            "documentUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "frameAncestors": {
               "__compat": {
                 "support": {
@@ -1923,6 +1986,27 @@
             }
           },
           "details": {
+            "documentUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "frameId": {
               "__compat": {
                 "support": {
@@ -2178,6 +2262,27 @@
             }
           },
           "details": {
+            "documentUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "frameId": {
               "__compat": {
                 "support": {
@@ -2517,6 +2622,27 @@
             }
           },
           "details": {
+            "documentUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "error": {
               "__compat": {
                 "support": {
@@ -2831,6 +2957,27 @@
             }
           },
           "details": {
+            "documentUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "frameId": {
               "__compat": {
                 "support": {
@@ -3128,6 +3275,27 @@
             }
           },
           "details": {
+            "documentUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "frameId": {
               "__compat": {
                 "support": {
@@ -3467,6 +3635,27 @@
             }
           },
           "details": {
+            "documentUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "54"
+                  },
+                  "firefox_android": {
+                    "version_added": "54"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "frameId": {
               "__compat": {
                 "support": {

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -1023,6 +1023,27 @@
                 }
               }
             },
+            "originUrl": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "48"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "parentFrameId": {
               "__compat": {
                 "support": {


### PR DESCRIPTION
`documentUrl` is a Firefox (and FxA)-only property in the `details` object that's passed into webRequest listeners. It was added in Firefox 54.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1311815 and https://hg.mozilla.org/mozilla-central/diff/51541cde2e06/toolkit/components/extensions/schemas/web_request.json.

That diff also indicates that `originUrl` was also added to all event listeners at that time, but I think it was in fact added earlier - the previous compat data listed it from version 48 for all events except `onAuthRequired`. Looking through the diff, I think it was in fact present before version 54 for all event listeners including `onAuthRequired` - I don't see any special handling of that event listener here.

So in this patch I've also added `originUrl` to `onAuthRequired`, indicating that it was supported from 48, like all the other event listeners.

