### PR TITLE
Migrate atomics compat notes

### DIFF
--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -1130,8 +1130,20 @@
                   "version_removed": "57"
                 },
                 {
-                  "version_added": "46",
+                  "version_added": "48",
                   "version_removed": "55",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "46",
+                  "version_removed": "48",
+                  "alternative_name": "futexWait",
                   "flags": [
                     {
                       "type": "preference",
@@ -1158,8 +1170,20 @@
                   "version_removed": "57"
                 },
                 {
-                  "version_added": "46",
+                  "version_added": "48",
                   "version_removed": "55",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "46",
+                  "version_removed": "48",
+                  "alternative_name": "futexWait",
                   "flags": [
                     {
                       "type": "preference",
@@ -1239,8 +1263,20 @@
                   "version_removed": "57"
                 },
                 {
-                  "version_added": "46",
+                  "version_added": "48",
                   "version_removed": "55",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "46",
+                  "version_removed": "48",
+                  "alternative_name": "futexWake",
                   "flags": [
                     {
                       "type": "preference",
@@ -1267,8 +1303,20 @@
                   "version_removed": "57"
                 },
                 {
-                  "version_added": "46",
+                  "version_added": "48",
                   "version_removed": "55",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "46",
+                  "version_removed": "48",
+                  "alternative_name": "futexWake",
                   "flags": [
                     {
                       "type": "preference",

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -1285,7 +1285,8 @@
                       "name": "javascript.options.shared_memory",
                       "value_to_set": "true"
                     }
-                  ]
+                  ],
+                  "notes": "The <code>count</code> parameter defaults to <code>0</code> instead of the later-specified <code>+Infinity</code>."
                 }
               ],
               "firefox_android": [
@@ -1325,7 +1326,8 @@
                       "name": "javascript.options.shared_memory",
                       "value_to_set": "true"
                     }
-                  ]
+                  ],
+                  "notes": "The <code>count</code> parameter defaults to <code>0</code> instead of the later-specified <code>+Infinity</code>."
                 }
               ],
               "ie": {

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -1150,7 +1150,8 @@
                       "name": "javascript.options.shared_memory",
                       "value_to_set": "true"
                     }
-                  ]
+                  ],
+                  "notes": "The method returns values <code>Atomics.OK</code>, <code>Atomics.TIMEDOUT</code>, and <code>Atomics.NOTEQUAL</code>, instead of the later-specified strings."
                 }
               ],
               "firefox_android": [
@@ -1190,7 +1191,8 @@
                       "name": "javascript.options.shared_memory",
                       "value_to_set": "true"
                     }
-                  ]
+                  ],
+                  "notes": "The method returns values <code>Atomics.OK</code>, <code>Atomics.TIMEDOUT</code>, and <code>Atomics.NOTEQUAL</code>, instead of the later-specified strings."
                 }
               ],
               "ie": {


### PR DESCRIPTION
Looking at #2545, I noticed that the `Atomics` page has a bunch of [un-migrated compatibility notes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics#Compatibility_notes). This PR migrates those notes, so they can be removed from the page.