### PR TITLE
Correct support for windowTypes parameter in browser.windows methods

### DIFF
--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -903,7 +903,7 @@
                     "version_added": "14"
                   },
                   "firefox": {
-                    "version_added": "45"
+                    "version_added": false
                   },
                   "firefox_android": {
                     "version_added": false
@@ -911,6 +911,11 @@
                   "opera": {
                     "version_added": "33"
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "deprecated": true
                 }
               }
             }
@@ -968,7 +973,7 @@
                   "version_added": "14"
                 },
                 "firefox": {
-                  "version_added": "45"
+                  "version_added": "58"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -1031,7 +1036,7 @@
                     "version_added": "14"
                   },
                   "firefox": {
-                    "version_added": "45"
+                    "version_added": false
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1039,6 +1044,11 @@
                   "opera": {
                     "version_added": "33"
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "deprecated": true
                 }
               }
             }
@@ -1095,7 +1105,7 @@
                     "version_added": "14"
                   },
                   "firefox": {
-                    "version_added": "45"
+                    "version_added": false
                   },
                   "firefox_android": {
                     "version_added": false
@@ -1103,6 +1113,11 @@
                   "opera": {
                     "version_added": "33"
                   }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "deprecated": true
                 }
               }
             }


### PR DESCRIPTION
For `getAll()`, it was added in Firefox 58 ([bug 1406379](https://bugzilla.mozilla.org/show_bug.cgi?id=1406379)).
For `get()`, `getCurrent()` and `getLastFocused()` it has never worked ([bug 1415913](https://bugzilla.mozilla.org/show_bug.cgi?id=1415913))
and has been deprecated ([bug 1419132](https://bugzilla.mozilla.org/show_bug.cgi?id=1419132)).