### PR TITLE
fix(css.properties.resize): update Edge and IE compatibility

### DIFF
--- a/css/properties/resize.json
+++ b/css/properties/resize.json
@@ -15,10 +15,10 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -72,10 +72,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "5",
@@ -85,7 +85,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "15"


### PR DESCRIPTION
Checked

* Edge 17 (Windows 10)
* IE 11 (Windows 10)
* Edge Mobile 42.0.0.2233 (Android 7.1.1) 