### PR TITLE
Update window.open support to indicate IE and Edge support

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3509,7 +3509,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -3521,7 +3521,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
Updating window.open support to show that IE and Edge support the call at a basic level.