### PR TITLE
Fix Navigator.share compatibility Chrome/Opera

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1791,7 +1791,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/share",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": false
             },
             "chrome_android": {
               "version_added": "61"
@@ -1812,7 +1812,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "48"
+              "version_added": false
             },
             "opera_android": {
               "version_added": "48"


### PR DESCRIPTION
The **Navigator.share** API is falsely flagged as compatible with Chrome and Opera for desktop, but the API is only supported in the Android versions.

I have manually verified this on desktop Chrome and desktop Opera.

    navigator.share === undefined

This [Google Developers article](https://developers.google.com/web/updates/2016/09/navigator-share) specifically mentions Android support. I could not find any indication for desktop support in any browser.