### PR TITLE
Make mentions of macOS more consistent

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -195,7 +195,7 @@
                 "version_removed": "50",
                 "notes": [
                   "Removed in favor of <code>navigator.getBattery()</code>.",
-                  "The Battery API was supported on Android, Windows, and Linux with UPower installed. Support for MacOS was available starting with Firefox 18."
+                  "The Battery API was supported on Android, Windows, and Linux with UPower installed. Support for macOS was available starting with Firefox 18."
                 ]
               },
               {
@@ -221,7 +221,7 @@
                 "version_removed": "50",
                 "notes": [
                   "Removed in favor of <code>navigator.getBattery()</code>.",
-                  "The Battery API was supported on Android, Windows, and Linux with UPower installed. Support for MacOS was available starting with Firefox 18."
+                  "The Battery API was supported on Android, Windows, and Linux with UPower installed. Support for macOS was available starting with Firefox 18."
                 ]
               },
               {

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -2649,7 +2649,7 @@
               },
               "firefox": {
                 "notes": [
-                  "This function does not work on Mac OS X."
+                  "This function does not work on macOS."
                 ],
                 "version_added": "56"
               },


### PR DESCRIPTION
I realize it's a little thing, but it's been on my to do list for a while to strive for a little more consistency in the way we refer to operating systems. This fixes up a few places where the operating system for Macs shows up.