### PR TITLE
Fix note formatting for appearance property

### DIFF
--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -97,13 +97,13 @@
                 {
                   "version_added": "1",
                   "partial_implementation": true,
-                  "notes": "Doesn’t work with &lt;input type=\"checkbox\"&gt; and &lt;input type=\"radio\"&gt;"
+                  "notes": "Doesn’t work with <code>&lt;input type=\"checkbox\"&gt;</code> and <code>&lt;input type=\"radio\"&gt;</code>."
                 }
               ],
               "firefox_android": {
                 "version_added": "4",
                 "partial_implementation": true,
-                "notes": "Doesn’t work with &lt;input type=\"checkbox\"&gt; and &lt;input type=\"radio\"&gt;"
+                "notes": "Doesn’t work with <code>&lt;input type=\"checkbox\"&gt;</code> and <code>&lt;input type=\"radio\"&gt;</code>."
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This adds some code formatting to notes on the `appearance` property. Another little cleanup brought to you by pedantry.