### PR TITLE
Invert onbeforeunload.custom_text_support_removed

### DIFF
--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -191,51 +191,59 @@
             "deprecated": false
           }
         },
-        "custom_text_support_removed": {
+        "custom_text_support": {
           "__compat": {
-            "description": "Custom text support removed",
+            "description": "Custom text support",
             "support": {
               "chrome": {
-                "version_added": "51"
+                "version_added": true,
+                "version_removed": "51"
               },
               "chrome_android": {
-                "version_added": "51"
+                "version_added": true,
+                "version_removed": "51"
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
-                "version_added": "44"
+                "version_added": true,
+                "version_removed": "44"
               },
               "firefox_android": {
-                "version_added": "44"
+                "version_added": true,
+                "version_removed": "44"
               },
               "ie": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
-                "version_added": "38"
+                "version_added": true,
+                "version_removed": "38"
               },
               "opera_android": {
-                "version_added": "38"
+                "version_added": true,
+                "version_removed": "38"
               },
               "safari": {
-                "version_added": "9"
+                "version_added": true,
+                "version_removed": "9"
               },
               "safari_ios": {
                 "version_added": null
               },
               "webview_android": {
-                "version_added": "51"
+                "version_added": true,
+                "version_removed": "51"
               }
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
While reviewing #2566, I noticed that this data was for the removal of a feature, which struck me as a bit confusing (e.g., `"version_added"` meant the version when a behavior was removed
from the browser). This flips things around, so you don't have to mentally negate everything here.