### PR TITLE
fix(http.headers.sts): Strict‑Transport‑Security is not deprecated

### DIFF
--- a/http/headers/strict-transport-security.json
+++ b/http/headers/strict-transport-security.json
@@ -48,7 +48,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
`git blame` revealed that this was added in https://github.com/mdn/browser-compat-data/commit/7b719641950bb4e4ade853d85144bf6aaab1f5b7.

review?(@Elchi3)