### PR TITLE
Misc fixes for PermissionStatus.json

### DIFF
--- a/api/PermissionStatus.json
+++ b/api/PermissionStatus.json
@@ -4,20 +4,44 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PermissionStatus",
         "support": {
-          "webview_android": {
-            "version_added": "43"
-          },
           "chrome": {
             "version_added": "43"
           },
           "chrome_android": {
             "version_added": "43"
           },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
           "firefox": {
             "version_added": "46"
           },
           "firefox_android": {
             "version_added": "46"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          },
+          "samsunginternet_android": {
+            "version_added": null
+          },
+          "webview_android": {
+            "version_added": "43"
           }
         },
         "status": {
@@ -26,20 +50,61 @@
           "deprecated": false
         }
       },
+      "onchange": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PermissionStatus/onchange",
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "43"
+            },
+            "firefox": {
+              "version_added": "46"
+            },
+            "firefox_android": {
+              "version_added": "46"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "43"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "state": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PermissionStatus/state",
           "support": {
-            "webview_android": [
-              {
-                "version_added": "44"
-              },
-              {
-                "alternative_name": "status",
-                "version_added": "43",
-                "version_removed": "44"
-              }
-            ],
             "chrome": [
               {
                 "version_added": "44"
@@ -60,39 +125,46 @@
                 "version_removed": "44"
               }
             ],
-            "firefox": {
-              "version_added": "46"
+            "edge": {
+              "version_added": null
             },
-            "firefox_android": {
-              "version_added": "46"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onchange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PermissionStatus/onchange",
-          "support": {
-            "webview_android": {
-              "version_added": "43"
-            },
-            "chrome": {
-              "version_added": "43"
-            },
-            "chrome_android": {
-              "version_added": "43"
+            "edge_mobile": {
+              "version_added": null
             },
             "firefox": {
               "version_added": "46"
             },
             "firefox_android": {
               "version_added": "46"
-            }
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": [
+              {
+                "version_added": "44"
+              },
+              {
+                "alternative_name": "status",
+                "version_added": "43",
+                "version_removed": "44"
+              }
+            ]
           },
           "status": {
             "experimental": true,


### PR DESCRIPTION
This alphabetizes the features and browser listings, and also adds missing browsers.

I was originally going to add the `status` subfeature to the JSON but I noticed the alternative name was already present, see #2605 for more info. So this PR is just a clean-up.