### PR TITLE
Use correct name for menus permission

### DIFF
--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -509,9 +509,9 @@
             }
           }
         },
-        "menu": {
+        "menus": {
           "__compat": {
-            "description": "<code>menu</code>",
+            "description": "<code>menus</code>",
             "support": {
               "chrome": {
                 "version_added": false


### PR DESCRIPTION
According to https://bugzilla.mozilla.org/show_bug.cgi?id=1215376 and https://github.com/mdn/browser-compat-data/blob/master/webextensions/api/menus.json this permission is called `menus`.

It would be nice if the Browser Extensions Draft (https://browserext.github.io/browserext/#contextMenus) would shed some light on `contextMenus` vs `menus`. Is `contextMenus` deprecated in favor of `menus`?