### PR TITLE
Use correct name for contextMenus permission

### DIFF
--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -220,9 +220,9 @@
             }
           }
         },
-        "contextMenu": {
+        "contextMenus": {
           "__compat": {
-            "description": "<code>contextMenu</code>",
+            "description": "<code>contextMenus</code>",
             "support": {
               "chrome": {
                 "version_added": true


### PR DESCRIPTION
According the the Browser Extension Working Draft (https://browserext.github.io/browserext/#contextMenus)
it should be called `contextMenus`.

Relates to #2612.