### PR TITLE
update SVG <use> browser support - mobile safari has no support for "…

### DIFF
--- a/svg/elements/use.json
+++ b/svg/elements/use.json
@@ -187,7 +187,7 @@
                 "version_added": false
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
update SVG <use> browser support - mobile safari has no support for "href"  ("deprecated" xlink_href as the only option).

This is a copy of @Michal-Miky-Jankovsky pull request [2548](https://github.com/mdn/browser-compat-data/pull/2548) but updated for mobile safari