### PR TITLE
Numeric font weights are supported in Chrome as of release 62

### DIFF
--- a/css/properties/font-weight.json
+++ b/css/properties/font-weight.json
@@ -59,10 +59,10 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": false
+                "version_added": "62"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "62"
               },
               "edge": {
                 "version_added": null


### PR DESCRIPTION
See:

- https://chromium-review.googlesource.com/c/chromium/src/+/589569
- https://storage.googleapis.com/chromium-find-releases-static/c42.html#c42c9e59df46381a15d51fe87ddb4928a1d64b6e