### PR TITLE
Add Promise.finally support in Safari 11.1

### DIFF
--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -314,10 +314,10 @@
                 "version_added": "50"
               },
               "safari": {
-                "version_added": false
+                "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11.1"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
Close #2001 

Screenshots made with BrowserStack:

![image](https://user-images.githubusercontent.com/1437027/44265745-30727880-a228-11e8-8bc0-c10e3d039f5d.png)
![image](https://user-images.githubusercontent.com/1437027/44265751-336d6900-a228-11e8-966d-76d89ca850fd.png)
