### PR TITLE
Bug 1471947 / Bug 1471948 ‑ WebComponents are shipping in Firefox 63

### DIFF
--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -23,6 +23,9 @@
           },
           "firefox": [
             {
+              "version_added": "63"
+            },
+            {
               "version_added": "59",
               "flags": [
                 {
@@ -50,6 +53,9 @@
             }
           ],
           "firefox_android": [
+            {
+              "version_added": "63"
+            },
             {
               "version_added": "59",
               "flags": [
@@ -123,6 +129,9 @@
             },
             "firefox": [
               {
+                "version_added": "63"
+              },
+              {
                 "version_added": "59",
                 "flags": [
                   {
@@ -150,6 +159,9 @@
               }
             ],
             "firefox_android": [
+              {
+                "version_added": "63"
+              },
               {
                 "version_added": "59",
                 "flags": [
@@ -247,6 +259,9 @@
             },
             "firefox": [
               {
+                "version_added": "63"
+              },
+              {
                 "version_added": "59",
                 "flags": [
                   {
@@ -274,6 +289,9 @@
               }
             ],
             "firefox_android": [
+              {
+                "version_added": "63"
+              },
               {
                 "version_added": "59",
                 "flags": [
@@ -388,6 +406,9 @@
             },
             "firefox": [
               {
+                "version_added": "63"
+              },
+              {
                 "version_added": "59",
                 "flags": [
                   {
@@ -415,6 +436,9 @@
               }
             ],
             "firefox_android": [
+              {
+                "version_added": "63"
+              },
               {
                 "version_added": "59",
                 "flags": [
@@ -529,6 +553,9 @@
             },
             "firefox": [
               {
+                "version_added": "63"
+              },
+              {
                 "version_added": "59",
                 "flags": [
                   {
@@ -556,6 +583,9 @@
               }
             ],
             "firefox_android": [
+              {
+                "version_added": "63"
+              },
               {
                 "version_added": "59",
                 "flags": [

--- a/api/Element.json
+++ b/api/Element.json
@@ -173,28 +173,38 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
-            "firefox": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-            },
-            "firefox_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-            },
+            "firefox": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -2223,24 +2233,10 @@
             },
             "firefox": {
               "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ],
               "notes": "Available only to <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions'>WebExtensions</a>."
             },
             "firefox_android": {
               "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ],
               "notes": "Available only to <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions'>WebExtensions</a>."
             },
             "ie": {
@@ -3673,28 +3669,38 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
-            "firefox": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-            },
-            "firefox_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-            },
+            "firefox": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -23,6 +23,9 @@
           },
           "firefox": [
             {
+              "version_added": "63"
+            },
+            {
               "version_added": "59",
               "flags": [
                 {
@@ -50,6 +53,9 @@
             }
           ],
           "firefox_android": [
+            {
+              "version_added": "63"
+            },
             {
               "version_added": "59",
               "flags": [
@@ -125,6 +131,9 @@
             },
             "firefox": [
               {
+                "version_added": "63"
+              },
+              {
                 "version_added": "59",
                 "flags": [
                   {
@@ -152,6 +161,9 @@
               }
             ],
             "firefox_android": [
+              {
+                "version_added": "63"
+              },
               {
                 "version_added": "59",
                 "flags": [
@@ -228,6 +240,9 @@
             },
             "firefox": [
               {
+                "version_added": "63"
+              },
+              {
                 "version_added": "59",
                 "flags": [
                   {
@@ -255,6 +270,9 @@
               }
             ],
             "firefox_android": [
+              {
+                "version_added": "63"
+              },
               {
                 "version_added": "59",
                 "flags": [

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -21,28 +21,38 @@
             "version_added": false,
             "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
           },
-          "firefox": {
-            "version_added": "59",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.webcomponents.shadowdom.enabled",
-                "value_to_set": "true"
-              }
-            ],
-            "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-          },
-          "firefox_android": {
-            "version_added": "59",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.webcomponents.shadowdom.enabled",
-                "value_to_set": "true"
-              }
-            ],
-            "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-          },
+          "firefox": [
+            {
+              "version_added": "63"
+            },
+            {
+              "version_added": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "63"
+            },
+            {
+              "version_added": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -89,28 +99,38 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
-            "firefox": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-            },
-            "firefox_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-            },
+            "firefox": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -158,28 +178,38 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
-            "firefox": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-            },
-            "firefox_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-            },
+            "firefox": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -227,28 +257,38 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
-            "firefox": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-            },
-            "firefox_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-            },
+            "firefox": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/Slotable.json
+++ b/api/Slotable.json
@@ -23,6 +23,9 @@
           },
           "firefox": [
             {
+              "version_added": "63"
+            },
+            {
               "version_added": "59",
               "flags": [
                 {
@@ -50,6 +53,9 @@
             }
           ],
           "firefox_android": [
+            {
+              "version_added": "63"
+            },
             {
               "version_added": "59",
               "flags": [
@@ -125,6 +131,9 @@
             },
             "firefox": [
               {
+                "version_added": "63"
+              },
+              {
                 "version_added": "59",
                 "flags": [
                   {
@@ -152,6 +161,9 @@
               }
             ],
             "firefox_android": [
+              {
+                "version_added": "63"
+              },
               {
                 "version_added": "59",
                 "flags": [

--- a/api/Window.json
+++ b/api/Window.json
@@ -1321,6 +1321,9 @@
             },
             "firefox": [
               {
+                "version_added": "63"
+              },
+              {
                 "version_added": "59",
                 "flags": [
                   {
@@ -1348,6 +1351,9 @@
               }
             ],
             "firefox_android": [
+              {
+                "version_added": "63"
+              },
               {
                 "version_added": "59",
                 "flags": [

--- a/css/selectors/host.json
+++ b/css/selectors/host.json
@@ -23,28 +23,38 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
-            "firefox": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-            },
-            "firefox_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-            },
+            "firefox": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "61",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "61",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/selectors/hostfunction.json
+++ b/css/selectors/hostfunction.json
@@ -23,28 +23,38 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
-            "firefox": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-            },
-            "firefox_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-            },
+            "firefox": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "61",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "61",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/selectors/slotted.json
+++ b/css/selectors/slotted.json
@@ -21,26 +21,36 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/html/elements/slot.json
+++ b/html/elements/slot.json
@@ -22,6 +22,9 @@
             },
             "firefox": [
               {
+                "version_added": "63"
+              },
+              {
                 "version_added": "59",
                 "flags": [
                   {
@@ -49,6 +52,9 @@
               }
             ],
             "firefox_android": [
+              {
+                "version_added": "63"
+              },
               {
                 "version_added": "59",
                 "flags": [

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -569,6 +569,9 @@
             },
             "firefox": [
               {
+                "version_added": "63"
+              },
+              {
                 "version_added": "59",
                 "flags": [
                   {
@@ -596,6 +599,9 @@
               }
             ],
             "firefox_android": [
+              {
+                "version_added": "63"
+              },
               {
                 "version_added": "59",
                 "flags": [
@@ -973,6 +979,9 @@
             },
             "firefox": [
               {
+                "version_added": "63"
+              },
+              {
                 "version_added": "59",
                 "flags": [
                   {
@@ -1000,6 +1009,9 @@
               }
             ],
             "firefox_android": [
+              {
+                "version_added": "63"
+              },
               {
                 "version_added": "59",
                 "flags": [


### PR DESCRIPTION
See [bug 1471947](https://bugzil.la/1471947) and [bug 1471948](https://bugzil.la/1471948) on Bugzilla for more info.

---

Semi‑follow‑up to #1667 and #1987 (as ES6 modules are listed on the [webcomponents.org](https://www.webcomponents.org/) website).