### PR TITLE
fix(html.elements.applet): <applet> was removed in Chrome 47

### DIFF
--- a/html/elements/applet.json
+++ b/html/elements/applet.json
@@ -10,7 +10,7 @@
             },
             "chrome": {
               "version_added": true,
-              "notes": "Although the element is still supported, the Java plugin has been removed in Chrome 42 and an error message is displayed since then. Removal is <a href='https://www.chromestatus.com/features/6246781461463040'>under consideration</a>."
+              "version_removed": "47"
             },
             "chrome_android": {
               "version_added": false
@@ -36,17 +36,17 @@
             },
             "opera": {
               "version_added": true,
-              "notes": "Removal in Opera is <a href='https://www.chromestatus.com/features/6246781461463040'>under consideration</a>."
+              "version_removed": "34"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": true,
               "notes": "Removal in Safari is <a href='https://bugs.webkit.org/show_bug.cgi?id=157926'>under consideration</a>."
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -65,7 +65,8 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "47"
               },
               "chrome_android": {
                 "version_added": false
@@ -88,16 +89,17 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "34"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -117,7 +119,8 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "47"
               },
               "chrome_android": {
                 "version_added": false
@@ -140,16 +143,17 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "34"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -169,7 +173,8 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "47"
               },
               "chrome_android": {
                 "version_added": false
@@ -192,16 +197,17 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "34"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -221,7 +227,8 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "47"
               },
               "chrome_android": {
                 "version_added": false
@@ -244,16 +251,17 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "34"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -273,7 +281,8 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "47"
               },
               "chrome_android": {
                 "version_added": false
@@ -296,16 +305,17 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "34"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -325,7 +335,8 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "47"
               },
               "chrome_android": {
                 "version_added": false
@@ -348,16 +359,17 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "34"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -377,7 +389,8 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "47"
               },
               "chrome_android": {
                 "version_added": false
@@ -400,16 +413,17 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "34"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -429,7 +443,8 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "47"
               },
               "chrome_android": {
                 "version_added": false
@@ -452,16 +467,17 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "34"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -481,7 +497,8 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "47"
               },
               "chrome_android": {
                 "version_added": false
@@ -504,16 +521,17 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "34"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -533,7 +551,8 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "47"
               },
               "chrome_android": {
                 "version_added": false
@@ -556,16 +575,17 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "34"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -585,7 +605,8 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "47"
               },
               "chrome_android": {
                 "version_added": false
@@ -608,16 +629,17 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "34"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -637,7 +659,8 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "47"
               },
               "chrome_android": {
                 "version_added": false
@@ -660,16 +683,17 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "34"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -689,7 +713,8 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "47"
               },
               "chrome_android": {
                 "version_added": false
@@ -712,16 +737,17 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "34"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -741,7 +767,8 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "47"
               },
               "chrome_android": {
                 "version_added": false
@@ -764,16 +791,17 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "34"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -793,7 +821,8 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "47"
               },
               "chrome_android": {
                 "version_added": false
@@ -816,16 +845,17 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "34"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
## External links:
- https://crbug.com/470301
- https://chromium.googlesource.com/chromium/src/+/6da0cb9a75c72db9b042891d1d8ce6c0e3caa956
- https://storage.googleapis.com/chromium-find-releases-static/6da.html#6da0cb9a75c72db9b042891d1d8ce6c0e3caa956