### PR TITLE
fix(css.properties.display): Correct hierarchy of XUL display values

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -1071,270 +1071,270 @@
                 "deprecated": false
               }
             }
-          },
-          "xul_box_values": {
-            "__compat": {
-              "description": "<code>-moz-box</code> and <code>-moz-inline-box</code>",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": true,
-                  "notes": "Scheduled for removal (See <a href='https://bugzil.la/879275'>bug 879275</a>)."
-                },
-                "firefox_android": {
-                  "version_added": true,
-                  "notes": "Scheduled for removal (See <a href='https://bugzil.la/879275'>bug 879275</a>)."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                }
+          }
+        },
+        "xul_box_values": {
+          "__compat": {
+            "description": "<code>-moz-box</code> and <code>-moz-inline-box</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true,
+                "notes": "Scheduled for removal (See <a href='https://bugzil.la/879275'>bug 879275</a>)."
+              },
+              "firefox_android": {
+                "version_added": true,
+                "notes": "Scheduled for removal (See <a href='https://bugzil.la/879275'>bug 879275</a>)."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
-          },
-          "xul_grid_values": {
-            "__compat": {
-              "description": "<code>-moz-grid</code>, <code>-moz-inline-grid</code>, <code>-moz-grid-group</code> and <code>-moz-grid-line</code>",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": true,
-                  "version_removed": "62"
-                },
-                "firefox_android": {
-                  "version_added": true,
-                  "version_removed": "62"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                }
+          }
+        },
+        "xul_grid_values": {
+          "__compat": {
+            "description": "<code>-moz-grid</code>, <code>-moz-inline-grid</code>, <code>-moz-grid-group</code> and <code>-moz-grid-line</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true,
+                "version_removed": "62"
+              },
+              "firefox_android": {
+                "version_added": true,
+                "version_removed": "62"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
-          },
-          "xul_stack_values": {
-            "__compat": {
-              "description": "<code>-moz-stack</code> and <code>-moz-inline-stack</code>",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": true,
-                  "version_removed": "62"
-                },
-                "firefox_android": {
-                  "version_added": true,
-                  "version_removed": "62"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                }
+          }
+        },
+        "xul_stack_values": {
+          "__compat": {
+            "description": "<code>-moz-stack</code> and <code>-moz-inline-stack</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true,
+                "version_removed": "62"
+              },
+              "firefox_android": {
+                "version_added": true,
+                "version_removed": "62"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
-          },
-          "xul_deck_values": {
-            "__compat": {
-              "description": "<code>-moz-deck</code>",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": true,
-                  "version_removed": "62"
-                },
-                "firefox_android": {
-                  "version_added": true,
-                  "version_removed": "62"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                }
+          }
+        },
+        "xul_deck_values": {
+          "__compat": {
+            "description": "<code>-moz-deck</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true,
+                "version_removed": "62"
+              },
+              "firefox_android": {
+                "version_added": true,
+                "version_removed": "62"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
-          },
-          "xul_popup_values": {
-            "__compat": {
-              "description": "<code>-moz-popup</code>",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": true,
-                  "version_removed": "62"
-                },
-                "firefox_android": {
-                  "version_added": true,
-                  "version_removed": "62"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                }
+          }
+        },
+        "xul_popup_values": {
+          "__compat": {
+            "description": "<code>-moz-popup</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true,
+                "version_removed": "62"
+              },
+              "firefox_android": {
+                "version_added": true,
+                "version_removed": "62"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
Follow‑up to #1955, where I accidentally put the XUL display values under `display: contents` and only discovered it [once I checked the published version](https://developer.mozilla.org/docs/Web/CSS/display#Browser_compatibility).

Best reviewed with [**Hide whitespace changes**](https://github.com/mdn/browser-compat-data/pull/2628/files?w=1) enabled.