### PR TITLE
Support for RGBA hex notation landed in Chrome 62, not 63

### DIFF
--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -476,7 +476,7 @@
               },
               "chrome": [
                 {
-                  "version_added": "63"
+                  "version_added": "62"
                 },
                 {
                   "version_added": "52",


### PR DESCRIPTION
See:

- https://chromium-review.googlesource.com/c/chromium/src/+/567841
- https://storage.googleapis.com/chromium-find-releases-static/5b5.html#5b57665fd1db6ae64c4809f2c66eba1538f7e21d