### PR TITLE
fix(api.BluetoothDevice): Add missing `paired` property

### DIFF
--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -520,6 +520,56 @@
           }
         }
       },
+      "paired": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/paired",
+          "support": {
+            "chrome": {
+              "version_added": "45",
+              "version_removed": "52",
+              "notes": "Behind a flag. Chrome OS only."
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
       "unwatchAdvertisements": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/unwatchAdvertisements",


### PR DESCRIPTION
I missed this in #2611.

Follow‑up to #2611 and #2622.