### PR TITLE
fix(css.selectors.placeholder-shown): Firefox supports non‑text types

### DIFF
--- a/css/selectors/placeholder-shown.json
+++ b/css/selectors/placeholder-shown.json
@@ -83,13 +83,13 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": true
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": true
               },
               "ie": {
                 "version_added": false
@@ -98,13 +98,13 @@
                 "version_added": null
               },
               "opera_android": {
-                "version_added": false
+                "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": null
@@ -114,8 +114,8 @@
               }
             },
             "status": {
-              "experimental": false,
-              "standard_track": false,
+              "experimental": true,
+              "standard_track": true,
               "deprecated": false
             }
           }


### PR DESCRIPTION
Tested on MDN with the [`:placeholder‑shown` and `<input type="number">`](https://developer.mozilla.org/en-US/docs/Web/CSS/:placeholder-shown#Result_4) example.