### PR TITLE
fix(css.properties.place‑*): Split grid and flex context

### DIFF
--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -125,9 +125,6 @@
             "__compat": {
               "description": "<code>start</code> and <code>end</code>",
               "support": {
-                "webview_android": {
-                  "version_added": null
-                },
                 "chrome": {
                   "version_added": null
                 },
@@ -162,6 +159,9 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
                   "version_added": null
                 }
               },
@@ -176,9 +176,6 @@
             "__compat": {
               "description": "<code>left</code> and <code>right</code>",
               "support": {
-                "webview_android": {
-                  "version_added": null
-                },
                 "chrome": {
                   "version_added": null
                 },
@@ -213,6 +210,9 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
                   "version_added": null
                 }
               },
@@ -227,9 +227,6 @@
             "__compat": {
               "description": "<code>baseline</code>",
               "support": {
-                "webview_android": {
-                  "version_added": null
-                },
                 "chrome": {
                   "version_added": null
                 },
@@ -264,6 +261,9 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
                   "version_added": null
                 }
               },
@@ -278,9 +278,6 @@
             "__compat": {
               "description": "<code>first baseline</code> and <code>last baseline</code>",
               "support": {
-                "webview_android": {
-                  "version_added": null
-                },
                 "chrome": {
                   "version_added": null
                 },
@@ -315,6 +312,9 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
                   "version_added": null
                 }
               },
@@ -329,9 +329,6 @@
             "__compat": {
               "description": "<code>stretch</code>",
               "support": {
-                "webview_android": {
-                  "version_added": null
-                },
                 "chrome": {
                   "version_added": null
                 },
@@ -366,6 +363,9 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
                   "version_added": null
                 }
               },

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -131,9 +131,6 @@
             "__compat": {
               "description": "<code>space-evenly</code>",
               "support": {
-                "webview_android": {
-                  "version_added": false
-                },
                 "chrome": {
                   "version_added": "60"
                 },
@@ -169,6 +166,9 @@
                 },
                 "samsunginternet_android": {
                   "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
                 }
               },
               "status": {
@@ -182,11 +182,9 @@
             "__compat": {
               "description": "<code>start</code> and <code>end</code>",
               "support": {
-                "webview_android": {
-                  "version_added": null
-                },
                 "chrome": {
                   "version_added": true,
+                  "partial_implementation": true,
                   "notes": "This value is recognized, but has no effect."
                 },
                 "chrome_android": {
@@ -209,6 +207,7 @@
                 },
                 "opera": {
                   "version_added": true,
+                  "partial_implementation": true,
                   "notes": "This value is recognized, but has no effect."
                 },
                 "opera_android": {
@@ -221,6 +220,9 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
                   "version_added": null
                 }
               },
@@ -235,11 +237,9 @@
             "__compat": {
               "description": "<code>left</code> and <code>right</code>",
               "support": {
-                "webview_android": {
-                  "version_added": null
-                },
                 "chrome": {
                   "version_added": true,
+                  "partial_implementation": true,
                   "notes": "This value is recognized, but has no effect."
                 },
                 "chrome_android": {
@@ -257,6 +257,8 @@
                   },
                   {
                     "version_added": true,
+                    "version_removed": "52",
+                    "partial_implementation": true,
                     "notes": "This value is recognized, but has no effect."
                   }
                 ],
@@ -266,15 +268,19 @@
                   },
                   {
                     "version_added": true,
+                    "version_removed": "52",
+                    "partial_implementation": true,
                     "notes": "This value is recognized, but has no effect."
                   }
                 ],
                 "ie": {
                   "version_added": true,
+                  "partial_implementation": true,
                   "notes": "This value is recognized, but has no effect."
                 },
                 "opera": {
                   "version_added": true,
+                  "partial_implementation": true,
                   "notes": "This value is recognized, but has no effect."
                 },
                 "opera_android": {
@@ -287,6 +293,9 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
                   "version_added": null
                 }
               },
@@ -301,9 +310,6 @@
             "__compat": {
               "description": "<code>baseline</code>",
               "support": {
-                "webview_android": {
-                  "version_added": null
-                },
                 "chrome": {
                   "version_added": "57"
                 },
@@ -343,6 +349,9 @@
                 },
                 "samsunginternet_android": {
                   "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
                 }
               },
               "status": {
@@ -356,9 +365,6 @@
             "__compat": {
               "description": "<code>first baseline</code> and <code>last baseline</code>",
               "support": {
-                "webview_android": {
-                  "version_added": null
-                },
                 "chrome": {
                   "version_added": false
                 },
@@ -398,6 +404,9 @@
                 },
                 "samsunginternet_android": {
                   "version_added": false
+                },
+                "webview_android": {
+                  "version_added": null
                 }
               },
               "status": {
@@ -411,9 +420,6 @@
             "__compat": {
               "description": "<code>stretch</code>",
               "support": {
-                "webview_android": {
-                  "version_added": null
-                },
                 "chrome": {
                   "version_added": "57"
                 },
@@ -448,6 +454,9 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
                   "version_added": null
                 }
               },

--- a/css/properties/justify-items.json
+++ b/css/properties/justify-items.json
@@ -7,9 +7,6 @@
             "description": "Supported in Flex Layout",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-items",
             "support": {
-              "webview_android": {
-                "version_added": "52"
-              },
               "chrome": {
                 "version_added": "52"
               },
@@ -45,6 +42,9 @@
               },
               "samsunginternet_android": {
                 "version_added": null
+              },
+              "webview_android": {
+                "version_added": "52"
               }
             },
             "status": {
@@ -59,9 +59,6 @@
             "description": "Supported in Grid Layout",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-items",
             "support": {
-              "webview_android": {
-                "version_added": "57"
-              },
               "chrome": {
                 "version_added": "57"
               },
@@ -97,6 +94,9 @@
               },
               "samsunginternet_android": {
                 "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "57"
               }
             },
             "status": {

--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -2,54 +2,108 @@
   "css": {
     "properties": {
       "justify-self": {
-        "__compat": {
-          "description": "Supported in Grid Layout",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-self",
-          "support": {
-            "webview_android": {
-              "version_added": "57"
+        "flex_context": {
+          "__compat": {
+            "description": "Supported in Flex Layout",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-self",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": "16"
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "45"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "44"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              }
             },
-            "chrome": {
-              "version_added": "57"
-            },
-            "chrome_android": {
-              "version_added": "57"
-            },
-            "edge": {
-              "version_added": "16"
-            },
-            "edge_mobile": {
-              "version_added": "16"
-            },
-            "firefox": {
-              "version_added": "45"
-            },
-            "firefox_android": {
-              "version_added": "45"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "44"
-            },
-            "opera_android": {
-              "version_added": "44"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": "6.0"
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+          }
+        },
+        "grid_context": {
+          "__compat": {
+            "description": "Supported in Grid Layout",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-self",
+            "support": {
+              "webview_android": {
+                "version_added": "57"
+              },
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": "16"
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "45"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "44"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -7,9 +7,6 @@
             "description": "Supported in Flex Layout",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-self",
             "support": {
-              "webview_android": {
-                "version_added": "57"
-              },
               "chrome": {
                 "version_added": "57"
               },
@@ -45,6 +42,9 @@
               },
               "samsunginternet_android": {
                 "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "57"
               }
             },
             "status": {
@@ -59,9 +59,6 @@
             "description": "Supported in Grid Layout",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-self",
             "support": {
-              "webview_android": {
-                "version_added": "57"
-              },
               "chrome": {
                 "version_added": "57"
               },
@@ -97,6 +94,9 @@
               },
               "samsunginternet_android": {
                 "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "57"
               }
             },
             "status": {

--- a/css/properties/place-content.json
+++ b/css/properties/place-content.json
@@ -7,9 +7,6 @@
             "description": "Supported in Flex Layout",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-content",
             "support": {
-              "webview_android": {
-                "version_added": "59"
-              },
               "chrome": {
                 "version_added": "59"
               },
@@ -45,6 +42,9 @@
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
+              },
+              "webview_android": {
+                "version_added": "59"
               }
             },
             "status": {
@@ -59,9 +59,6 @@
             "description": "Supported in Grid Layout",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-content",
             "support": {
-              "webview_android": {
-                "version_added": "59"
-              },
               "chrome": {
                 "version_added": "59"
               },
@@ -97,6 +94,9 @@
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
+              },
+              "webview_android": {
+                "version_added": "59"
               }
             },
             "status": {
@@ -110,9 +110,6 @@
           "__compat": {
             "description": "You can only specify a single value if it is valid for both <code>align-content</code> and <code>justify-content</code>",
             "support": {
-              "webview_android": {
-                "version_added": true
-              },
               "chrome": {
                 "version_added": true
               },
@@ -147,6 +144,9 @@
                 "version_added": null
               },
               "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
                 "version_added": true
               }
             },

--- a/css/properties/place-items.json
+++ b/css/properties/place-items.json
@@ -7,9 +7,6 @@
             "description": "Supported in Flex Layout",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/jplace-items",
             "support": {
-              "webview_android": {
-                "version_added": "59"
-              },
               "chrome": {
                 "version_added": "59"
               },
@@ -45,6 +42,9 @@
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
+              },
+              "webview_android": {
+                "version_added": "59"
               }
             },
             "status": {
@@ -59,9 +59,6 @@
             "description": "Supported in Grid Layout",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-items",
             "support": {
-              "webview_android": {
-                "version_added": "59"
-              },
               "chrome": {
                 "version_added": "59"
               },
@@ -97,6 +94,9 @@
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
+              },
+              "webview_android": {
+                "version_added": "59"
               }
             },
             "status": {

--- a/css/properties/place-items.json
+++ b/css/properties/place-items.json
@@ -2,53 +2,108 @@
   "css": {
     "properties": {
       "place-items": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-items",
-          "support": {
-            "webview_android": {
-              "version_added": "59"
+        "flex_context": {
+          "__compat": {
+            "description": "Supported in Flex Layout",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/jplace-items",
+            "support": {
+              "webview_android": {
+                "version_added": "59"
+              },
+              "chrome": {
+                "version_added": "59"
+              },
+              "chrome_android": {
+                "version_added": "59"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "45"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "7.0"
+              }
             },
-            "chrome": {
-              "version_added": "59"
-            },
-            "chrome_android": {
-              "version_added": "59"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "45"
-            },
-            "firefox_android": {
-              "version_added": "45"
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": "7.0"
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+          }
+        },
+        "grid_context": {
+          "__compat": {
+            "description": "Supported in Grid Layout",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-items",
+            "support": {
+              "webview_android": {
+                "version_added": "59"
+              },
+              "chrome": {
+                "version_added": "59"
+              },
+              "chrome_android": {
+                "version_added": "59"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "45"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "7.0"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/properties/place-items.json
+++ b/css/properties/place-items.json
@@ -5,7 +5,7 @@
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/jplace-items",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-items",
             "support": {
               "chrome": {
                 "version_added": "59"

--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -2,53 +2,108 @@
   "css": {
     "properties": {
       "place-self": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-self",
-          "support": {
-            "webview_android": {
-              "version_added": "59"
+        "flex_context": {
+          "__compat": {
+            "description": "Supported in Flex Layout",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-self",
+            "support": {
+              "webview_android": {
+                "version_added": "59"
+              },
+              "chrome": {
+                "version_added": "59"
+              },
+              "chrome_android": {
+                "version_added": "59"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "7.0"
+              }
             },
-            "chrome": {
-              "version_added": "59"
-            },
-            "chrome_android": {
-              "version_added": "59"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "45"
-            },
-            "firefox_android": {
-              "version_added": true
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": "7.0"
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+          }
+        },
+        "grid_context": {
+          "__compat": {
+            "description": "Supported in Grid Layout",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-self",
+            "support": {
+              "webview_android": {
+                "version_added": "59"
+              },
+              "chrome": {
+                "version_added": "59"
+              },
+              "chrome_android": {
+                "version_added": "59"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "7.0"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -7,9 +7,6 @@
             "description": "Supported in Flex Layout",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-self",
             "support": {
-              "webview_android": {
-                "version_added": "59"
-              },
               "chrome": {
                 "version_added": "59"
               },
@@ -26,7 +23,7 @@
                 "version_added": "45"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "ie": {
                 "version_added": null
@@ -45,6 +42,9 @@
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
+              },
+              "webview_android": {
+                "version_added": "59"
               }
             },
             "status": {
@@ -59,9 +59,6 @@
             "description": "Supported in Grid Layout",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-self",
             "support": {
-              "webview_android": {
-                "version_added": "59"
-              },
               "chrome": {
                 "version_added": "59"
               },
@@ -78,7 +75,7 @@
                 "version_added": "45"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "ie": {
                 "version_added": null
@@ -97,6 +94,9 @@
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
+              },
+              "webview_android": {
+                "version_added": "59"
               }
             },
             "status": {


### PR DESCRIPTION
Closes #2635 and closes #2636.

Best reviewed with [**Hide whitespace changes**](https://github.com/mdn/browser-compat-data/pull/2637/files?w=1) enabled.

---

review?(@Elchi3)