### PR TITLE
Unprefixed logical CSS properties are shipping in Chromium 69

### DIFF
--- a/css/properties/margin-block-end.json
+++ b/css/properties/margin-block-end.json
@@ -5,14 +5,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block-end",
           "support": {
-            "webview_android": {
-              "version_added": false
-            },
             "chrome": {
-              "version_added": false
+              "version_added": "69"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "69"
             },
             "edge": {
               "version_added": null
@@ -56,10 +53,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -69,6 +66,9 @@
             },
             "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/margin-block-start.json
+++ b/css/properties/margin-block-start.json
@@ -5,14 +5,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block-start",
           "support": {
-            "webview_android": {
-              "version_added": false
-            },
             "chrome": {
-              "version_added": false
+              "version_added": "69"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "69"
             },
             "edge": {
               "version_added": null
@@ -56,10 +53,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -69,6 +66,9 @@
             },
             "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -5,16 +5,24 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-inline-end",
           "support": {
-            "webview_android": {
-              "version_added": true
-            },
-            "chrome": {
-              "alternative_name": "-webkit-margin-end",
-              "version_added": "2"
-            },
-            "chrome_android": {
-              "version_added": null
-            },
+            "chrome": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "2",
+                "alternative_name": "-webkit-margin-end"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "2",
+                "alternative_name": "-webkit-margin-end"
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -26,10 +34,6 @@
                 "version_added": "41"
               },
               {
-                "alternative_name": "-moz-margin-end",
-                "version_added": "3"
-              },
-              {
                 "version_added": "38",
                 "version_removed": "51",
                 "flags": [
@@ -39,6 +43,10 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": "3",
+                "alternative_name": "-moz-margin-end"
               }
             ],
             "firefox_android": [
@@ -46,10 +54,6 @@
                 "version_added": "41"
               },
               {
-                "alternative_name": "-moz-margin-end",
-                "version_added": "4"
-              },
-              {
                 "version_added": "38",
                 "version_removed": "51",
                 "flags": [
@@ -59,27 +63,54 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": "4",
+                "alternative_name": "-moz-margin-end"
               }
             ],
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "15",
+                "alternative_name": "-webkit-margin-end"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "14",
+                "alternative_name": "-webkit-margin-end"
+              }
+            ],
             "safari": {
-              "alternative_name": "-webkit-margin-end",
-              "version_added": "3"
+              "version_added": "3",
+              "alternative_name": "-webkit-margin-end"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3",
+              "alternative_name": "-webkit-margin-end"
             },
             "samsunginternet_android": {
-              "version_added": null
-            }
+              "version_added": true,
+              "alternative_name": "-webkit-margin-end"
+            },
+            "webview_android": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "2",
+                "alternative_name": "-webkit-margin-end"
+              }
+            ]
           },
           "status": {
             "experimental": true,

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -5,16 +5,24 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-inline-start",
           "support": {
-            "webview_android": {
-              "version_added": true
-            },
-            "chrome": {
-              "alternative_name": "-webkit-margin-start",
-              "version_added": "2"
-            },
-            "chrome_android": {
-              "version_added": null
-            },
+            "chrome": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "2",
+                "alternative_name": "-webkit-margin-end"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "2",
+                "alternative_name": "-webkit-margin-end"
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -26,10 +34,6 @@
                 "version_added": "41"
               },
               {
-                "alternative_name": "-moz-margin-start",
-                "version_added": "3"
-              },
-              {
                 "version_added": "38",
                 "version_removed": "51",
                 "flags": [
@@ -39,6 +43,10 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": "3",
+                "alternative_name": "-moz-margin-start"
               }
             ],
             "firefox_android": [
@@ -46,10 +54,6 @@
                 "version_added": "41"
               },
               {
-                "alternative_name": "-moz-margin-start",
-                "version_added": "4"
-              },
-              {
                 "version_added": "38",
                 "version_removed": "51",
                 "flags": [
@@ -59,27 +63,54 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": "4",
+                "alternative_name": "-moz-margin-start"
               }
             ],
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "15",
+                "alternative_name": "-webkit-margin-start"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "14",
+                "alternative_name": "-webkit-margin-start"
+              }
+            ],
             "safari": {
-              "alternative_name": "-webkit-margin-start",
-              "version_added": "3"
+              "version_added": "3",
+              "alternative_name": "-webkit-margin-start"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3",
+              "alternative_name": "-webkit-margin-start"
             },
             "samsunginternet_android": {
-              "version_added": null
-            }
+              "version_added": true,
+              "alternative_name": "-webkit-margin-start"
+            },
+            "webview_android": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "2",
+                "alternative_name": "-webkit-margin-start"
+              }
+            ]
           },
           "status": {
             "experimental": true,

--- a/css/properties/padding-block-end.json
+++ b/css/properties/padding-block-end.json
@@ -5,20 +5,17 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-block-end",
           "support": {
-            "webview_android": {
-              "version_added": false
-            },
             "chrome": {
-              "version_added": false
+              "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
-              "version_added": false
+              "version_added": null
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": [
               {
@@ -56,10 +53,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -69,6 +66,9 @@
             },
             "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/padding-block-start.json
+++ b/css/properties/padding-block-start.json
@@ -5,20 +5,17 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-block-start",
           "support": {
-            "webview_android": {
-              "version_added": false
-            },
             "chrome": {
-              "version_added": false
+              "version_added": "69"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "69"
             },
             "edge": {
               "version_added": null
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": null
             },
             "firefox": [
               {
@@ -56,10 +53,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -69,6 +66,9 @@
             },
             "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -5,23 +5,29 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-inline-end",
           "support": {
-            "webview_android": {
-              "alternative_name": "-webkit-padding-end",
-              "version_added": true
-            },
-            "chrome": {
-              "alternative_name": "-webkit-padding-end",
-              "version_added": "2"
-            },
-            "chrome_android": {
-              "alternative_name": "-webkit-padding-end",
-              "version_added": "2"
-            },
+            "chrome": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "2",
+                "alternative_name": "-webkit-padding-end"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "2",
+                "alternative_name": "-webkit-padding-end"
+              }
+            ],
             "edge": {
               "version_added": null
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": null
             },
             "firefox": [
               {
@@ -39,8 +45,8 @@
                 ]
               },
               {
-                "alternative_name": "-moz-padding-end",
-                "version_added": "3"
+                "version_added": "3",
+                "alternative_name": "-moz-padding-end"
               }
             ],
             "firefox_android": [
@@ -59,32 +65,52 @@
                 ]
               },
               {
-                "alternative_name": "-moz-padding-end",
-                "version_added": "4"
+                "version_added": "4",
+                "alternative_name": "-moz-padding-end"
               }
             ],
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "alternative_name": "-webkit-padding-end",
-              "version_added": "15"
-            },
-            "opera_android": {
-              "alternative_name": "-webkit-padding-end",
-              "version_added": "15"
-            },
+            "opera": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "15",
+                "alternative_name": "-webkit-padding-end"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "14",
+                "alternative_name": "-webkit-padding-end"
+              }
+            ],
             "safari": {
-              "alternative_name": "-webkit-padding-end",
-              "version_added": "3"
+              "version_added": "3",
+              "alternative_name": "-webkit-padding-end"
             },
             "safari_ios": {
-              "alternative_name": "-webkit-padding-end",
-              "version_added": true
+              "version_added": "3",
+              "alternative_name": "-webkit-padding-end"
             },
             "samsunginternet_android": {
-              "version_added": true
-            }
+              "version_added": true,
+              "alternative_name": "-webkit-padding-end"
+            },
+            "webview_android": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "2",
+                "alternative_name": "-webkit-padding-end"
+              }
+            ]
           },
           "status": {
             "experimental": true,

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -5,23 +5,29 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-inline-start",
           "support": {
-            "webview_android": {
-              "alternative_name": "-webkit-padding-start",
-              "version_added": true
-            },
-            "chrome": {
-              "alternative_name": "-webkit-padding-start",
-              "version_added": "2"
-            },
-            "chrome_android": {
-              "alternative_name": "-webkit-padding-start",
-              "version_added": true
-            },
+            "chrome": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "2",
+                "alternative_name": "-webkit-padding-start"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "2",
+                "alternative_name": "-webkit-padding-start"
+              }
+            ],
             "edge": {
-              "version_added": false
+              "version_added": null
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": [
               {
@@ -39,8 +45,8 @@
                 ]
               },
               {
-                "alternative_name": "-moz-padding-start",
-                "version_added": "3"
+                "version_added": "3",
+                "alternative_name": "-moz-padding-start"
               }
             ],
             "firefox_android": [
@@ -59,32 +65,52 @@
                 ]
               },
               {
-                "alternative_name": "-moz-padding-start",
-                "version_added": "4"
+                "version_added": "4",
+                "alternative_name": "-moz-padding-start"
               }
             ],
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "alternative_name": "-webkit-padding-start",
-              "version_added": true
-            },
-            "opera_android": {
-              "alternative_name": "-webkit-padding-start",
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "15",
+                "alternative_name": "-webkit-padding-start"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "14",
+                "alternative_name": "-webkit-padding-start"
+              }
+            ],
             "safari": {
-              "alternative_name": "-webkit-padding-start",
-              "version_added": "3"
+              "version_added": "3",
+              "alternative_name": "-webkit-padding-start"
             },
             "safari_ios": {
-              "alternative_name": "-webkit-padding-start",
-              "version_added": true
+              "version_added": "3",
+              "alternative_name": "-webkit-padding-start"
             },
             "samsunginternet_android": {
-              "version_added": true
-            }
+              "version_added": true,
+              "alternative_name": "-webkit-padding-start"
+            },
+            "webview_android": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "2",
+                "alternative_name": "-webkit-padding-start"
+              }
+            ]
           },
           "status": {
             "experimental": true,


### PR DESCRIPTION
I also reset all Edge support values to `null`, as the compat data contains mixed conflicting signals, and there were only 4 non‑`null` Edge values (2 `true` and 2 `false`, the remaining 12 were `null`).

---

review?(@Elchi3, @jpmedley)