### PR TITLE
Firefox 63 ships Clear-Site-Data header

### DIFF
--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -17,28 +17,36 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "62",
-              "flags": [
-                {
-                  "name": "dom.clearSiteData.enabled",
-                  "type": "preference",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1470111'>bug 1470111</a> for enabling this by default."
-            },
-            "firefox_android": {
-              "version_added": "62",
-              "flags": [
-                {
-                  "name": "dom.clearSiteData.enabled",
-                  "type": "preference",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1470111'>bug 1470111</a> for enabling this by default."
-            },
+            "firefox": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "62",
+                "flags": [
+                  {
+                    "name": "dom.clearSiteData.enabled",
+                    "type": "preference",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "62",
+                "flags": [
+                  {
+                    "name": "dom.clearSiteData.enabled",
+                    "type": "preference",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": null
             },


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1470111
Updates: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data