### PR TITLE
Performance: add Safari 11 updates

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -79,10 +79,10 @@
               "version_added": "33"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "46"
@@ -127,10 +127,10 @@
               "version_added": "33"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "46"
@@ -189,10 +189,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": [
               {
@@ -244,10 +244,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": true
@@ -292,10 +292,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": true
@@ -340,10 +340,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": true
@@ -388,10 +388,10 @@
               "version_added": "33"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "46"
@@ -436,10 +436,10 @@
               "version_added": "33"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "46"
@@ -484,10 +484,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": true
@@ -762,10 +762,10 @@
               "version_added": "49"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "62"
@@ -861,7 +861,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -43,10 +43,10 @@
             "version_added": "33"
           },
           "safari": {
-            "version_added": false
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": null
@@ -150,10 +150,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -201,10 +201,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -252,10 +252,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -303,10 +303,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -354,10 +354,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/PerformanceMark.json
+++ b/api/PerformanceMark.json
@@ -35,10 +35,10 @@
             "version_added": "33"
           },
           "safari": {
-            "version_added": false
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": null

--- a/api/PerformanceMeasure.json
+++ b/api/PerformanceMeasure.json
@@ -35,10 +35,10 @@
             "version_added": "33"
           },
           "safari": {
-            "version_added": false
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": null

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -29,10 +29,10 @@
             "version_added": "11"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "11"
           }
         },
         "status": {
@@ -110,10 +110,10 @@
               "version_added": "39"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": false
@@ -152,10 +152,10 @@
               "version_added": "39"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": false
@@ -194,10 +194,10 @@
               "version_added": "39"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": false

--- a/api/PerformanceObserverEntryList.json
+++ b/api/PerformanceObserverEntryList.json
@@ -35,10 +35,10 @@
             "version_added": "39"
           },
           "safari": {
-            "version_added": false
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": null


### PR DESCRIPTION
Close #2642 

I tested all of the changes either via BrowserStack (jsconsole.com) or manually in Safari devtools.

*I didn't test nor update support in web workers.* - they are left as `null`

![image](https://user-images.githubusercontent.com/1437027/44466384-73658f00-a620-11e8-89f3-88357a40cbb4.png)
