### PR TITLE
Animation.{effect|finished|ready} ship in Firefox 63

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -322,28 +322,38 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "This property is supported in Firefox 48 but is read-only. It became writable in Firefox 51."
-            },
-            "firefox_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "This property is supported in Firefox 48 but is read-only. It became writable in Firefox 51."
-            },
+            "firefox": [
+              {
+                "version_added": "48",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "This property is supported in Firefox 48 but is read-only. It became writable in Firefox 51."
+              },
+              {
+                "version_added": "63"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "48",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "This property is supported in Firefox 48 but is read-only. It became writable in Firefox 51."
+              },
+              {
+                "version_added": "63"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -466,26 +476,36 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "40",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "40",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "40",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "63"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "40",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "63"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -1130,26 +1150,36 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "37",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "37",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "37",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "63"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "37",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "63"
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/Animation.json
+++ b/api/Animation.json
@@ -324,6 +324,9 @@
             },
             "firefox": [
               {
+                "version_added": "63"
+              },
+              {
                 "version_added": "48",
                 "flags": [
                   {
@@ -333,9 +336,6 @@
                   }
                 ],
                 "notes": "This property is supported in Firefox 48 but is read-only. It became writable in Firefox 51."
-              },
-              {
-                "version_added": "63"
               }
             ],
             "firefox_android": [
@@ -478,6 +478,9 @@
             },
             "firefox": [
               {
+                "version_added": "63"
+              },
+              {
                 "version_added": "40",
                 "flags": [
                   {
@@ -486,9 +489,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "63"
               }
             ],
             "firefox_android": [
@@ -1152,6 +1152,9 @@
             },
             "firefox": [
               {
+                "version_added": "63"
+              },
+              {
                 "version_added": "37",
                 "flags": [
                   {
@@ -1160,9 +1163,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "63"
               }
             ],
             "firefox_android": [

--- a/api/Animation.json
+++ b/api/Animation.json
@@ -340,6 +340,9 @@
             ],
             "firefox_android": [
               {
+                "version_added": "63"
+              },
+              {
                 "version_added": "48",
                 "flags": [
                   {
@@ -349,9 +352,6 @@
                   }
                 ],
                 "notes": "This property is supported in Firefox 48 but is read-only. It became writable in Firefox 51."
-              },
-              {
-                "version_added": "63"
               }
             ],
             "ie": {
@@ -493,6 +493,9 @@
             ],
             "firefox_android": [
               {
+                "version_added": "63"
+              },
+              {
                 "version_added": "40",
                 "flags": [
                   {
@@ -501,9 +504,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "63"
               }
             ],
             "ie": {
@@ -1167,6 +1167,9 @@
             ],
             "firefox_android": [
               {
+                "version_added": "63"
+              },
+              {
                 "version_added": "37",
                 "flags": [
                   {
@@ -1175,9 +1178,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "63"
               }
             ],
             "ie": {


### PR DESCRIPTION
Add indications that Animation.ready, .finished, and
.effect are now enabled by default in Firefox 63.