### PR TITLE
Object.entries is supported in iOS Safari from 10.1.

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -654,7 +654,7 @@
                 "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10.1"
               },
               "samsunginternet_android": {
                 "version_added": "6.0"


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries

Fixes #2546.

[The ES6 compat table says it's supported](http://kangax.github.io/compat-table/es2016plus/#test-Object_static_methods_a_href=_https://tc39.github.io/ecma262/#sec-object.entries_Object.entries_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;), and I'd say it's safe to assume the version added would be the same as desktop Safari.