### PR TITLE
XDomainRequest was removed in IE11, not IE10.

### DIFF
--- a/api/XDomainRequest.json
+++ b/api/XDomainRequest.json
@@ -24,7 +24,7 @@
           },
           "ie": {
             "version_added": "8",
-            "version_removed": "10"
+            "version_removed": "11"
           },
           "opera": {
             "version_added": false
@@ -75,7 +75,7 @@
             },
             "ie": {
               "version_added": "8",
-              "version_removed": "10"
+              "version_removed": "11"
             },
             "opera": {
               "version_added": false
@@ -127,7 +127,7 @@
             },
             "ie": {
               "version_added": "8",
-              "version_removed": "10"
+              "version_removed": "11"
             },
             "opera": {
               "version_added": false
@@ -179,7 +179,7 @@
             },
             "ie": {
               "version_added": "8",
-              "version_removed": "10"
+              "version_removed": "11"
             },
             "opera": {
               "version_added": false
@@ -231,7 +231,7 @@
             },
             "ie": {
               "version_added": "8",
-              "version_removed": "10"
+              "version_removed": "11"
             },
             "opera": {
               "version_added": false
@@ -283,7 +283,7 @@
             },
             "ie": {
               "version_added": "8",
-              "version_removed": "10"
+              "version_removed": "11"
             },
             "opera": {
               "version_added": false
@@ -335,7 +335,7 @@
             },
             "ie": {
               "version_added": "8",
-              "version_removed": "10"
+              "version_removed": "11"
             },
             "opera": {
               "version_added": false
@@ -387,7 +387,7 @@
             },
             "ie": {
               "version_added": "8",
-              "version_removed": "10"
+              "version_removed": "11"
             },
             "opera": {
               "version_added": false
@@ -439,7 +439,7 @@
             },
             "ie": {
               "version_added": "8",
-              "version_removed": "10"
+              "version_removed": "11"
             },
             "opera": {
               "version_added": false
@@ -491,7 +491,7 @@
             },
             "ie": {
               "version_added": "8",
-              "version_removed": "10"
+              "version_removed": "11"
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
Fixes #2169. See discussion in that issue for more info.