### PR TITLE
CSS image-orientation: <angle> & flip obsolete

### DIFF
--- a/css/properties/image-orientation.json
+++ b/css/properties/image-orientation.json
@@ -98,6 +98,8 @@
               }
             },
             "status": {
+              "experimental": false,
+              "standard_track": false,
               "deprecated": true
             }
           }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1473450