### PR TITLE
Improve alternative names for EventTarget methods in IE

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -483,6 +483,112 @@
           }
         }
       },
+      "attachEvent": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/EventTarget/attachEvent",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6",
+              "version_removed": "11",
+              "notes": "<code>attachEvent()</code> is not supported in IE11. It is replaced by <code>addEventListener()</code>."
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "detachEvent": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/EventTarget/detachEvent",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6",
+              "version_removed": "11",
+              "notes": "<code>detachEvent()</code> is not supported in IE11. It is replaced by <code>removeEventListener()</code>."
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
       "dispatchEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EventTarget/dispatchEvent",
@@ -538,6 +644,59 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        }
+      },
+      "fireEvent": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/EventTarget/fireEvent",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "6",
+              "version_removed": "11",
+              "notes": "<code>fireEvent()</code> is not supported in IE11. It is replaced by <code>dispatchEvent()</code>."
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -150,8 +150,9 @@
               },
               {
                 "alternative_name": "attachEvent",
-                "version_added": true,
-                "notes": "Older versions of IE supported an equivalent, proprietary, <code>EventTarget.attachEvent()</code> method."
+                "version_added": "6",
+                "version_removed": "11",
+                "notes": "Older versions of IE supported an equivalent, proprietary <code>EventTarget.attachEvent()</code> method."
               }
             ],
             "opera": {
@@ -483,112 +484,6 @@
           }
         }
       },
-      "attachEvent": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/EventTarget/attachEvent",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "edge_mobile": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": "6",
-              "version_removed": "11",
-              "notes": "<code>attachEvent()</code> is not supported in IE11. It is replaced by <code>addEventListener()</code>."
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
-      "detachEvent": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/EventTarget/detachEvent",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "edge_mobile": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": "6",
-              "version_removed": "11",
-              "notes": "<code>detachEvent()</code> is not supported in IE11. It is replaced by <code>removeEventListener()</code>."
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "dispatchEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EventTarget/dispatchEvent",
@@ -620,8 +515,9 @@
               },
               {
                 "alternative_name": "fireEvent",
-                "version_added": true,
-                "notes": "Older versions of IE supported an equivalent, proprietary, <code>EventTarget.fireEvent()</code> method."
+                "version_added": "6",
+                "version_removed": "11",
+                "notes": "Older versions of IE supported an equivalent, proprietary <code>EventTarget.fireEvent()</code> method."
               }
             ],
             "opera": {
@@ -644,59 +540,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        }
-      },
-      "fireEvent": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/EventTarget/fireEvent",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "edge_mobile": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": "6",
-              "version_removed": "11",
-              "notes": "<code>fireEvent()</code> is not supported in IE11. It is replaced by <code>dispatchEvent()</code>."
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
           }
         }
       },
@@ -725,9 +568,17 @@
             "firefox_android": {
               "version_added": "4"
             },
-            "ie": {
-              "version_added": "9"
-            },
+            "ie": [
+              {
+                "version_added": "9"
+              },
+              {
+                "alternative_name": "detachEvent",
+                "version_added": "6",
+                "version_removed": "11",
+                "notes": "Older versions of IE supported an equivalent, proprietary <code>EventTarget.detachEvent()</code> method."
+              }
+            ],
             "opera": {
               "version_added": "7"
             },


### PR DESCRIPTION
Added some IE-specific methods to the EventTarget API:

- [`attachEvent`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/attachEvent)
- [`detachEvent`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/detachEvent)
- [`fireEvent`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/fireEvent)

EDIT: Those docs will be deleted, instead I've improved the data on the alternative names of the standard equivalent methods.