### PR TITLE
Add CompositionEvent constructor.

### DIFF
--- a/api/CompositionEvent.json
+++ b/api/CompositionEvent.json
@@ -4,14 +4,11 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CompositionEvent",
         "support": {
-          "webview_android": {
-            "version_added": null
-          },
           "chrome": {
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -42,6 +39,9 @@
           },
           "samsunginternet_android": {
             "version_added": null
+          },
+          "webview_android": {
+            "version_added": true
           }
         },
         "status": {
@@ -50,18 +50,67 @@
           "deprecated": false
         }
       },
-      "data": {
+      "CompositionEvent": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CompositionEvent/data",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CompositionEvent/CompositionEvent",
+          "description": "<code>CompositionEvent()</code> constructor",
           "support": {
-            "webview_android": {
-              "version_added": null
-            },
             "chrome": {
               "version_added": true
             },
             "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
               "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "data": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CompositionEvent/data",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -92,6 +141,9 @@
             },
             "samsunginternet_android": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -105,14 +157,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CompositionEvent/initCompositionEvent",
           "support": {
-            "webview_android": {
-              "version_added": null
-            },
             "chrome": {
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -143,6 +192,9 @@
             },
             "samsunginternet_android": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -156,14 +208,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CompositionEvent/locale",
           "support": {
-            "webview_android": {
-              "version_added": null
-            },
             "chrome": {
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -194,6 +243,9 @@
             },
             "samsunginternet_android": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
This updates the `CompositionEvent.json` file to add [the `CompositionEvent` constructor](https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent/CompositionEvent). This PR also reorders the browser support arrays so webview_android is at the bottom, and marks chrome_android as true.

Notes:

- I find it suspicious that Chrome is true but Opera is false, but I don't know enough about Opera to really say for sure that that is incorrect.
- [The Firefox 53 release notes](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/53#Changes_for_Web_developers#Events) mention that this constructor was added in 53 (the rest of the API was apparently added in 9).