### PR TITLE
Add compat data for WritableStreamDefaultController

### DIFF
--- a/api/WritableStreamDefaultController.json
+++ b/api/WritableStreamDefaultController.json
@@ -1,0 +1,158 @@
+{
+  "api": {
+    "WritableStreamDefaultController": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController",
+        "support": {
+          "chrome": {
+            "version_added": "58"
+          },
+          "chrome_android": {
+            "version_added": "58"
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "45"
+          },
+          "opera_android": {
+            "version_added": "45"
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          },
+          "samsunginternet_android": {
+            "version_added": null
+          },
+          "webview_android": {
+            "version_added": "58"
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "WritableStreamDefaultController": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController/WritableStreamDefaultController",
+          "description": "<code>WritableStreamDefaultController()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController/error",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultController

Adds data for the main API from the table in the article, the subfeatures are left null because they have no table.

- [`WritableStreamDefaultController` constructor](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultController/WritableStreamDefaultController)
- [`error`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultController/error)