### PR TITLE
Add data for ScriptProcessorNode API

### DIFF
--- a/api/ScriptProcessorNode.json
+++ b/api/ScriptProcessorNode.json
@@ -4,100 +4,118 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScriptProcessorNode",
         "support": {
-          "webview_android": {
-            "version_added": null
-          },
           "chrome": {
-            "version_added": null
+            "version_added": "14",
+            "prefix": "webkit"
           },
           "chrome_android": {
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
-            "version_added": null
+            "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": "25"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "25"
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
-          "opera": {
-            "version_added": null
-          },
+          "opera": [
+            {
+              "version_added": "22"
+            },
+            {
+              "version_added": "15",
+              "prefix": "webkit"
+            }
+          ],
           "opera_android": {
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "6",
+            "prefix": "webkit"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "6",
+            "prefix": "webkit"
           },
           "samsunginternet_android": {
+            "version_added": null
+          },
+          "webview_android": {
             "version_added": null
           }
         },
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "bufferSize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScriptProcessorNode/bufferSize",
           "support": {
-            "webview_android": {
-              "version_added": null
-            },
             "chrome": {
-              "version_added": null
+              "version_added": "14",
+              "prefix": "webkit"
             },
             "chrome_android": {
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
               "version_added": null
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -105,50 +123,59 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScriptProcessorNode/onaudioprocess",
           "support": {
-            "webview_android": {
-              "version_added": null
-            },
             "chrome": {
-              "version_added": null
+              "version_added": "14",
+              "prefix": "webkit"
             },
             "chrome_android": {
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
               "version_added": null
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/ScriptProcessorNode

The data is based on data in the ScriptProcessorNode article. I'm pretty sure Chrome no longer has this feature prefixed, but I can't find any information about when that happened. I also assume Chrome for Android supports the API, but I can't find any solid info on that either.

- [`bufferSize`](https://developer.mozilla.org/en-US/docs/Web/API/ScriptProcessorNode/bufferSize)
- [`onaudioprocess`](https://developer.mozilla.org/en-US/docs/Web/API/ScriptProcessorNode/onaudioprocess)