### PR TITLE
Add compat data for ReadableStreamDefaultController.

### DIFF
--- a/api/ReadableStreamDefaultController.json
+++ b/api/ReadableStreamDefaultController.json
@@ -1,0 +1,337 @@
+{
+  "api": {
+    "ReadableStreamDefaultController": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController",
+        "support": {
+          "chrome": {
+            "version_added": "52"
+          },
+          "chrome_android": {
+            "version_added": "52"
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": "57",
+            "notes": "Not yet enabled by default. See <a href='https://bugzil.la/1389628'>bug 1389628</a>.",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.streams.enabled",
+                "value_to_set": "true"
+              },
+              {
+                "type": "preference",
+                "name": "javascript.options.streams",
+                "value_to_set": "true"
+              }
+            ]
+          },
+          "firefox_android": {
+            "version_added": "57",
+            "notes": "Not yet enabled by default. See <a href='https://bugzil.la/1389628'>bug 1389628</a>.",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.streams.enabled",
+                "value_to_set": "true"
+              },
+              {
+                "type": "preference",
+                "name": "javascript.options.streams",
+                "value_to_set": "true"
+              }
+            ]
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "39"
+          },
+          "opera_android": {
+            "version_added": "39"
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          },
+          "samsunginternet_android": {
+            "version_added": null
+          },
+          "webview_android": {
+            "version_added": "52"
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "ReadableStreamDefaultController": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/ReadableStreamDefaultController",
+          "description": "<code>ReadableStreamDefaultController()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "close": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/close",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "desiredSize": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/desiredSize",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "enqueue": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/enqueue",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/error",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultController

Data for the base API is mostly from the current table in the article.

Subfeatures are marked as null because of the current lack of tables on their pages. Should we just assume that if the base API is implemented, the subfeatures are too?

Subfeatures:
- [`ReadableStreamDefaultController` constructor](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/ReadableStreamDefaultController)
- [`close`](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/close)
- [`desiredSize`](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/desiredSize)
- [`enqueue`](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/enqueue)
- [`error`](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/error)

Notes:
- [Source for implementation in Firefox 57](https://bugzilla.mozilla.org/show_bug.cgi?id=1128959)
- [Bug for enabling Streams API by default in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1389628)
- [WebKit's documentation has ReadableStreamDefaultController listed, is this sufficient to mark it as supported in Safari 10.1+?](https://developer.apple.com/documentation/webkitjs/readablestreamdefaultcontroller)