### PR TITLE
Add Firefox support of xml:space in SVG

### DIFF
--- a/svg/attributes/core.json
+++ b/svg/attributes/core.json
@@ -262,10 +262,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": "3"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": null


### PR DESCRIPTION
According to the resolution bug[1], this feature missed the 2.0 merge
window, so I tagged it as 3.0, and Firefox didn’t exist on Android back
then so I tagged it as always.

I don’t have access to other browsers to test, so I’m leaving the other
ones as is.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=319786