### PR TITLE
Add IE compatibility for location.origin and .toString

### DIFF
--- a/api/Location.json
+++ b/api/Location.json
@@ -327,7 +327,8 @@
               "notes": "Before Firefox 49, results for URL using the blob scheme incorrectly returned null."
             },
             "ie": {
-              "version_added": null
+              "version_added": "11",
+              "notes": "Intranet sites are set to Compatibility View, which will emulate IE7 and omit window.location.origin."
             },
             "opera": {
               "version_added": null
@@ -733,7 +734,8 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11",
+              "notes": "Intranet sites are set to Compatibility View, which will emulate IE7 and omit window.location.toString."
             },
             "opera": {
               "version_added": null

--- a/api/Location.json
+++ b/api/Location.json
@@ -328,7 +328,7 @@
             },
             "ie": {
               "version_added": "11",
-              "notes": "Intranet sites are set to Compatibility View, which will emulate IE7 and omit window.location.origin."
+              "notes": "Intranet sites are set to Compatibility View, which will emulate IE7 and omit <code>window.location.origin</code>."
             },
             "opera": {
               "version_added": null
@@ -735,7 +735,7 @@
             },
             "ie": {
               "version_added": "11",
-              "notes": "Intranet sites are set to Compatibility View, which will emulate IE7 and omit window.location.toString."
+              "notes": "Intranet sites are set to Compatibility View, which will emulate IE7 and omit <code>window.location.toString</code>."
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
These were added in IE11, but don't work in Compatibility Mode (emulated IE7). More info: https://stackoverflow.com/a/38930269