### PR TITLE
Animation timeline pref changes in Firefox 63

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -1379,28 +1379,54 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "This property is supported in Firefox 48 but is read-only. It became writable in Firefox 49."
-            },
-            "firefox_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "This property is supported in Firefox 48 but is read-only. It became writable in Firefox 49."
-            },
+            "firefox": [
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.timelines.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "48",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "This property is supported in Firefox 48 but is read-only. It became writable in Firefox 49."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.timelines.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "48",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "This property is supported in Firefox 48 but is read-only. It became writable in Firefox 49."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/AnimationTimeline.json
+++ b/api/AnimationTimeline.json
@@ -21,11 +21,18 @@
           },
           "firefox": [
             {
-              "version_added": "48"
+              "version_added": "63",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.timelines.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             {
-              "version_added": "45",
-              "version_removed": "48",
+              "version_added": "48",
+              "version_removed": "63",
               "flags": [
                 {
                   "type": "preference",
@@ -37,11 +44,18 @@
           ],
           "firefox_android": [
             {
-              "version_added": "48"
+              "version_added": "63",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.timelines.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             {
-              "version_added": "45",
-              "version_removed": "48",
+              "version_added": "48",
+              "version_removed": "63",
               "flags": [
                 {
                   "type": "preference",
@@ -95,12 +109,52 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "34"
-            },
-            "firefox_android": {
-              "version_added": "34"
-            },
+            "firefox": [
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.timelines.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "48",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.timelines.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "48",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/DocumentTimeline.json
+++ b/api/DocumentTimeline.json
@@ -19,12 +19,52 @@
           "edge_mobile": {
             "version_added": null
           },
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": {
-            "version_added": false
-          },
+          "firefox": [
+            {
+              "version_added": "63",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.timelines.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
+              "version_added": "50",
+              "version_removed": "63",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.core.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "63",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.timelines.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
+              "version_added": "50",
+              "version_removed": "63",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.core.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -70,12 +110,52 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "50"
-            },
-            "firefox_android": {
-              "version_added": "50"
-            },
+            "firefox": [
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.timelines.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "50",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.timelines.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "50",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1471814

https://developer.mozilla.org/en-US/docs/Web/API/Animation/timeline
https://developer.mozilla.org/en-US/docs/Web/API/AnimationTimeline
https://developer.mozilla.org/en-US/docs/Web/API/AnimationTimeline/currentTime
https://developer.mozilla.org/en-US/docs/Web/API/DocumentTimeline
https://developer.mozilla.org/en-US/docs/Web/API/DocumentTimeline/DocumentTimeline

Now use the dom.animations-api.timelines.enabled pref (starting with Firefox 63) and no longer the dom.animations-api.core.enabled pref.

Does this also affect https://developer.mozilla.org/en-US/docs/Web/API/Document/timeline?

r? @birtles 