### PR TITLE
Animation compositing preference in Firefox 63

### DIFF
--- a/api/KeyframeEffect.json
+++ b/api/KeyframeEffect.json
@@ -119,10 +119,24 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "63"
+              "version_added": "63",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.compositing.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": "63"
+              "version_added": "63",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.compositing.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": null
@@ -221,10 +235,24 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "63"
+              "version_added": "63",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.compositing.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": "63"
+              "version_added": "63",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.compositing.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1471814

These two are still behind a pref "dom.animations-api.compositing.enabled".
https://developer.mozilla.org/en-US/docs/Web/API/KeyframeEffect/composite
https://developer.mozilla.org/en-US/docs/Web/API/KeyframeEffect/iterationComposite

review? @birtles 