### PR TITLE
Firefox for Android does not support extraParameters in tabs.onUpdated.addListener

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -2089,7 +2089,7 @@
                   "version_added": "61"
                 },
                 "firefox_android": {
-                  "version_added": "61"
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": false


### PR DESCRIPTION
Firefox for desktop: https://searchfox.org/mozilla-central/rev/e126996d9b0a3d7653de205898517f4f5b632e7f/browser/components/extensions/parent/ext-tabs.js#143

Firefox for Android: https://searchfox.org/mozilla-central/rev/e126996d9b0a3d7653de205898517f4f5b632e7f/mobile/android/components/extensions/ext-tabs.js#171