### PR TITLE
Firefox doesn't support clipboard permissions

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -552,10 +552,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null
@@ -588,7 +588,7 @@
       },
       "clipboard-write_permission": {
         "__compat": {
-          "description": "<code>camera</code> permission",
+          "description": "<code>clipboard-write</code> permission",
           "support": {
             "chrome": {
               "version_added": "64"
@@ -603,10 +603,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
Set support flag to false for both clipboard-read and
clipboard-write permissions. Fix the
description of clipboard-write_permission to say
"clipboard-write" instead of "camera".