### PR TITLE
More Element subfeatures

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2737,43 +2737,50 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/querySelector",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
-            "ie": {
-              "version_added": null
-            },
+            "ie": [
+              {
+                "version_added": "9"
+              },
+              {
+                "version_added": "8",
+                "partial_implementation": true,
+                "notes": "<code>querySelector()</code> is supported, but only for CSS 2.1 selectors."
+              }
+            ],
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -3387,43 +3387,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scrollLeft",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -397,9 +397,16 @@
             "chrome_android": {
               "version_added": true
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "12",
+                "notes": "Not supported for SVG elements.",
+                "partial_implementation": true
+              }
+            ],
             "edge_mobile": {
               "version_added": "12"
             },
@@ -410,9 +417,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "10",
-              "notes": "Not supported for SVG elements. This is fixed in Edge 16.16299.",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -438,7 +443,7 @@
         },
         "toggle_method_second_argument": {
           "__compat": {
-            "description": "<code>toggle()</code> method's second argument.",
+            "description": "<code>toggle()</code> method's second argument",
             "support": {
               "webview_android": {
                 "version_added": true
@@ -489,7 +494,7 @@
         },
         "add_and_remove_multiple_arguments": {
           "__compat": {
-            "description": "Multiple arguments for <code>add()</code> & <code>remove()</code>.",
+            "description": "Multiple arguments for <code>add()</code> & <code>remove()</code>",
             "support": {
               "webview_android": {
                 "version_added": true
@@ -2905,57 +2910,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "scope_pseudo_class": {
-          "__compat": {
-            "description": "<code>:scope</code> pseudo-class",
-            "support": {
-              "webview_android": {
-                "version_added": true
-              },
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "32"
-              },
-              "firefox_android": {
-                "version_added": "32"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "15"
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": "7"
-              },
-              "safari_ios": {
-                "version_added": "7"
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },

--- a/api/Element.json
+++ b/api/Element.json
@@ -287,28 +287,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/classList",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": true
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": null
-            },
-            "edge": {
               "version_added": true
             },
+            "edge": {
+              "version_added": "12"
+            },
             "edge_mobile": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10",
+              "notes": "Not supported for SVG elements. This is fixed in Edge 16.16299.",
+              "partial_implementation": true
             },
             "opera": {
               "version_added": true
@@ -317,10 +319,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -330,6 +332,159 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "toggle_method_second_argument": {
+          "__compat": {
+            "description": "<code>toggle()</code> method's second argument.",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "24"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "24"
+              },
+              "firefox_android": {
+                "version_added": "24"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "add_and_remove_multiple_arguments": {
+          "__compat": {
+            "description": "Multiple arguments for <code>add()</code> & <code>remove()</code>.",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": "24"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "26"
+              },
+              "firefox_android": {
+                "version_added": "26"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "replace": {
+          "__compat": {
+            "description": "<code>replace()</code>",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": "61"
+              },
+              "chrome_android": {
+                "version_added": "61"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": {
+                "version_added": "49"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/Element.json
+++ b/api/Element.json
@@ -2530,13 +2530,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ongotpointercapture",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "edge": {
               "version_added": null
@@ -2544,26 +2544,56 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
+            "firefox": [
+              {
+                "version_added": "59"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "10",
+                "prefix": "ms"
+              }
+            ],
             "opera": {
-              "version_added": null
+              "version_added": "42"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -2581,13 +2611,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/onlostpointercapture",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "edge": {
               "version_added": null
@@ -2595,26 +2625,56 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
+            "firefox": [
+              {
+                "version_added": "59"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "10",
+                "prefix": "ms"
+              }
+            ],
             "opera": {
-              "version_added": null
+              "version_added": "42"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/Element.json
+++ b/api/Element.json
@@ -2061,43 +2061,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/insertAdjacentHTML",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "8"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "8"
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
-              "version_added": null
+              "version_added": "7"
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -2795,49 +2795,107 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/querySelectorAll",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
-            "ie": {
-              "version_added": null
-            },
+            "ie": [
+              {
+                "version_added": "9"
+              },
+              {
+                "version_added": "8",
+                "partial_implementation": true,
+                "notes": "<code>querySelectorAll()</code> is supported, but only for CSS 2.1 selectors."
+              }
+            ],
             "opera": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "scope_pseudo_class": {
+          "__compat": {
+            "description": "<code>:scope</code> pseudo-class",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "32"
+              },
+              "firefox_android": {
+                "version_added": "32"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/Element.json
+++ b/api/Element.json
@@ -106,34 +106,34 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/animate",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "36"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "48"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "23"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "23"
             },
             "safari": {
               "version_added": null
@@ -149,6 +149,108 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "id_option": {
+          "__compat": {
+            "description": "<code>id</code> option",
+            "support": {
+              "webview_android": {
+                "version_added": "50"
+              },
+              "chrome": {
+                "version_added": "50"
+              },
+              "chrome_android": {
+                "version_added": "50"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "37"
+              },
+              "opera_android": {
+                "version_added": "37"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "composite_iterationcomposite_and_spacing_options": {
+          "__compat": {
+            "description": "<code>composite</code>, <code>iterationComposite</code>, and <code>spacing</code> options",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/Element.json
+++ b/api/Element.json
@@ -2632,43 +2632,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/outerHTML",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "11"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
-              "version_added": null
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -2839,13 +2839,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/releasePointerCapture",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "edge": {
               "version_added": null
@@ -2853,26 +2853,56 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
+            "firefox": [
+              {
+                "version_added": "59"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "10",
+                "prefix": "ms"
+              }
+            ],
             "opera": {
-              "version_added": null
+              "version_added": "42"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -3859,13 +3889,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/setPointerCapture",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "edge": {
               "version_added": null
@@ -3873,26 +3903,56 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
+            "firefox": [
+              {
+                "version_added": "59"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "10",
+                "prefix": "ms"
+              }
+            ],
             "opera": {
-              "version_added": null
+              "version_added": "42"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/Element.json
+++ b/api/Element.json
@@ -3438,43 +3438,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scrollLeftMax",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": "16"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "16"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -3540,43 +3540,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scrollTopMax",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": "16"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "16"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -3481,43 +3481,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scrollTop",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -4043,10 +4043,10 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": null
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "edge": {
               "version_added": null

--- a/api/Element.json
+++ b/api/Element.json
@@ -3328,43 +3328,51 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scrollHeight",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
-            "firefox": {
-              "version_added": null
-            },
+            "firefox": [
+              {
+                "version_added": "21"
+              },
+              {
+                "version_added": "3",
+                "version_removed": "21",
+                "partial_implementation": true,
+                "notes": "In Firefox versions prior to 21, when an element's content does not generate a vertical scrollbar, then its <code>scrollHeight</code> property is equal to its <code>clientHeight</code> property. This can mean either the content is too short to require a scrollbar or that the element has a CSS style <code>overflow</code> value of <code>visible</code> (non-scrollable)."
+              }
+            ],
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "8"
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "4"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -646,43 +646,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/clientHeight",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "6"
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -799,43 +799,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/clientWidth",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "6"
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
Part of #2494.

This PR adds/updates:
- [`Element.animate`](https://developer.mozilla.org/en-US/docs/Web/API/Element/animate) and its subfeatures
- [`Element.classList`](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList) and its subfeatures
- [`Element.clientWidth`](https://developer.mozilla.org/en-US/docs/Web/API/Element/clientWidth)
- [`Element.clientHeight`](https://developer.mozilla.org/en-US/docs/Web/API/Element/clientHeight)
- [`Element.tabStop`](https://developer.mozilla.org/en-US/docs/Web/API/Element/tabStop)
- [`Element.setPointerCapture`](https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture)
- [`Element.releasePointerCapture`](https://developer.mozilla.org/en-US/docs/Web/API/Element/releasePointerCapture)
- [`Element.ongotpointercapture`](https://developer.mozilla.org/en-US/docs/Web/API/Element/ongotpointercapture)
- [`Element.onlostpointercapture`](https://developer.mozilla.org/en-US/docs/Web/API/Element/onlostpointercapture)
- [`Element.scrollTop`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop)
- [`Element.scrollLeft`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft)
- [`Element.scrollTopMax`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTopMax)
- [`Element.scrollLeftMax`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeftMax)
- [`Element.scrollHeight`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight)
- [`Element.outerHTML`](https://developer.mozilla.org/en-US/docs/Web/API/Element/outerHTML)
- [`Element.querySelector`](https://developer.mozilla.org/en-US/docs/Web/API/Element/querySelector)
- [`Element.querySelectorAll`](https://developer.mozilla.org/en-US/docs/Web/API/Element/querySelectorAll)
- [`Element.insertAdjacentHTML`](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML)

These are pretty much all ported from their respective articles, except for `setPointerCapture`, `releasePointerCapture`, `ongotpointercapture`, and `onlostpointercapture`, which have tables with really weird data that links to seemingly(?) unrelated bugs like https://bugs.chromium.org/p/chromium/issues/detail?id=248918. I essentially took the data for these four from the [`PointerEvent` API article](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent) instead.

I've tried to keep each feature/set of features to a separate commit for ease of review, hopefully that helps :)