### PR TITLE
The opera now is supporting hasFocus method

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4066,10 +4066,10 @@
               "version_added": "6"
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true


### PR DESCRIPTION
We can learn from [here](https://www.opera.com/docs/specs/presto2.10/html5/). The opera supports this method since Opera Presto 2.10. But I did not test it actually.