### PR TITLE
Add compat data for Notification constructor.

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -171,6 +171,76 @@
           }
         }
       },
+      "Notification": {
+        "__compat": {
+          "description": "<code>Notification()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Notification/Notification",
+          "support": {
+            "webview_android": {
+              "version_added": false
+            },
+            "chrome": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "5",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "4",
+                "prefix": "moz"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "4",
+                "prefix": "moz"
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "25"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "actions": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Notification/actions",


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Notification/Notification

This doesn't include the numerous subfeatures as they're repetitive of the data in the original Notification API compat data.

Some of this data seems suspect to me, specifically Android WebView being false, but that's also `false` in the parent API data so I'd say that's out of scope for this PR.