### PR TITLE
Add note from "Geolocation API"

### DIFF
--- a/api/Geolocation.json
+++ b/api/Geolocation.json
@@ -17,7 +17,8 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "3.5"
+            "version_added": "3.5",
+            "note": "<a href='http://catb.org/gpsd/'>GPSD</a> (GPS daemon) support added in Firefox 3.6. WiFi-based location is provided by Google (<a href='https://support.mozilla.org/en-US/kb/does-firefox-share-my-location-websites'>privacy</a>) or a custom provider (<a href='https://wiki.mozilla.org/CloudServices/Location/Software'>MLS instructions</a>)."
           },
           "firefox_android": {
             "version_added": "4"

--- a/api/Geolocation.json
+++ b/api/Geolocation.json
@@ -18,7 +18,7 @@
           },
           "firefox": {
             "version_added": "3.5",
-            "note": "<a href='http://catb.org/gpsd/'>GPSD</a> (GPS daemon) support added in Firefox 3.6. WiFi-based location is provided by Google (<a href='https://support.mozilla.org/en-US/kb/does-firefox-share-my-location-websites'>privacy</a>) or a custom provider (<a href='https://wiki.mozilla.org/CloudServices/Location/Software'>MLS instructions</a>)."
+            "notes": "<a href='http://catb.org/gpsd/'>GPSD</a> (GPS daemon) support added in Firefox 3.6. WiFi-based location is provided by Google (<a href='https://support.mozilla.org/en-US/kb/does-firefox-share-my-location-websites'>privacy</a>) or a custom provider (<a href='https://wiki.mozilla.org/CloudServices/Location/Software'>MLS instructions</a>)."
           },
           "firefox_android": {
             "version_added": "4"


### PR DESCRIPTION
This commit moves the notes about Firefox at https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API$revision/1408651 into the note section.