### PR TITLE
Renaming offset-* logical properties

### DIFF
--- a/css/properties/inset-block-end.json
+++ b/css/properties/inset-block-end.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "offset-block-start": {
+      "inset-block-end": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-block-start",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-block-end",
           "support": {
             "webview_android": {
               "version_added": false
@@ -22,7 +22,12 @@
             },
             "firefox": [
               {
-                "version_added": "41"
+                "version_added": "63"
+              },
+              {
+                "alternative_name": "offset-block-end",
+                "version_added": "41",
+                "version_removed": "63"
               },
               {
                 "version_added": "38",
@@ -38,7 +43,12 @@
             ],
             "firefox_android": [
               {
-                "version_added": "41"
+                "version_added": "63"
+              },
+              {
+                "alternative_name": "offset-block-end",
+                "version_added": "41",
+                "version_removed": "63"
               },
               {
                 "version_added": "38",

--- a/css/properties/inset-block-start.json
+++ b/css/properties/inset-block-start.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "offset-block-end": {
+      "inset-block-start": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-block-end",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-block-start",
           "support": {
             "webview_android": {
               "version_added": false
@@ -22,7 +22,12 @@
             },
             "firefox": [
               {
-                "version_added": "41"
+                "version_added": "63"
+              },
+              {
+                "alternative_name": "offset-block-start",
+                "version_added": "41",
+                "version_removed": "63"
               },
               {
                 "version_added": "38",
@@ -38,7 +43,12 @@
             ],
             "firefox_android": [
               {
-                "version_added": "41"
+                "version_added": "63"
+              },
+              {
+                "alternative_name": "offset-block-start",
+                "version_added": "41",
+                "version_removed": "63"
               },
               {
                 "version_added": "38",

--- a/css/properties/inset-inline-end.json
+++ b/css/properties/inset-inline-end.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "offset-inline-end": {
+      "inset-inline-end": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-inline-end",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-inline-end",
           "support": {
             "webview_android": {
               "version_added": false
@@ -22,7 +22,12 @@
             },
             "firefox": [
               {
-                "version_added": "41"
+                "version_added": "63"
+              },
+              {
+                "alternative_name": "offset-inline-end",
+                "version_added": "41",
+                "version_removed": "63"
               },
               {
                 "version_added": "38",
@@ -38,7 +43,12 @@
             ],
             "firefox_android": [
               {
-                "version_added": "41"
+                "version_added": "63"
+              },
+              {
+                "alternative_name": "offset-inline-end",
+                "version_added": "41",
+                "version_removed": "63"
               },
               {
                 "version_added": "38",

--- a/css/properties/inset-inline-start.json
+++ b/css/properties/inset-inline-start.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "offset-inline-start": {
+      "inset-inline-start": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-inline-start",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-inline-start",
           "support": {
             "webview_android": {
               "version_added": false
@@ -22,7 +22,12 @@
             },
             "firefox": [
               {
-                "version_added": "41"
+                "version_added": "63"
+              },
+              {
+                "alternative_name": "offset-inline-start",
+                "version_added": "41",
+                "version_removed": "63"
               },
               {
                 "version_added": "38",
@@ -38,7 +43,12 @@
             ],
             "firefox_android": [
               {
-                "version_added": "41"
+                "version_added": "63"
+              },
+              {
+                "alternative_name": "offset-inline-start",
+                "version_added": "41",
+                "version_removed": "63"
               },
               {
                 "version_added": "38",


### PR DESCRIPTION
For Firefox 63 these properties have been renamed, I used the alternate name flag to supply the old name. Once these are merged as the file is renamed the pages will need to be updated too.

See: https://www.fxsitecompat.com/en-CA/docs/2018/offset-logical-properties-have-been-renamed-to-inset/