### PR TITLE
Update NetworkInformation for Firefox and Edge

### DIFF
--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -10,6 +10,9 @@
           "chrome_android": {
             "version_added": "38"
           },
+          "edge": {
+            "version_added": false
+          },
           "firefox": {
             "version_added": false
           },
@@ -50,6 +53,9 @@
             },
             "chrome_android": {
               "version_added": "38"
+            },
+            "edge": {
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -93,8 +99,11 @@
             "chrome_android": {
               "version_added": "38"
             },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
               "version_added": null
@@ -134,6 +143,9 @@
             },
             "chrome_android": {
               "version_added": "38"
+            },
+            "edge": {
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -177,6 +189,9 @@
             "chrome_android": {
               "version_added": "38"
             },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -218,6 +233,9 @@
             },
             "chrome_android": {
               "version_added": "38"
+            },
+            "edge": {
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -262,6 +280,9 @@
             "chrome_android": {
               "version_added": "38"
             },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -303,6 +324,9 @@
             },
             "chrome_android": {
               "version_added": "38"
+            },
+            "edge": {
+              "version_added": false
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This updates the NetworkInformation API info for Firefox and Edge. Tested using [https://googlechrome.github.io/samples/network-information/](https://googlechrome.github.io/samples/network-information/), with

- Microsoft Edge 42.17134.1.0
- Firefox Developer Edition 62.0b20