### PR TITLE
Add webview_android browser data

### DIFF
--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode",
         "support": {
           "webview_android": {
-            "version_added": "14"
+            "version_added": true
           },
           "chrome": {
             "version_added": "14"
@@ -367,7 +367,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/onended",
           "support": {
             "webview_android": {
-              "version_added": "14"
+              "version_added": true
             },
             "chrome": {
               "version_added": "14"
@@ -471,7 +471,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/start",
           "support": {
             "webview_android": {
-              "version_added": "14"
+              "version_added": true
             },
             "chrome": {
               "version_added": "14",
@@ -523,7 +523,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/stop",
           "support": {
             "webview_android": {
-              "version_added": "14"
+              "version_added": true
             },
             "chrome": {
               "version_added": "14"

--- a/api/AudioListener.json
+++ b/api/AudioListener.json
@@ -55,7 +55,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioListener/dopplerFactor",
           "support": {
             "webview_android": {
-              "version_added": "14",
+              "version_added": true,
               "version_removed": "56"
             },
             "chrome": {
@@ -648,7 +648,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioListener/setOrientation",
           "support": {
             "webview_android": {
-              "version_added": "14"
+              "version_added": true
             },
             "chrome": {
               "version_added": "14"
@@ -699,7 +699,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioListener/setPosition",
           "support": {
             "webview_android": {
-              "version_added": "14"
+              "version_added": true
             },
             "chrome": {
               "version_added": "14"

--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -9,7 +9,7 @@
               "version_added": "57"
             },
             {
-              "version_added": "14",
+              "version_added": true,
               "version_removed": "56",
               "alternative_name": "AudioSourceNode"
             }
@@ -108,7 +108,7 @@
                 "version_added": "57"
               },
               {
-                "version_added": "14",
+                "version_added": true,
                 "version_removed": "56",
                 "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
@@ -180,7 +180,7 @@
                 "version_added": "57"
               },
               {
-                "version_added": "14",
+                "version_added": true,
                 "version_removed": "56",
                 "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
@@ -252,7 +252,7 @@
                 "version_added": "57"
               },
               {
-                "version_added": "14",
+                "version_added": true,
                 "version_removed": "56",
                 "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -990,7 +990,7 @@
                 "version_added": "57"
               },
               {
-                "version_added": "33",
+                "version_added": "4.4.3",
                 "prefix": "webkit"
               }
             ],

--- a/api/BiquadFilterNode.json
+++ b/api/BiquadFilterNode.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BiquadFilterNode",
         "support": {
           "webview_android": {
-            "version_added": "14"
+            "version_added": true
           },
           "chrome": {
             "version_added": "14"
@@ -57,7 +57,7 @@
           "support": {
             "webview_android": {
               "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "notes": "Before version 59, the default values were not supported."
             },
             "chrome": {
               "version_added": "55",

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -558,7 +558,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/imageSmoothingEnabled",
           "support": {
             "webview_android": {
-              "version_added": "30"
+              "version_added": "4.4"
             },
             "chrome": [
               {

--- a/api/ChannelSplitterNode.json
+++ b/api/ChannelSplitterNode.json
@@ -5,8 +5,8 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ChannelSplitterNode",
         "support": {
           "webview_android": {
-            "version_added": "14",
-            "notes": "Starting in Chrome 56, <code>channelCountMode</code> is set to <code>explicit</code> and <code>channelCount</code> is fixed to the number of outputs, as per the latest spec."
+            "version_added": true,
+            "notes": "Starting in version 56, <code>channelCountMode</code> is set to <code>explicit</code> and <code>channelCount</code> is fixed to the number of outputs, as per the latest spec."
           },
           "chrome": {
             "version_added": "14",

--- a/api/ConstantSourceNode.json
+++ b/api/ConstantSourceNode.json
@@ -164,7 +164,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ConstantSourceNode/onended",
           "support": {
             "webview_android": {
-              "version_added": "14"
+              "version_added": true
             },
             "chrome": {
               "version_added": "14"
@@ -219,7 +219,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ConstantSourceNode/start",
           "support": {
             "webview_android": {
-              "version_added": "14"
+              "version_added": true
             },
             "chrome": {
               "version_added": "14"
@@ -274,7 +274,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ConstantSourceNode/stop",
           "support": {
             "webview_android": {
-              "version_added": "14"
+              "version_added": true
             },
             "chrome": {
               "version_added": "14"

--- a/api/ConvolverNode.json
+++ b/api/ConvolverNode.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ConvolverNode",
         "support": {
           "webview_android": {
-            "version_added": "14"
+            "version_added": true
           },
           "chrome": {
             "version_added": "14"
@@ -107,7 +107,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ConvolverNode/buffer",
           "support": {
             "webview_android": {
-              "version_added": "14"
+              "version_added": true
             },
             "chrome": {
               "version_added": "14"
@@ -158,7 +158,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ConvolverNode/normalize",
           "support": {
             "webview_android": {
-              "version_added": "14"
+              "version_added": true
             },
             "chrome": {
               "version_added": "14"

--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -41,7 +41,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": "11"
+            "version_added": true
           }
         },
         "status": {
@@ -181,7 +181,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "11"
+              "version_added": true
             }
           },
           "status": {

--- a/api/DOMHighResTimestamp.json
+++ b/api/DOMHighResTimestamp.json
@@ -38,7 +38,7 @@
             "version_added": "9"
           },
           "webview_android": {
-            "version_added": "6"
+            "version_added": true
           }
         },
         "status": {

--- a/api/DelayNode.json
+++ b/api/DelayNode.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DelayNode",
         "support": {
           "webview_android": {
-            "version_added": "14"
+            "version_added": true
           },
           "chrome": {
             "version_added": "14"

--- a/api/Document.json
+++ b/api/Document.json
@@ -1983,7 +1983,7 @@
             },
             "webview_android": [
               {
-                "version_added": "22",
+                "version_added": true,
                 "version_removed": "66"
               },
               {
@@ -2037,7 +2037,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "22"
+              "version_added": true
             }
           },
           "status": {
@@ -5617,7 +5617,7 @@
               "version_added": "7"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -6538,7 +6538,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "35"
+              "version_added": "37"
             }
           },
           "status": {
@@ -7151,7 +7151,7 @@
               "version_added": "7"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/DynamicsCompressorNode.json
+++ b/api/DynamicsCompressorNode.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DynamicsCompressorNode",
         "support": {
           "webview_android": {
-            "version_added": "14"
+            "version_added": true
           },
           "chrome": {
             "version_added": "14"
@@ -57,7 +57,7 @@
           "support": {
             "webview_android": {
               "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "notes": "Before version 59, the default values were not supported."
             },
             "chrome": {
               "version_added": "55",

--- a/api/Element.json
+++ b/api/Element.json
@@ -111,7 +111,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/animate",
           "support": {
             "webview_android": {
-              "version_added": "36"
+              "version_added": "37"
             },
             "chrome": {
               "version_added": "36"
@@ -1080,11 +1080,11 @@
             ],
             "webview_android": [
               {
-                "version_added": "35",
-                "notes": "In Chrome 45, the ability to have multiple shadow roots was deprecated."
+                "version_added": "37",
+                "notes": "In version 45, the ability to have multiple shadow roots was deprecated."
               },
               {
-                "version_added": "25",
+                "version_added": true,
                 "version_removed": true,
                 "prefix": "webkit"
               }

--- a/api/Event.json
+++ b/api/Event.json
@@ -86,7 +86,7 @@
               "version_added": "6"
             },
             "webview_android": {
-              "version_added": "15"
+              "version_added": true
             }
           },
           "status": {
@@ -520,7 +520,7 @@
               "version_added": "5"
             },
             "webview_android": {
-              "version_added": "18"
+              "version_added": true
             }
           },
           "status": {
@@ -786,7 +786,7 @@
             },
             "webview_android": {
               "version_added": "46",
-              "notes": "Starting with Chrome 53 and Opera 40, untrusted events do not invoke the default action."
+              "notes": "Starting with version 53, untrusted events do not invoke the default action."
             }
           },
           "status": {
@@ -1126,7 +1126,7 @@
               "version_added": "5"
             },
             "webview_android": {
-              "version_added": "6"
+              "version_added": true
             }
           },
           "status": {
@@ -1278,7 +1278,7 @@
             },
             "webview_android": {
               "version_added": "49",
-              "notes": "Starting with Chrome 49, Firefox 54 and Opera 36, this property returns <a href='https://developer.mozilla.org/docs/Web/API/DOMHighResTimeStamp'><code>DOMHighResTimeStamp</code></a> instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMTimeStamp'><code>DOMTimeStamp</code></a>."
+              "notes": "Starting with version 49, this property returns <a href='https://developer.mozilla.org/docs/Web/API/DOMHighResTimeStamp'><code>DOMHighResTimeStamp</code></a> instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMTimeStamp'><code>DOMTimeStamp</code></a>."
             }
           },
           "status": {

--- a/api/EventSource.json
+++ b/api/EventSource.json
@@ -38,7 +38,7 @@
             "version_added": "5"
           },
           "webview_android": {
-            "version_added": "6"
+            "version_added": true
           }
         },
         "status": {
@@ -134,7 +134,7 @@
               "version_added": "5"
             },
             "webview_android": {
-              "version_added": "9"
+              "version_added": true
             }
           },
           "status": {
@@ -181,7 +181,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": "26"
+                "version_added": true
               }
             },
             "status": {
@@ -230,7 +230,7 @@
               "version_added": "5"
             },
             "webview_android": {
-              "version_added": "6"
+              "version_added": true
             }
           },
           "status": {
@@ -278,7 +278,7 @@
               "version_added": "5"
             },
             "webview_android": {
-              "version_added": "6"
+              "version_added": true
             }
           },
           "status": {
@@ -326,7 +326,7 @@
               "version_added": "5"
             },
             "webview_android": {
-              "version_added": "6"
+              "version_added": true
             }
           },
           "status": {
@@ -374,7 +374,7 @@
               "version_added": "5"
             },
             "webview_android": {
-              "version_added": "6"
+              "version_added": true
             }
           },
           "status": {
@@ -422,7 +422,7 @@
               "version_added": "5"
             },
             "webview_android": {
-              "version_added": "6"
+              "version_added": true
             }
           },
           "status": {
@@ -470,7 +470,7 @@
               "version_added": "5"
             },
             "webview_android": {
-              "version_added": "6"
+              "version_added": true
             }
           },
           "status": {
@@ -518,7 +518,7 @@
               "version_added": "5"
             },
             "webview_android": {
-              "version_added": "6"
+              "version_added": true
             }
           },
           "status": {

--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace",
         "support": {
           "webview_android": {
-            "version_added": "35"
+            "version_added": "37"
           },
           "chrome": {
             "version_added": "35"
@@ -53,7 +53,7 @@
           "description": "<code>FontFace()</code> constructor",
           "support": {
             "webview_android": {
-              "version_added": "35"
+              "version_added": "37"
             },
             "chrome": {
               "version_added": "35"

--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet",
         "support": {
           "webview_android": {
-            "version_added": "35"
+            "version_added": "37"
           },
           "chrome": {
             "version_added": "35"
@@ -292,7 +292,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/check",
           "support": {
             "webview_android": {
-              "version_added": "35"
+              "version_added": "37"
             },
             "chrome": {
               "version_added": "35"
@@ -436,7 +436,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/load",
           "support": {
             "webview_android": {
-              "version_added": "35"
+              "version_added": "37"
             },
             "chrome": {
               "version_added": "35"
@@ -484,7 +484,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/ready",
           "support": {
             "webview_android": {
-              "version_added": "35"
+              "version_added": "37"
             },
             "chrome": {
               "version_added": "35"

--- a/api/GainNode.json
+++ b/api/GainNode.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GainNode",
         "support": {
           "webview_android": {
-            "version_added": "14"
+            "version_added": true
           },
           "chrome": {
             "version_added": "14"

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -2830,7 +2830,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "35"
+              "version_added": "37"
             }
           },
           "status": {
@@ -2906,7 +2906,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "35"
+              "version_added": "37"
             }
           },
           "status": {
@@ -2982,7 +2982,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "35"
+              "version_added": "37"
             }
           },
           "status": {
@@ -3058,7 +3058,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "35"
+              "version_added": "37"
             }
           },
           "status": {
@@ -3236,7 +3236,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "35"
+              "version_added": "37"
             }
           },
           "status": {
@@ -3312,7 +3312,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "35"
+              "version_added": "37"
             }
           },
           "status": {
@@ -3388,7 +3388,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "35"
+              "version_added": "37"
             }
           },
           "status": {
@@ -3464,7 +3464,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "35"
+              "version_added": "37"
             }
           },
           "status": {

--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -106,7 +106,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/download",
           "support": {
             "webview_android": {
-              "version_added": "14"
+              "version_added": true
             },
             "chrome": {
               "version_added": "14"

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -245,7 +245,7 @@
             },
             "webview_android": {
               "prefix": "webkit",
-              "version_added": "17",
+              "version_added": true,
               "notes": "Daily test builds only."
             }
           },
@@ -1942,7 +1942,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "4"
+              "version_added": true
             }
           },
           "status": {
@@ -2330,7 +2330,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "4"
+              "version_added": true
             }
           },
           "status": {

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -673,7 +673,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "34"
+              "version_added": "37"
             }
           },
           "status": {

--- a/api/HTMLShadowElement.json
+++ b/api/HTMLShadowElement.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLShadowElement",
         "support": {
           "webview_android": {
-            "version_added": "35"
+            "version_added": "37"
           },
           "chrome": {
             "version_added": "35"
@@ -71,7 +71,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLShadowElement/getDistributedNodes",
           "support": {
             "webview_android": {
-              "version_added": "35"
+              "version_added": "37"
             },
             "chrome": {
               "version_added": "35"

--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTemplateElement",
         "support": {
           "webview_android": {
-            "version_added": "26"
+            "version_added": true
           },
           "chrome": {
             "version_added": "26"
@@ -55,7 +55,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTemplateElement/content",
           "support": {
             "webview_android": {
-              "version_added": "26"
+              "version_added": true
             },
             "chrome": {
               "version_added": "26"

--- a/api/HTMLTrackElement.json
+++ b/api/HTMLTrackElement.json
@@ -66,7 +66,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": "23"
+            "version_added": true
           }
         },
         "status": {
@@ -139,7 +139,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "23"
+              "version_added": true
             }
           },
           "status": {
@@ -213,7 +213,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "23"
+              "version_added": true
             }
           },
           "status": {
@@ -287,7 +287,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "23"
+              "version_added": true
             }
           },
           "status": {
@@ -361,7 +361,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "23"
+              "version_added": true
             }
           },
           "status": {
@@ -437,7 +437,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "23"
+              "version_added": true
             }
           },
           "status": {
@@ -511,7 +511,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "23"
+              "version_added": true
             }
           },
           "status": {
@@ -585,7 +585,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "23"
+              "version_added": true
             }
           },
           "status": {

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -703,7 +703,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -6,10 +6,10 @@
         "support": {
           "webview_android": [
             {
-              "version_added": "24"
+              "version_added": true
             },
             {
-              "version_added": "23",
+              "version_added": true,
               "version_removed": "57",
               "prefix": "webkit"
             }
@@ -106,10 +106,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }

--- a/api/IDBCursorWithValue.json
+++ b/api/IDBCursorWithValue.json
@@ -6,10 +6,10 @@
         "support": {
           "webview_android": [
             {
-              "version_added": "24"
+              "version_added": true
             },
             {
-              "version_added": "23",
+              "version_added": true,
               "version_removed": "57",
               "prefix": "webkit"
             }

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -6,10 +6,10 @@
         "support": {
           "webview_android": [
             {
-              "version_added": "24"
+              "version_added": true
             },
             {
-              "version_added": "23",
+              "version_added": true,
               "version_removed": "57",
               "prefix": "webkit"
             }
@@ -95,7 +95,7 @@
                 "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }

--- a/api/IDBEnvironment.json
+++ b/api/IDBEnvironment.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBEnvironment",
         "support": {
           "webview_android": {
-            "version_added": "24"
+            "version_added": true
           },
           "chrome": [
             {

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -6,10 +6,10 @@
         "support": {
           "webview_android": [
             {
-              "version_added": "24"
+              "version_added": true
             },
             {
-              "version_added": "23",
+              "version_added": true,
               "version_removed": "57",
               "prefix": "webkit"
             }
@@ -143,11 +143,11 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
-                "version_removed": "24",
+                "version_added": true,
+                "version_removed": true,
                 "prefix": "webkit"
               }
             ],
@@ -216,11 +216,11 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
-                "version_removed": "24",
+                "version_added": true,
+                "version_removed": true,
                 "prefix": "webkit"
               }
             ],
@@ -289,11 +289,11 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
-                "version_removed": "24",
+                "version_added": true,
+                "version_removed": true,
                 "prefix": "webkit"
               }
             ],

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -6,10 +6,10 @@
         "support": {
           "webview_android": [
             {
-              "version_added": "24"
+              "version_added": true
             },
             {
-              "version_added": "23",
+              "version_added": true,
               "version_removed": "57",
               "prefix": "webkit"
             }
@@ -194,11 +194,11 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
-                "version_removed": "24",
+                "version_added": true,
+                "version_removed": true,
                 "prefix": "webkit"
               }
             ],
@@ -318,11 +318,11 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
-                "version_removed": "24",
+                "version_added": true,
+                "version_removed": true,
                 "prefix": "webkit"
               }
             ],
@@ -391,11 +391,11 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
-                "version_removed": "24",
+                "version_added": true,
+                "version_removed": true,
                 "prefix": "webkit"
               }
             ],
@@ -515,11 +515,11 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
-                "version_removed": "24",
+                "version_added": true,
+                "version_removed": true,
                 "prefix": "webkit"
               }
             ],
@@ -588,11 +588,11 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
-                "version_removed": "24",
+                "version_added": true,
+                "version_removed": true,
                 "prefix": "webkit"
               }
             ],
@@ -661,11 +661,11 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
-                "version_removed": "24",
+                "version_added": true,
+                "version_removed": true,
                 "prefix": "webkit"
               }
             ],
@@ -734,11 +734,11 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
-                "version_removed": "24",
+                "version_added": true,
+                "version_removed": true,
                 "prefix": "webkit"
               }
             ],
@@ -933,11 +933,11 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
-                "version_removed": "24",
+                "version_added": true,
+                "version_removed": true,
                 "prefix": "webkit"
               }
             ],
@@ -1006,11 +1006,11 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
-                "version_removed": "24",
+                "version_added": true,
+                "version_removed": true,
                 "prefix": "webkit"
               }
             ],
@@ -1079,11 +1079,11 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
-                "version_removed": "24",
+                "version_added": true,
+                "version_removed": true,
                 "prefix": "webkit"
               }
             ],

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -6,10 +6,10 @@
         "support": {
           "webview_android": [
             {
-              "version_added": "24"
+              "version_added": true
             },
             {
-              "version_added": "23",
+              "version_added": true,
               "version_removed": "57",
               "prefix": "webkit"
             }
@@ -143,10 +143,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -230,10 +230,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -317,10 +317,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -404,10 +404,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -542,10 +542,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -629,10 +629,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -716,10 +716,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -803,10 +803,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -890,10 +890,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -977,10 +977,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -1064,10 +1064,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -1151,10 +1151,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -1397,10 +1397,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -1484,10 +1484,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -1571,10 +1571,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -1657,10 +1657,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }

--- a/api/IDBOpenDBRequest.json
+++ b/api/IDBOpenDBRequest.json
@@ -6,10 +6,10 @@
         "support": {
           "webview_android": [
             {
-              "version_added": "24"
+              "version_added": true
             },
             {
-              "version_added": "23",
+              "version_added": true,
               "version_removed": "57",
               "prefix": "webkit"
             }
@@ -143,10 +143,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -230,10 +230,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }

--- a/api/IDBRequest.json
+++ b/api/IDBRequest.json
@@ -6,10 +6,10 @@
         "support": {
           "webview_android": [
             {
-              "version_added": "24"
+              "version_added": true
             },
             {
-              "version_added": "23",
+              "version_added": true,
               "version_removed": "57",
               "prefix": "webkit"
             }
@@ -143,10 +143,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -6,10 +6,10 @@
         "support": {
           "webview_android": [
             {
-              "version_added": "24"
+              "version_added": true
             },
             {
-              "version_added": "23",
+              "version_added": true,
               "version_removed": "57",
               "prefix": "webkit"
             }
@@ -143,10 +143,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -230,10 +230,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }

--- a/api/IDBVersionChangeEvent.json
+++ b/api/IDBVersionChangeEvent.json
@@ -121,10 +121,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -208,10 +208,10 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "24"
+                "version_added": true
               },
               {
-                "version_added": "23",
+                "version_added": true,
                 "version_removed": "57",
                 "prefix": "webkit"
               }

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -670,7 +670,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardEvent/keyIdentifier",
           "support": {
             "webview_android": {
-              "version_added": "26",
+              "version_added": true,
               "version_removed": "54"
             },
             "chrome": {
@@ -983,7 +983,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardEvent/getModifierState",
           "support": {
             "webview_android": {
-              "version_added": "31"
+              "version_added": "4.4.3"
             },
             "chrome": {
               "version_added": "31"

--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaElementAudioSourceNode",
         "support": {
           "webview_android": {
-            "version_added": "14"
+            "version_added": true
           },
           "chrome": {
             "version_added": "14"
@@ -57,7 +57,7 @@
           "support": {
             "webview_android": {
               "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "notes": "Before version 59, the default values were not supported."
             },
             "chrome": {
               "version_added": "55",

--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "webview_android": {
-            "version_added": "9"
+            "version_added": true
           }
         },
         "status": {

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -48,7 +48,7 @@
             "version_added": "8"
           },
           "webview_android": {
-            "version_added": "33"
+            "version_added": "4.4.3"
           },
           "chrome_android": {
             "version_added": "33"
@@ -123,7 +123,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome_android": {
               "version_added": "33"
@@ -199,7 +199,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome_android": {
               "version_added": "33"
@@ -275,7 +275,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome_android": {
               "version_added": "33"
@@ -351,7 +351,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome_android": {
               "version_added": "33"
@@ -427,7 +427,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome_android": {
               "version_added": "33"
@@ -496,7 +496,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome_android": {
               "version_added": "33"
@@ -565,7 +565,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome_android": {
               "version_added": "33"
@@ -634,7 +634,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome_android": {
               "version_added": "33"
@@ -710,7 +710,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome_android": {
               "version_added": "33"
@@ -786,7 +786,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome_android": {
               "version_added": "33"
@@ -862,7 +862,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome_android": {
               "version_added": "33"
@@ -1022,7 +1022,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome_android": {
               "version_added": "33"

--- a/api/MediaStreamAudioDestinationNode.json
+++ b/api/MediaStreamAudioDestinationNode.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamAudioDestinationNode",
         "support": {
           "webview_android": {
-            "version_added": "14"
+            "version_added": true
           },
           "chrome": {
             "version_added": "14"

--- a/api/MediaStreamAudioSourceNode.json
+++ b/api/MediaStreamAudioSourceNode.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamAudioSourceNode",
         "support": {
           "webview_android": {
-            "version_added": "14"
+            "version_added": true
           },
           "chrome": {
             "version_added": "14"

--- a/api/MutationObserver.json
+++ b/api/MutationObserver.json
@@ -70,11 +70,11 @@
           },
           "webview_android": [
             {
-              "version_added": "26"
+              "version_added": true
             },
             {
-              "version_added": "18",
-              "version_removed": "26",
+              "version_added": true,
+              "version_removed": true,
               "prefix": "Webkit"
             }
           ]
@@ -156,11 +156,11 @@
             },
             "webview_android": [
               {
-                "version_added": "26"
+                "version_added": true
               },
               {
-                "version_added": "18",
-                "version_removed": "26",
+                "version_added": true,
+                "version_removed": true,
                 "prefix": "Webkit"
               }
             ]
@@ -213,7 +213,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "18"
+              "version_added": true
             }
           },
           "status": {
@@ -264,7 +264,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "18"
+              "version_added": true
             }
           },
           "status": {
@@ -315,7 +315,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "18"
+              "version_added": true
             }
           },
           "status": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -856,10 +856,10 @@
             },
             "webview_android": [
               {
-                "version_added": "35"
+                "version_added": "37"
               },
               {
-                "version_added": "21",
+                "version_added": true,
                 "prefix": "-webkit-"
               }
             ]
@@ -1161,7 +1161,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "35"
+              "version_added": "37"
             }
           },
           "status": {
@@ -2109,7 +2109,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "32",
+              "version_added": "4.4.3",
               "notes": [
                 "Beginning in version 55, this is not supported in cross-origin iframes.",
                 "Beginning in version 60, this method requires a user gesture. Otherwise it returns <code>false</code>."

--- a/api/NavigatorLanguage.json
+++ b/api/NavigatorLanguage.json
@@ -197,7 +197,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "32",
+              "version_added": "4.4.3",
               "notes": "In Chrome, <code>navigator.language</code> is the language of the browser UI, and is not guaranteed to be equal to <code>navigator.languages[0]</code>."
             }
           },

--- a/api/OfflineAudioCompletionEvent.json
+++ b/api/OfflineAudioCompletionEvent.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OfflineAudioCompletionEvent",
         "support": {
           "webview_android": {
-            "version_added": "14"
+            "version_added": true
           },
           "chrome": {
             "version_added": "14"
@@ -57,7 +57,7 @@
           "support": {
             "webview_android": {
               "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "notes": "Before version 59, the default values were not supported."
             },
             "chrome": {
               "version_added": "55",

--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OfflineAudioContext",
         "support": {
           "webview_android": {
-            "version_added": "14"
+            "version_added": true
           },
           "chrome": {
             "version_added": "14"
@@ -57,7 +57,7 @@
           "support": {
             "webview_android": {
               "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "notes": "Before version 59, the default values were not supported."
             },
             "chrome": {
               "version_added": "55",

--- a/api/OscillatorNode.json
+++ b/api/OscillatorNode.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OscillatorNode",
         "support": {
           "webview_android": {
-            "version_added": "14"
+            "version_added": true
           },
           "chrome": {
             "version_added": "14"
@@ -57,7 +57,7 @@
           "support": {
             "webview_android": {
               "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "notes": "Before version 59, the default values were not supported."
             },
             "chrome": {
               "version_added": "55",
@@ -314,7 +314,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OscillatorNode/setPeriodicWave",
           "support": {
             "webview_android": {
-              "version_added": "14"
+              "version_added": true
             },
             "chrome": {
               "version_added": "14"
@@ -365,7 +365,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OscillatorNode/start",
           "support": {
             "webview_android": {
-              "version_added": "14"
+              "version_added": true
             },
             "chrome": {
               "version_added": "14"
@@ -418,7 +418,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OscillatorNode/stop",
           "support": {
             "webview_android": {
-              "version_added": "14"
+              "version_added": true
             },
             "chrome": {
               "version_added": "14"

--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PannerNode",
         "support": {
           "webview_android": {
-            "version_added": "14"
+            "version_added": true
           },
           "chrome": {
             "version_added": "14"
@@ -57,7 +57,7 @@
           "support": {
             "webview_android": {
               "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "notes": "Before version 59, the default values were not supported."
             },
             "chrome": {
               "version_added": "55",
@@ -926,7 +926,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PannerNode/setVelocity",
           "support": {
             "webview_android": {
-              "version_added": "14",
+              "version_added": true,
               "version_removed": "56"
             },
             "chrome": {

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -594,7 +594,7 @@
               "version_added": "9"
             },
             "webview_android": {
-              "version_added": "25"
+              "version_added": true
             }
           },
           "status": {

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -32,7 +32,7 @@
             "version_added": "11"
           },
           "webview_android": {
-            "version_added": "11"
+            "version_added": true
           }
         },
         "status": {

--- a/api/PeriodicWave.json
+++ b/api/PeriodicWave.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PeriodicWave",
         "support": {
           "webview_android": {
-            "version_added": "14"
+            "version_added": true
           },
           "chrome": {
             "version_added": "14"

--- a/api/Position.json
+++ b/api/Position.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": "5"
+            "version_added": true
           }
         },
         "status": {
@@ -133,7 +133,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "5"
+              "version_added": true
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "5"
+              "version_added": true
             }
           },
           "status": {

--- a/api/PositionError.json
+++ b/api/PositionError.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": "5"
+            "version_added": true
           }
         },
         "status": {
@@ -133,7 +133,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "5"
+              "version_added": true
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "5"
+              "version_added": true
             }
           },
           "status": {

--- a/api/PositionOptions.json
+++ b/api/PositionOptions.json
@@ -53,7 +53,7 @@
             "version_added": null
           },
           "webview_android": {
-            "version_added": "5"
+            "version_added": true
           }
         },
         "status": {
@@ -167,7 +167,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "5"
+              "version_added": true
             }
           },
           "status": {
@@ -230,7 +230,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "5"
+              "version_added": true
             }
           },
           "status": {
@@ -293,7 +293,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "5"
+              "version_added": true
             }
           },
           "status": {

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel",
         "support": {
           "webview_android": {
-            "version_added": "29"
+            "version_added": "4.4"
           },
           "chrome": {
             "version_added": true
@@ -69,7 +69,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/binaryType",
           "support": {
             "webview_android": {
-              "version_added": "29"
+              "version_added": "4.4"
             },
             "chrome": {
               "version_added": true

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -49,7 +49,7 @@
             "version_added": "8"
           },
           "webview_android": {
-            "version_added": "33"
+            "version_added": "4.4.3"
           },
           "edge_mobile": {
             "version_added": true
@@ -119,7 +119,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true
@@ -190,7 +190,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true
@@ -261,7 +261,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true
@@ -432,7 +432,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true
@@ -503,7 +503,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true
@@ -574,7 +574,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true
@@ -645,7 +645,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true
@@ -716,7 +716,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true
@@ -787,7 +787,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true
@@ -872,7 +872,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": "17"
@@ -936,7 +936,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": "17"
@@ -1000,7 +1000,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": "17"
@@ -1064,7 +1064,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": "17"
@@ -1128,7 +1128,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": "17"
@@ -1199,7 +1199,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true
@@ -1362,7 +1362,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true
@@ -1433,7 +1433,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -63,7 +63,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": "33"
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -198,7 +198,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/SpeechSynthesis.json
+++ b/api/SpeechSynthesis.json
@@ -51,7 +51,7 @@
             "version_added": "7.1"
           },
           "webview_android": {
-            "version_added": "33"
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -65,7 +65,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesis/cancel",
           "support": {
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome": {
               "version_added": "33"
@@ -172,7 +172,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -233,7 +233,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -294,7 +294,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -355,7 +355,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -416,7 +416,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -477,7 +477,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -538,7 +538,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -599,7 +599,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/SpeechSynthesisErrorEvent.json
+++ b/api/SpeechSynthesisErrorEvent.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisErrorEvent",
         "support": {
           "webview_android": {
-            "version_added": "33"
+            "version_added": "4.4.3"
           },
           "chrome": {
             "version_added": "33"
@@ -65,7 +65,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisErrorEvent/error",
           "support": {
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome": {
               "version_added": "33"

--- a/api/SpeechSynthesisEvent.json
+++ b/api/SpeechSynthesisEvent.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisEvent",
         "support": {
           "webview_android": {
-            "version_added": "33"
+            "version_added": "4.4.3"
           },
           "chrome": {
             "version_added": "33"
@@ -65,7 +65,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisEvent/charIndex",
           "support": {
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome": {
               "version_added": "33"
@@ -126,7 +126,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisEvent/elapsedTime",
           "support": {
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome": {
               "version_added": "33"
@@ -187,7 +187,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisEvent/name",
           "support": {
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome": {
               "version_added": "33"
@@ -248,7 +248,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisEvent/utterance",
           "support": {
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome": {
               "version_added": "33"

--- a/api/SpeechSynthesisUtterance.json
+++ b/api/SpeechSynthesisUtterance.json
@@ -51,7 +51,7 @@
             "version_added": "7.1"
           },
           "webview_android": {
-            "version_added": "33"
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -112,7 +112,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -173,7 +173,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -234,7 +234,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -295,7 +295,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -356,7 +356,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -417,7 +417,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -478,7 +478,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -539,7 +539,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -600,7 +600,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -661,7 +661,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -722,7 +722,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -783,7 +783,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -844,7 +844,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -905,7 +905,7 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/SpeechSynthesisVoice.json
+++ b/api/SpeechSynthesisVoice.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisVoice",
         "support": {
           "webview_android": {
-            "version_added": "33"
+            "version_added": "4.4.3"
           },
           "chrome": {
             "version_added": "33"
@@ -65,7 +65,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisVoice/default",
           "support": {
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome": {
               "version_added": "33"
@@ -126,7 +126,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisVoice/lang",
           "support": {
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome": {
               "version_added": "33"
@@ -187,7 +187,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisVoice/localService",
           "support": {
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome": {
               "version_added": "33"
@@ -248,7 +248,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisVoice/name",
           "support": {
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome": {
               "version_added": "33"
@@ -309,7 +309,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisVoice/voiceURI",
           "support": {
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "chrome": {
               "version_added": "33"

--- a/api/Storage.json
+++ b/api/Storage.json
@@ -38,7 +38,7 @@
             "version_added": "3.2"
           },
           "webview_android": {
-            "version_added": "18"
+            "version_added": true
           }
         },
         "status": {
@@ -85,7 +85,7 @@
               "version_added": "3.2"
             },
             "webview_android": {
-              "version_added": "18"
+              "version_added": true
             }
           },
           "status": {
@@ -133,7 +133,7 @@
               "version_added": "3.2"
             },
             "webview_android": {
-              "version_added": "18"
+              "version_added": true
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": "3.2"
             },
             "webview_android": {
-              "version_added": "18"
+              "version_added": true
             }
           },
           "status": {
@@ -229,7 +229,7 @@
               "version_added": "3.2"
             },
             "webview_android": {
-              "version_added": "18"
+              "version_added": true
             }
           },
           "status": {
@@ -277,7 +277,7 @@
               "version_added": "3.2"
             },
             "webview_android": {
-              "version_added": "18"
+              "version_added": true
             }
           },
           "status": {
@@ -325,7 +325,7 @@
               "version_added": "3.2"
             },
             "webview_android": {
-              "version_added": "18"
+              "version_added": true
             }
           },
           "status": {

--- a/api/Text.json
+++ b/api/Text.json
@@ -74,7 +74,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "28"
+              "version_added": true
             }
           },
           "status": {
@@ -325,7 +325,7 @@
             "webview_android": {
               "version_added": true,
               "notes": [
-                "Before Chrome 30, the <code>offset</code> argument was optional."
+                "Before version 4.4, the <code>offset</code> argument was optional."
               ]
             }
           },

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -55,7 +55,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/width",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "4"

--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -26,7 +26,7 @@
             "version_added": "6"
           },
           "webview_android": {
-            "version_added": "30"
+            "version_added": "4.4"
           },
           "chrome_android": {
             "version_added": "18"
@@ -76,7 +76,7 @@
               "version_added": "6"
             },
             "webview_android": {
-              "version_added": "30"
+              "version_added": "4.4"
             },
             "chrome_android": {
               "version_added": "18"
@@ -127,7 +127,7 @@
               "version_added": "6"
             },
             "webview_android": {
-              "version_added": "30"
+              "version_added": "4.4"
             },
             "chrome_android": {
               "version_added": "18"
@@ -178,7 +178,7 @@
               "version_added": "6"
             },
             "webview_android": {
-              "version_added": "30"
+              "version_added": "4.4"
             },
             "chrome_android": {
               "version_added": "18"
@@ -229,7 +229,7 @@
               "version_added": "6"
             },
             "webview_android": {
-              "version_added": "30"
+              "version_added": "4.4"
             },
             "chrome_android": {
               "version_added": "18"
@@ -280,7 +280,7 @@
               "version_added": "6"
             },
             "webview_android": {
-              "version_added": "30"
+              "version_added": "4.4"
             },
             "chrome_android": {
               "version_added": "18"
@@ -331,7 +331,7 @@
               "version_added": "6"
             },
             "webview_android": {
-              "version_added": "30"
+              "version_added": "4.4"
             },
             "chrome_android": {
               "version_added": "18"
@@ -382,7 +382,7 @@
               "version_added": "6"
             },
             "webview_android": {
-              "version_added": "30"
+              "version_added": "4.4"
             },
             "chrome_android": {
               "version_added": "18"
@@ -436,7 +436,7 @@
               "version_added": "6"
             },
             "webview_android": {
-              "version_added": "30"
+              "version_added": "4.4"
             },
             "chrome_android": {
               "version_added": "18"
@@ -526,7 +526,7 @@
               "version_added": "6"
             },
             "webview_android": {
-              "version_added": "30"
+              "version_added": "4.4"
             },
             "chrome_android": {
               "version_added": "18"
@@ -577,7 +577,7 @@
               "version_added": "6"
             },
             "webview_android": {
-              "version_added": "30"
+              "version_added": "4.4"
             },
             "chrome_android": {
               "version_added": "18"

--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -41,7 +41,7 @@
             "version_added": "8"
           },
           "webview_android": {
-            "version_added": "33"
+            "version_added": "4.4.3"
           },
           "edge_mobile": {
             "version_added": true
@@ -103,7 +103,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true
@@ -166,7 +166,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true
@@ -229,7 +229,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true
@@ -292,7 +292,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true
@@ -350,7 +350,7 @@
               "version_added": "8"
             },
             "webview_android": {
-              "version_added": "33"
+              "version_added": "4.4.3"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/WaveShaperNode.json
+++ b/api/WaveShaperNode.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WaveShaperNode",
         "support": {
           "webview_android": {
-            "version_added": "14"
+            "version_added": true
           },
           "chrome": {
             "version_added": "14"

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -225,12 +225,17 @@
         "68": {
           "release_date": "2018-07-24",
           "release_notes": "https://chromereleases.googleblog.com/2018/07/chrome-for-android-update.html",
-          "status": "current"
+          "status": "retired"
         },
         "69": {
-          "status": "beta"
+          "release_date": "2018-09-06",
+          "release_notes": "https://chromereleases.googleblog.com/2018/09/chrome-for-android-update_6.html",
+          "status": "current"
         },
         "70": {
+          "status": "beta"
+        },
+        "71": {
           "status": "nightly"
         }
       }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -1,0 +1,239 @@
+{
+  "browsers": {
+    "webview_android": {
+      "name": "WebView Android",
+      "releases": {
+        "1": {
+          "release_date": "2008-09-23",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_version_history#Android_1.0_(API_1)",
+          "status": "retired"
+        },
+        "1.1": {
+          "release_date": "2009-02-09",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_version_history#Android_1.1_(API_2)",
+          "status": "retired"
+        },
+        "1.5": {
+          "release_date": "2009-04-27",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_Cupcake",
+          "status": "retired"
+        },
+        "1.6": {
+          "release_date": "2009-09-15",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_Donut",
+          "status": "retired"
+        },
+        "2": {
+          "release_date": "2009-10-26",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_Eclair",
+          "status": "retired"
+        },
+        "2.2": {
+          "release_date": "2010-05-20",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_Froyo",
+          "status": "retired"
+        },
+        "2.3": {
+          "release_date": "2010-12-06",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_Gingerbread",
+          "status": "retired"
+        },
+        "3": {
+          "release_date": "2011-02-22",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_Honeycomb",
+          "status": "retired"
+        },
+        "4": {
+          "release_date": "2011-10-18",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_Ice_Cream_Sandwich",
+          "status": "retired"
+        },
+        "4.1": {
+          "release_date": "2012-07-09",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_Jelly_Bean",
+          "status": "retired"
+        },
+        "4.2": {
+          "release_date": "2013-07-24",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_Jelly_Bean",
+          "status": "retired"
+        },
+        "4.4": {
+          "release_date": "2013-12-09",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_KitKat",
+          "status": "retired"
+        },
+        "4.4.3": {
+          "release_date": "2014-06-02",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_KitKat",
+          "status": "retired"
+        },
+        "37": {
+          "release_date": "2014-09-03",
+          "release_notes": "https://chromereleases.googleblog.com/2014/09/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "38": {
+          "release_date": "2014-10-08",
+          "release_notes": "https://chromereleases.googleblog.com/2014/10/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "39": {
+          "release_date": "2014-11-12",
+          "release_notes": "https://chromereleases.googleblog.com/2014/11/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "40": {
+          "release_date": "2015-01-21",
+          "release_notes": "https://chromereleases.googleblog.com/2015/01/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "41": {
+          "release_date": "2015-03-11",
+          "release_notes": "https://chromereleases.googleblog.com/2015/03/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "42": {
+          "release_date": "2015-04-15",
+          "release_notes": "https://chromereleases.googleblog.com/2015/04/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "43": {
+          "release_date": "2015-05-27",
+          "release_notes": "https://chromereleases.googleblog.com/2015/05/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "44": {
+          "release_date": "2015-07-29",
+          "release_notes": "https://chromereleases.googleblog.com/2015/07/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "45": {
+          "release_date": "2015-09-01",
+          "release_notes": "https://chromereleases.googleblog.com/2015/09/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "46": {
+          "release_date": "2015-10-14",
+          "release_notes": "https://chromereleases.googleblog.com/2015/10/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "47": {
+          "release_date": "2015-12-02",
+          "release_notes": "https://chromereleases.googleblog.com/2015/12/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "48": {
+          "release_date": "2016-01-26",
+          "release_notes": "https://chromereleases.googleblog.com/2016/01/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "49": {
+          "release_date": "2016-03-09",
+          "release_notes": "https://chromereleases.googleblog.com/2016/03/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "50": {
+          "release_date": "2016-04-13",
+          "status": "retired"
+        },
+        "51": {
+          "release_date": "2016-06-08",
+          "release_notes": "https://chromereleases.googleblog.com/2016/06/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "52": {
+          "release_date": "2016-07-27",
+          "release_notes": "https://chromereleases.googleblog.com/2016/07/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "53": {
+          "release_date": "2016-09-07",
+          "release_notes": "https://chromereleases.googleblog.com/2016/09/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "54": {
+          "release_date": "2016-10-19",
+          "release_notes": "https://chromereleases.googleblog.com/2016/10/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "55": {
+          "release_date": "2016-12-06",
+          "release_notes": "https://chromereleases.googleblog.com/2016/12/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "56": {
+          "release_date": "2017-02-01",
+          "release_notes": "https://chromereleases.googleblog.com/2017/02/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "57": {
+          "release_date": "2017-03-16",
+          "release_notes": "https://chromereleases.googleblog.com/2017/03/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "58": {
+          "release_date": "2017-04-25",
+          "release_notes": "https://chromereleases.googleblog.com/2017/04/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "59": {
+          "release_date": "2017-06-06",
+          "release_notes": "https://chromereleases.googleblog.com/2017/06/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "60": {
+          "release_date": "2017-08-01",
+          "release_notes": "https://chromereleases.googleblog.com/2017/08/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "61": {
+          "release_date": "2017-09-05",
+          "release_notes": "https://chromereleases.googleblog.com/2017/09/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "62": {
+          "release_date": "2017-10-24",
+          "release_notes": "https://chromereleases.googleblog.com/2017/10/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "63": {
+          "release_date": "2017-12-05",
+          "release_notes": "https://chromereleases.googleblog.com/2017/12/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "64": {
+          "release_date": "2018-01-23",
+          "release_notes": "https://chromereleases.googleblog.com/2018/01/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "65": {
+          "release_date": "2017-03-06",
+          "release_notes": "https://chromereleases.googleblog.com/2018/03/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "66": {
+          "release_date": "2017-04-17",
+          "release_notes": "https://chromereleases.googleblog.com/2018/04/chrome-for-android-update.html",
+          "status": "retired"
+        },
+        "67": {
+          "release_date": "2018-05-31",
+          "release_notes": "https://chromereleases.googleblog.com/2018/05/chrome-for-android-update_31.html",
+          "status": "retired"
+        },
+        "68": {
+          "release_date": "2018-07-24",
+          "release_notes": "https://chromereleases.googleblog.com/2018/07/chrome-for-android-update.html",
+          "status": "current"
+        },
+        "69": {
+          "status": "beta"
+        },
+        "70": {
+          "status": "nightly"
+        }
+      }
+    }
+  }
+}

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -125,7 +125,6 @@
         },
         "48": {
           "release_date": "2016-01-26",
-          "release_notes": "https://chromereleases.googleblog.com/2016/01/chrome-for-android-update.html",
           "status": "retired"
         },
         "49": {

--- a/css/at-rules/charset.json
+++ b/css/at-rules/charset.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@charset",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "2"

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -108,7 +108,7 @@
             "description": "WOFF 2",
             "support": {
               "webview_android": {
-                "version_added": "36"
+                "version_added": "37"
               },
               "chrome": {
                 "version_added": "36"

--- a/css/properties/-webkit-mask-box-image.json
+++ b/css/properties/-webkit-mask-box-image.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-box-image",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "1"

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -115,11 +115,11 @@
               },
               "webview_android": [
                 {
-                  "version_added": "29"
+                  "version_added": "4.4"
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "21"
+                  "version_added": true
                 }
               ]
             },

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -143,13 +143,13 @@
                   "version_added": "52"
                 },
                 {
-                  "version_added": "29",
+                  "version_added": "4.4",
                   "partial_implementation": true,
                   "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "21"
+                  "version_added": true
                 }
               ]
             },

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -102,16 +102,16 @@
               },
               "webview_android": [
                 {
-                  "version_added": "36"
+                  "version_added": "37"
                 },
                 {
-                  "version_added": "29",
+                  "version_added": "4.4",
                   "partial_implementation": true,
                   "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "21"
+                  "version_added": true
                 }
               ]
             },

--- a/css/properties/animation.json
+++ b/css/properties/animation.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "2.1",
+                "version_added": "2",
                 "notes": "The <a href='https://developer.mozilla.org/docs/Web/CSS/animation-fill-mode'><code>animation-fill-mode</code></a> property is not supported in Android browsers below 2.3."
               }
             ],

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "1"
@@ -56,7 +56,7 @@
             "description": "Multiple backgrounds",
             "support": {
               "webview_android": {
-                "version_added": "2.1"
+                "version_added": "2"
               },
               "chrome": {
                 "version_added": "1"

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -7,7 +7,7 @@
           "support": {
             "webview_android": {
               "prefix": "-webkit-",
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": [
               {
@@ -160,7 +160,7 @@
             "description": "<code>fill</code> keyword",
             "support": {
               "webview_android": {
-                "version_added": "18"
+                "version_added": true
               },
               "chrome": {
                 "version_added": true

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-radius",
           "support": {
             "webview_android": {
-              "version_added": "2.1",
+              "version_added": "2",
               "prefix": "-webkit-"
             },
             "chrome": [

--- a/css/properties/border-style.json
+++ b/css/properties/border-style.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-style",
           "support": {
             "webview_android": {
-              "version_added": "2.6"
+              "version_added": "3"
             },
             "chrome": {
               "version_added": "1"

--- a/css/properties/box-sizing.json
+++ b/css/properties/box-sizing.json
@@ -12,7 +12,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "2.1"
+                "version_added": "2"
               }
             ],
             "chrome": [

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -219,7 +219,7 @@
                   "alternative_name": "grid-gap"
                 },
                 {
-                  "version_added": "29",
+                  "version_added": "4.4",
                   "alternative_name": "grid-gap",
                   "flags": [
                     {

--- a/css/properties/columns.json
+++ b/css/properties/columns.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "2.1"
+                "version_added": "2"
               }
             ],
             "chrome": [

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -57,7 +57,7 @@
             "description": "<code>attr()</code>",
             "support": {
               "webview_android": {
-                "version_added": "2.1"
+                "version_added": "2"
               },
               "chrome": {
                 "version_added": "2"

--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counter-reset",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "2"

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -429,11 +429,11 @@
               },
               "webview_android": [
                 {
-                  "version_added": "29"
+                  "version_added": "4.4"
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "21"
+                  "version_added": true
                 }
               ]
             },
@@ -555,11 +555,11 @@
               },
               "webview_android": [
                 {
-                  "version_added": "29"
+                  "version_added": "4.4"
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "21"
+                  "version_added": true
                 }
               ]
             },
@@ -886,8 +886,8 @@
               },
               "webview_android": {
                 "version_added": true,
-                "version_removed": "32",
-                "notes": "Before Chrome 4, <code>run-in</code> was not supported before inline elements."
+                "version_removed": "4",
+                "notes": "Before version 4, <code>run-in</code> was not supported before inline elements."
               }
             },
             "status": {

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -886,7 +886,7 @@
               },
               "webview_android": {
                 "version_added": true,
-                "version_removed": "4",
+                "version_removed": "4.4.3",
                 "notes": "Before version 4, <code>run-in</code> was not supported before inline elements."
               }
             },

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -141,11 +141,11 @@
             },
             "webview_android": [
               {
-                "version_added": "29"
+                "version_added": "4.4"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": true
               }
             ]
           },

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -114,11 +114,11 @@
             },
             "webview_android": [
               {
-                "version_added": "29"
+                "version_added": "4.4"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": true
               }
             ]
           },

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -110,11 +110,11 @@
             ],
             "webview_android": [
               {
-                "version_added": "29"
+                "version_added": "4.4"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": true
               }
             ]
           },

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -111,11 +111,11 @@
             },
             "webview_android": [
               {
-                "version_added": "29"
+                "version_added": "4.4"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": true
               }
             ]
           },

--- a/css/properties/flex-shrink.json
+++ b/css/properties/flex-shrink.json
@@ -142,11 +142,11 @@
             },
             "webview_android": [
               {
-                "version_added": "29"
+                "version_added": "4.4"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": true
               }
             ]
           },

--- a/css/properties/flex-wrap.json
+++ b/css/properties/flex-wrap.json
@@ -54,11 +54,11 @@
             },
             "webview_android": [
               {
-                "version_added": "29"
+                "version_added": "4.4"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": true
               }
             ]
           },

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -129,11 +129,11 @@
             },
             "webview_android": [
               {
-                "version_added": "29"
+                "version_added": "4.4"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": true
               }
             ]
           },

--- a/css/properties/font-variant-ligatures.json
+++ b/css/properties/font-variant-ligatures.json
@@ -7,7 +7,7 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "34"
+                "version_added": "37"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/grid-column-end.json
+++ b/css/properties/grid-column-end.json
@@ -10,7 +10,7 @@
                 "version_added": "57"
               },
               {
-                "version_added": "29",
+                "version_added": "4.4",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/grid-column-start.json
+++ b/css/properties/grid-column-start.json
@@ -10,7 +10,7 @@
                 "version_added": "57"
               },
               {
-                "version_added": "29",
+                "version_added": "4.4",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/grid-column.json
+++ b/css/properties/grid-column.json
@@ -10,7 +10,7 @@
                 "version_added": "57"
               },
               {
-                "version_added": "29",
+                "version_added": "4.4",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -111,13 +111,13 @@
                   "version_added": "52"
                 },
                 {
-                  "version_added": "29",
+                  "version_added": "4.4",
                   "partial_implementation": true,
                   "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "21"
+                  "version_added": true
                 }
               ]
             },

--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -59,7 +59,7 @@
             "description": "<code>border<code>",
             "support": {
               "webview_android": {
-                "version_added": "2.1"
+                "version_added": "2"
               },
               "chrome": {
                 "version_added": "1"
@@ -110,7 +110,7 @@
             "description": "<code>content</content>",
             "support": {
               "webview_android": {
-                "version_added": "2.1"
+                "version_added": "2"
               },
               "chrome": {
                 "version_added": "1"
@@ -161,7 +161,7 @@
             "description": "<code>padding</code>",
             "support": {
               "webview_android": {
-                "version_added": "2.1"
+                "version_added": "2"
               },
               "chrome": {
                 "version_added": "1"
@@ -212,7 +212,7 @@
             "description": "<code>text</code>",
             "support": {
               "webview_android": {
-                "version_added": "2.1"
+                "version_added": "2"
               },
               "chrome": {
                 "version_added": "1"

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -7,7 +7,7 @@
           "support": {
             "webview_android": {
               "prefix": "-webkit-",
-              "version_added": "2.1",
+              "version_added": "2",
               "notes": "Initially, Android supported only <code>-webkit-</code> prefixed values for gradients (such as <code>-webkit-linear-gradient()</code>). Later, support for unprefixed values was added."
             },
             "chrome": {

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -216,7 +216,7 @@
             "support": {
               "webview_android": {
                 "prefix": "-webkit-",
-                "version_added": "2.1"
+                "version_added": "2"
               },
               "chrome": {
                 "prefix": "-webkit-",

--- a/css/properties/mask-repeat.json
+++ b/css/properties/mask-repeat.json
@@ -7,7 +7,7 @@
           "support": {
             "webview_android": {
               "prefix": "-webkit-",
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "prefix": "-webkit-",

--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -7,7 +7,7 @@
           "support": {
             "webview_android": [
               {
-                "version_added": "2.1"
+                "version_added": "2"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/object-fit.json
+++ b/css/properties/object-fit.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/object-fit",
           "support": {
             "webview_android": {
-              "version_added": "31"
+              "version_added": "4.4.3"
             },
             "chrome": {
               "version_added": "31"

--- a/css/properties/object-position.json
+++ b/css/properties/object-position.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/object-position",
           "support": {
             "webview_android": {
-              "version_added": "4.4.4"
+              "version_added": "4.4.3"
             },
             "chrome": {
               "version_added": "31"

--- a/css/properties/order.json
+++ b/css/properties/order.json
@@ -143,11 +143,11 @@
             },
             "webview_android": [
               {
-                "version_added": "29"
+                "version_added": "4.4"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": true
               }
             ]
           },

--- a/css/properties/orphans.json
+++ b/css/properties/orphans.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/orphans",
           "support": {
             "webview_android": {
-              "version_added": "25"
+              "version_added": "4.4"
             },
             "chrome": {
               "version_added": "25"

--- a/css/properties/orphans.json
+++ b/css/properties/orphans.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/orphans",
           "support": {
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": true
             },
             "chrome": {
               "version_added": "25"

--- a/css/properties/outline-style.json
+++ b/css/properties/outline-style.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/outline-style",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "1"

--- a/css/properties/pointer-events.json
+++ b/css/properties/pointer-events.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/pointer-events",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "1"

--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -10,7 +10,7 @@
                 "version_added": "47"
               },
               {
-                "version_added": "35",
+                "version_added": "37",
                 "version_removed": "47",
                 "flags": [
                   {

--- a/css/properties/touch-action.json
+++ b/css/properties/touch-action.json
@@ -7,7 +7,7 @@
           "description": "Level 1 values",
           "support": {
             "webview_android": {
-              "version_added": "36"
+              "version_added": "37"
             },
             "chrome": {
               "version_added": "36"
@@ -90,7 +90,7 @@
           "__compat": {
             "support": {
               "webview_android": {
-                "version_added": "36"
+                "version_added": "37"
               },
               "chrome": {
                 "version_added": "36"

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -7,7 +7,7 @@
           "support": {
             "webview_android": {
               "prefix": "-webkit-",
-              "version_added": "2.1",
+              "version_added": "2",
               "notes": "Android 2.3 has a bug where input forms will \"jump\" when typing, if any container element has a <code>-webkit-transform</code>."
             },
             "chrome": [

--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "2.1"
+                "version_added": "2"
               }
             ],
             "chrome": [

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "2.1"
+                "version_added": "2"
               }
             ],
             "chrome": [

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "2.1"
+                "version_added": "2"
               }
             ],
             "chrome": [

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -114,7 +114,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "6"
+                "version_added": true
               }
             ]
           },

--- a/css/selectors/checked.json
+++ b/css/selectors/checked.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:checked",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "1"

--- a/css/selectors/disabled.json
+++ b/css/selectors/disabled.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:disabled",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "1"

--- a/css/selectors/empty.json
+++ b/css/selectors/empty.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:empty",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "1"

--- a/css/selectors/enabled.json
+++ b/css/selectors/enabled.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:enabled",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "1"

--- a/css/selectors/first-of-type.json
+++ b/css/selectors/first-of-type.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:first-of-type",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "1"

--- a/css/selectors/last-of-type.json
+++ b/css/selectors/last-of-type.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:last-of-type",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "1"

--- a/css/selectors/matches.json
+++ b/css/selectors/matches.json
@@ -11,7 +11,7 @@
                 "version_added": "66"
               },
               {
-                "version_added": "12",
+                "version_added": true,
                 "alternative_name": ":-webkit-any"
               }
             ],

--- a/css/selectors/not.json
+++ b/css/selectors/not.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:not",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "1"

--- a/css/selectors/nth-last-of-type.json
+++ b/css/selectors/nth-last-of-type.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-last-of-type",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "4"

--- a/css/selectors/nth-of-type.json
+++ b/css/selectors/nth-of-type.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-of-type",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "1"

--- a/css/selectors/only-of-type.json
+++ b/css/selectors/only-of-type.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:only-of-type",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "1"

--- a/css/selectors/placeholder.json
+++ b/css/selectors/placeholder.json
@@ -99,7 +99,7 @@
               },
               {
                 "prefix": "-webkit-input-",
-                "version_added": "2.1"
+                "version_added": "2"
               }
             ]
           },

--- a/css/selectors/required.json
+++ b/css/selectors/required.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:required",
           "support": {
             "webview_android": {
-              "version_added": "4.4.4"
+              "version_added": "4.4.3"
             },
             "chrome": {
               "version_added": "10"

--- a/css/selectors/scope.json
+++ b/css/selectors/scope.json
@@ -81,7 +81,7 @@
             "description": "Support in DOM API such as in <code>querySelector()</code> and <code>querySelectorAll()</code>",
             "support": {
               "webview_android": {
-                "version_added": "4.4"
+                "version_added": true
               },
               "chrome": {
                 "version_added": "27"

--- a/css/selectors/scope.json
+++ b/css/selectors/scope.json
@@ -81,7 +81,7 @@
             "description": "Support in DOM API such as in <code>querySelector()</code> and <code>querySelectorAll()</code>",
             "support": {
               "webview_android": {
-                "version_added": "27"
+                "version_added": "4.4"
               },
               "chrome": {
                 "version_added": "27"

--- a/css/selectors/target.json
+++ b/css/selectors/target.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:target",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "1"

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -419,7 +419,7 @@
             "description": "<code>rem</code> unit",
             "support": {
               "webview_android": {
-                "version_added": "2.1"
+                "version_added": "2"
               },
               "chrome": {
                 "version_added": "4"

--- a/css/types/transform-function.json
+++ b/css/types/transform-function.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": true

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -755,7 +755,7 @@
           "__compat": {
             "support": {
               "webview_android": {
-                "version_added": "34"
+                "version_added": "37"
               },
               "chrome": {
                 "version_added": "34"

--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -42,11 +42,11 @@
               },
               "webview_android": [
                 {
-                  "version_added": "4.3"
+                  "version_added": "4.4"
                 },
                 {
-                  "version_added": "2.1",
-                  "version_removed": "4.3",
+                  "version_added": "2",
+                  "version_removed": "4.4",
                   "partial_implementation": true,
                   "notes": "Android WebView recognizes the <code>range</code> type, but doesn't implement a range-specific control."
                 }

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/template",
           "support": {
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": true
             },
             "chrome": {
               "version_added": "26"

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/template",
           "support": {
             "webview_android": {
-              "version_added": "26"
+              "version_added": "4.4"
             },
             "chrome": {
               "version_added": "26"

--- a/html/elements/track.json
+++ b/html/elements/track.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/track",
           "support": {
             "webview_android": {
-              "version_added": "25",
+              "version_added": "4.4",
               "notes": "Doesn’t work for fullscreen video."
             },
             "chrome": {
@@ -83,7 +83,7 @@
           "__compat": {
             "support": {
               "webview_android": {
-                "version_added": "25"
+                "version_added": "4.4"
               },
               "chrome": {
                 "version_added": "23"
@@ -159,7 +159,7 @@
           "__compat": {
             "support": {
               "webview_android": {
-                "version_added": "25"
+                "version_added": "4.4"
               },
               "chrome": {
                 "version_added": "23"
@@ -235,7 +235,7 @@
           "__compat": {
             "support": {
               "webview_android": {
-                "version_added": "25"
+                "version_added": "4.4"
               },
               "chrome": {
                 "version_added": "23"
@@ -311,7 +311,7 @@
           "__compat": {
             "support": {
               "webview_android": {
-                "version_added": "25"
+                "version_added": "4.4"
               },
               "chrome": {
                 "version_added": "23"
@@ -440,7 +440,7 @@
           "__compat": {
             "support": {
               "webview_android": {
-                "version_added": "25"
+                "version_added": "4.4"
               },
               "chrome": {
                 "version_added": "23"

--- a/html/elements/track.json
+++ b/html/elements/track.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/track",
           "support": {
             "webview_android": {
-              "version_added": "4.4",
+              "version_added": true,
               "notes": "Doesn’t work for fullscreen video."
             },
             "chrome": {

--- a/http/headers/access-control-allow-credentials.json
+++ b/http/headers/access-control-allow-credentials.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "4"

--- a/http/headers/access-control-allow-headers.json
+++ b/http/headers/access-control-allow-headers.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Access-Control-Allow-Headers",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "4"

--- a/http/headers/access-control-allow-methods.json
+++ b/http/headers/access-control-allow-methods.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Access-Control-Allow-Methods",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "4"

--- a/http/headers/access-control-allow-origin.json
+++ b/http/headers/access-control-allow-origin.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Access-Control-Allow-Origin",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "4"

--- a/http/headers/access-control-expose-headers.json
+++ b/http/headers/access-control-expose-headers.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Access-Control-Expose-Headers",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "4"

--- a/http/headers/access-control-max-age.json
+++ b/http/headers/access-control-max-age.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Access-Control-Max-Age",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "4"

--- a/http/headers/access-control-request-headers.json
+++ b/http/headers/access-control-request-headers.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Access-Control-Request-Headers",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "4"

--- a/http/headers/access-control-request-method.json
+++ b/http/headers/access-control-request-method.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Access-Control-Request-Method",
           "support": {
             "webview_android": {
-              "version_added": "2.1"
+              "version_added": "2"
             },
             "chrome": {
               "version_added": "4"

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -983,7 +983,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/referrer",
             "support": {
               "webview_android": {
-                "version_added": "33",
+                "version_added": "37",
                 "version_removed": "56"
               },
               "chrome": {

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -1008,7 +1008,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols",
             "support": {
               "webview_android": {
-                "version_added": "5.1"
+                "version_added": "38"
               },
               "chrome": {
                 "version_added": "38"

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -45,7 +45,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "4.4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -60,7 +60,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise",
             "support": {
               "webview_android": {
-                "version_added": "4.4.4"
+                "version_added": "4.4.3"
               },
               "chrome": {
                 "version_added": "32"
@@ -119,7 +119,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/all",
             "support": {
               "webview_android": {
-                "version_added": "4.4.4"
+                "version_added": "4.4.3"
               },
               "chrome": {
                 "version_added": "32"
@@ -173,7 +173,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/prototype",
             "support": {
               "webview_android": {
-                "version_added": "4.4.4"
+                "version_added": "4.4.3"
               },
               "chrome": {
                 "version_added": "32"
@@ -227,7 +227,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch",
             "support": {
               "webview_android": {
-                "version_added": "4.4.4"
+                "version_added": "4.4.3"
               },
               "chrome": {
                 "version_added": "32"
@@ -335,7 +335,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/then",
             "support": {
               "webview_android": {
-                "version_added": "4.4.4"
+                "version_added": "4.4.3"
               },
               "chrome": {
                 "version_added": "32"
@@ -389,7 +389,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/race",
             "support": {
               "webview_android": {
-                "version_added": "4.4.4"
+                "version_added": "4.4.3"
               },
               "chrome": {
                 "version_added": "32"
@@ -443,7 +443,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject",
             "support": {
               "webview_android": {
-                "version_added": "4.4.4"
+                "version_added": "4.4.3"
               },
               "chrome": {
                 "version_added": "32"
@@ -497,7 +497,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve",
             "support": {
               "webview_android": {
-                "version_added": "4.4.4"
+                "version_added": "4.4.3"
               },
               "chrome": {
                 "version_added": "32"

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap",
           "support": {
             "webview_android": {
-              "version_added": "36"
+              "version_added": "37"
             },
             "chrome": {
               "version_added": "36"
@@ -243,7 +243,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/clear",
             "support": {
               "webview_android": {
-                "version_added": "36",
+                "version_added": "37",
                 "version_removed": "43"
               },
               "chrome": {
@@ -306,7 +306,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/delete",
             "support": {
               "webview_android": {
-                "version_added": "36"
+                "version_added": "37"
               },
               "chrome": {
                 "version_added": "36"
@@ -373,7 +373,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/get",
             "support": {
               "webview_android": {
-                "version_added": "36"
+                "version_added": "37"
               },
               "chrome": {
                 "version_added": "36"
@@ -440,7 +440,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/has",
             "support": {
               "webview_android": {
-                "version_added": "36"
+                "version_added": "37"
               },
               "chrome": {
                 "version_added": "36"
@@ -507,7 +507,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/prototype",
             "support": {
               "webview_android": {
-                "version_added": "36"
+                "version_added": "37"
               },
               "chrome": {
                 "version_added": "36"
@@ -572,7 +572,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/set",
             "support": {
               "webview_android": {
-                "version_added": "36"
+                "version_added": "37"
               },
               "chrome": {
                 "version_added": "36"

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet",
           "support": {
             "webview_android": {
-              "version_added": "36"
+              "version_added": "37"
             },
             "chrome": {
               "version_added": "36"
@@ -167,7 +167,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/add",
             "support": {
               "webview_android": {
-                "version_added": "36"
+                "version_added": "37"
               },
               "chrome": {
                 "version_added": "36"
@@ -221,7 +221,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/clear",
             "support": {
               "webview_android": {
-                "version_added": "36",
+                "version_added": "37",
                 "version_removed": "43"
               },
               "chrome": {
@@ -282,7 +282,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/delete",
             "support": {
               "webview_android": {
-                "version_added": "36"
+                "version_added": "37"
               },
               "chrome": {
                 "version_added": "36"
@@ -336,7 +336,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/has",
             "support": {
               "webview_android": {
-                "version_added": "36"
+                "version_added": "37"
               },
               "chrome": {
                 "version_added": "36"
@@ -390,7 +390,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/prototype",
             "support": {
               "webview_android": {
-                "version_added": "36"
+                "version_added": "37"
               },
               "chrome": {
                 "version_added": "36"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1082,7 +1082,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for...of",
           "support": {
             "webview_android": {
-              "version_added": "5.1"
+              "version_added": "38"
             },
             "chrome": {
               "version_added": "38"

--- a/mathml/elements/math.json
+++ b/mathml/elements/math.json
@@ -54,8 +54,7 @@
               "version_added": "5.1"
             },
             "webview_android": {
-              "version_added": "24",
-              "version_removed": "26"
+              "version_added": false
             }
           },
           "status": {
@@ -152,8 +151,7 @@
                 "version_added": "5.1"
               },
               "webview_android": {
-                "version_added": "24",
-                "version_removed": "26"
+                "version_added": false
               }
             },
             "status": {
@@ -253,8 +251,7 @@
                 "version_added": "5.1"
               },
               "webview_android": {
-                "version_added": "24",
-                "version_removed": "26"
+                "version_added": false
               }
             },
             "status": {
@@ -304,8 +301,7 @@
                 "version_added": "5.1"
               },
               "webview_android": {
-                "version_added": "24",
-                "version_removed": "26"
+                "version_added": false
               }
             },
             "status": {
@@ -355,8 +351,7 @@
                 "version_added": "5.1"
               },
               "webview_android": {
-                "version_added": "24",
-                "version_removed": "26"
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
The fixes the last item on #591: Add release data (allowed versions) for `webview_android` and validate our compat data with it.

Some notes here:
- Android 4.4 is based on Chrome 30.
- Android 4.4.3 is based on Chrome 33.
- Android 5 had a webview based on Chrome 37 but also decoupled OS and browser, so the web engine can be updated separately. That means we can use Chrome Android version numbers from that point on.

@jpmedley can you have a look here? Does this allow-list for `webview_android` versions make sense to you?