### PR TITLE
Update Clipboard comments

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -78,7 +78,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "Firefox only supports reading the clipboard in browser extensions, using the <code>\"clipboardRead\"</code> extension permission."
+              "notes": "Currently works just like <code>readText()</code>; non-text content is not currently supported."
             },
             "firefox_android": {
               "version_added": "63",
@@ -89,7 +89,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "Firefox only supports reading the clipboard in browser extensions, using the <code>\"clipboardRead\"</code> extension permission."
+              "notes": "Currently works just like <code>readText()</code>; non-text content is not currently supported."
             },
             "ie": {
               "version_added": null
@@ -198,7 +198,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "Writing to the clipboard is available without permission in secure contexts and browser extensions, but only from user-initiated event callbacks. Browser extensions with the <code>\"clipboardWrite\"</code> permission can write to the clipboard at any time."
+              "notes": "Currently works exactly like <code>writeText()</code>, including the availability limitations currently imposed by Firefox."
             },
             "firefox_android": {
               "version_added": "63",
@@ -209,7 +209,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "Writing to the clipboard is available without permission in secure contexts and browser extensions, but only from user-initiated event callbacks. Browser extensions with the <code>\"clipboardWrite\"</code> permission can write to the clipboard at any time."
+              "notes": "Currently works exactly like <code>writeText()</code>, including the availability limitations currently imposed by Firefox."
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
Apparently my last edits to the Clipboard.json file did not get pushed before the PR was merged. This PR adds the final changes I made, clarifying two descriptions by explaining that currently Firefox's implementations of read() and write() are functionally identical to readText() and writeText().