### PR TITLE
Update the data for ScreenOrientation

### DIFF
--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -20,10 +20,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": "43"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "43"
           },
           "ie": {
             "version_added": null
@@ -41,7 +41,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "5"
           }
         },
         "status": {
@@ -70,10 +70,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "43"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "ie": {
               "version_added": null
@@ -121,10 +121,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "43"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "ie": {
               "version_added": null
@@ -172,10 +172,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "43"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "ie": {
               "version_added": null
@@ -223,10 +223,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "43"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "ie": {
               "version_added": null
@@ -274,10 +274,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "43"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "ie": {
               "version_added": null

--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -14,10 +14,10 @@
             "version_added": "38"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "edge_mobile": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": "43"
@@ -26,7 +26,7 @@
             "version_added": "43"
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": "25"
@@ -35,10 +35,10 @@
             "version_added": "25"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -64,10 +64,10 @@
               "version_added": "38"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "43"
@@ -76,7 +76,7 @@
               "version_added": "43"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "25"
@@ -85,10 +85,10 @@
               "version_added": "25"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -115,10 +115,10 @@
               "version_added": "38"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "43"
@@ -127,7 +127,7 @@
               "version_added": "43"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "25"
@@ -136,10 +136,10 @@
               "version_added": "25"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -166,10 +166,10 @@
               "version_added": "38"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "43"
@@ -178,7 +178,7 @@
               "version_added": "43"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "25"
@@ -187,10 +187,10 @@
               "version_added": "25"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -217,10 +217,10 @@
               "version_added": "38"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "43"
@@ -229,7 +229,7 @@
               "version_added": "43"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "25"
@@ -238,10 +238,10 @@
               "version_added": "25"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -268,10 +268,10 @@
               "version_added": "38"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "43"
@@ -280,7 +280,7 @@
               "version_added": "43"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "25"
@@ -289,10 +289,10 @@
               "version_added": "25"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -41,7 +41,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": "5"
+            "version_added": "5.0"
           }
         },
         "status": {


### PR DESCRIPTION
https://developer.microsoft.com/en-us/microsoft-edge/platform/catalog/?q=specName%3Ascreen-orientation tells me that firefox supports all the subfeatures while https://caniuse.com/#feat=screen-orientation tells me that Firefox supports this API since version 44. I assumed that all subfeatures shipped in this version, because I was not able to find the correspond bugzilla ticket.
https://platform-status.mozilla.org/#screen-orientation marks it as shipped in Firefox 15, but that refers to an older version of the spec, which did not had the ScreenOrientation object (but methods on Screen instead)

Due to not finding the bugzilla issues related to this, I was not able to fill the `firefox_android` column (caniuse only provides info about the latest version of this browser, which seems to support it though)