### PR TITLE
Remove flex-grow alternative-name from IE11

### DIFF
--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -75,9 +75,15 @@
                 ]
               }
             ],
-            "ie": {
-              "version_added": "11"
-            },
+            "ie": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "11",
+                "alternative_name": "-ms-flex-positive"
+              }
+            ],
             "opera": [
               {
                 "version_added": "12.1"

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -80,7 +80,7 @@
                 "version_added": "11"
               },
               {
-                "version_added": "11",
+                "version_added": "10",
                 "alternative_name": "-ms-flex-positive"
               }
             ],

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -76,7 +76,6 @@
               }
             ],
             "ie": {
-              "alternative_name": "-ms-flex-positive",
               "version_added": "11"
             },
             "opera": [


### PR DESCRIPTION
This alternative_name is misleading. IE11 supports correctly named flex-grow: https://msdn.microsoft.com/en-us/ie/dn254947(v=vs.94)