### PR TITLE
Chrome 66+ supports Asynchronous Clipboard API

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -8,10 +8,10 @@
             "version_added": false
           },
           "chrome": {
-            "version_added": false
+            "version_added": "66"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "66"
           },
           "edge": {
             "version_added": null
@@ -29,10 +29,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": false
+            "version_added": "53"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "53"
           },
           "safari": {
             "version_added": null
@@ -125,10 +125,10 @@
               "version_added": false
             },
             "chrome": {
-              "version_added": false
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "edge": {
               "version_added": null
@@ -148,10 +148,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": "53"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": null
@@ -245,10 +245,10 @@
               "version_added": false
             },
             "chrome": {
-              "version_added": false
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "edge": {
               "version_added": null
@@ -268,10 +268,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": "53"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": null


### PR DESCRIPTION
Chrome 66 and Opera 53 support this API according to the following URL.

- https://www.chromestatus.com/feature/5861289330999296
- https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/epeaao7l13M
- https://developers.google.com/web/updates/2018/03/clipboardapi
- https://bugs.chromium.org/p/chromium/issues/detail?id=677564