### PR TITLE
Fix DataTransferItemList constructor key (DO NOT MERGE)

### DIFF
--- a/api/DataTransferItemList.json
+++ b/api/DataTransferItemList.json
@@ -47,9 +47,9 @@
           "deprecated": false
         }
       },
-      "DataTransferItem": {
+      "DataTransferItemList": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItemList/DataTransferItem",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItemList/DataTransferItemList",
           "description": "<code>DataTransferItemList[]</code>",
           "support": {
             "chrome": {


### PR DESCRIPTION
~~Introduced by #1764 and pointed out by @connorshea.~~

The actual bug was fixed by @Elchi3 in #2625.