### PR TITLE
Bug 1264182 - objectURL methods removed from ServiceWorker

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -183,12 +183,24 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "4"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
+            "firefox": [
+              {
+                "version_added": "63",
+                "notes": "<code>createObjectURL()</code> and <code>revokeobjectURL()</code> are no longer available within the context of a <code>SharedWorker</code>."
+              },
+              {
+                "version_added": "4"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63",
+                "notes": "<code>createObjectURL()</code> and <code>revokeobjectURL()</code> are no longer available within the context of a <code>SharedWorker</code>."
+              },
+              {
+                "version_added": "4"
+              }
+            ],
             "ie": {
               "version_added": "10"
             },
@@ -800,12 +812,24 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "4"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
+            "firefox": [
+              {
+                "version_added": "63",
+                "notes": "<code>createObjectURL()</code> and <code>revokeobjectURL()</code> are no longer available within the context of a <code>SharedWorker</code>."
+              },
+              {
+                "version_added": "4"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63",
+                "notes": "<code>createObjectURL()</code> and <code>revokeobjectURL()</code> are no longer available within the context of a <code>SharedWorker</code>."
+              },
+              {
+                "version_added": "4"
+              }
+            ],
             "ie": {
               "version_added": "10"
             },

--- a/api/URL.json
+++ b/api/URL.json
@@ -185,11 +185,11 @@
             },
             "firefox": {
               "version_added": "4",
-              "notes": "<code>createObjectURL()</code> is no longer available within the context of a <code>SharedWorker</code>."
+              "notes": "<code>createObjectURL()</code> is no longer available within the context of a <code>ServiceWorker</code>."
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "<code>createObjectURL()</code> is no longer available within the context of a <code>SharedWorker</code>."
+              "notes": "<code>createObjectURL()</code> is no longer available within the context of a <code>ServiceWorker</code>."
             },
             "ie": {
               "version_added": "10"
@@ -804,11 +804,11 @@
             },
             "firefox": {
               "version_added": "4",
-              "notes": "<code>revokeObjectURL()</code> is no longer available within the context of a <code>SharedWorker</code>."
+              "notes": "<code>revokeObjectURL()</code> is no longer available within the context of a <code>ServiceWorker</code>."
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "<code>revokeObjectURL()</code> is no longer available within the context of a <code>SharedWorker</code>."
+              "notes": "<code>revokeObjectURL()</code> is no longer available within the context of a <code>ServiceWorker</code>."
             },
             "ie": {
               "version_added": "10"

--- a/api/URL.json
+++ b/api/URL.json
@@ -183,24 +183,14 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": [
-              {
-                "version_added": "63",
-                "notes": "<code>createObjectURL()</code> and <code>revokeobjectURL()</code> are no longer available within the context of a <code>SharedWorker</code>."
-              },
-              {
-                "version_added": "4"
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63",
-                "notes": "<code>createObjectURL()</code> and <code>revokeobjectURL()</code> are no longer available within the context of a <code>SharedWorker</code>."
-              },
-              {
-                "version_added": "4"
-              }
-            ],
+            "firefox": {
+              "version_added": "4",
+              "notes": "<code>createObjectURL()</code> is no longer available within the context of a <code>SharedWorker</code>."
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "notes": "<code>createObjectURL()</code> is no longer available within the context of a <code>SharedWorker</code>."
+            },
             "ie": {
               "version_added": "10"
             },
@@ -812,24 +802,14 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": [
-              {
-                "version_added": "63",
-                "notes": "<code>createObjectURL()</code> and <code>revokeobjectURL()</code> are no longer available within the context of a <code>SharedWorker</code>."
-              },
-              {
-                "version_added": "4"
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63",
-                "notes": "<code>createObjectURL()</code> and <code>revokeobjectURL()</code> are no longer available within the context of a <code>SharedWorker</code>."
-              },
-              {
-                "version_added": "4"
-              }
-            ],
+            "firefox": {
+              "version_added": "4",
+              "notes": "<code>revokeObjectURL()</code> is no longer available within the context of a <code>SharedWorker</code>."
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "notes": "<code>revokeObjectURL()</code> is no longer available within the context of a <code>SharedWorker</code>."
+            },
             "ie": {
               "version_added": "10"
             },


### PR DESCRIPTION
Note that starting in Firefox 63, createObjectURL() and
revokeObjectURL() can no longer be used from ServiceWorker
contexts.