### PR TITLE
Add compat data for CSS `::-ms-value` pseudo-element

### DIFF
--- a/css/selectors/-ms-value.json
+++ b/css/selectors/-ms-value.json
@@ -48,6 +48,53 @@
             "standard_track": false,
             "deprecated": false
           }
+        },
+        "color": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/selectors/-ms-value.json
+++ b/css/selectors/-ms-value.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "-ms-value": {
+        "__compat": {
+          "description": "<code>::-ms-value</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-ms-value",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/-ms-value.json
+++ b/css/selectors/-ms-value.json
@@ -18,7 +18,7 @@
               },
               {
                 "version_added": "12",
-                "version_removed": "15",
+                "version_removed": "16",
                 "partial_implementation": true,
                 "notes": [
                   "Edge 12-15 do not render the <code>color</code> property on <code>&lt;input&gt;</code> elements with a pre-filled <code>value</code> until the user selects a range of text or changes the input's value."

--- a/css/selectors/-ms-value.json
+++ b/css/selectors/-ms-value.json
@@ -49,8 +49,9 @@
             "deprecated": false
           }
         },
-        "color": {
+        "input_color": {
           "__compat": {
+            "description": "<code>color</code> property on <code>&lt;input&gt;<code> elements",
             "support": {
               "chrome": {
                 "version_added": false

--- a/css/selectors/-ms-value.json
+++ b/css/selectors/-ms-value.json
@@ -13,7 +13,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": [
+                "Edge 12-15 do not render the <code>color</code> property on <code>&lt;input&gt;</code> elements with a pre-filled <code>value</code> until the user selects a range of text or changes the input's value."
+              ]
             },
             "edge_mobile": {
               "version_added": false
@@ -25,7 +28,10 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "10",
+              "notes": [
+                "IE 10-11 do not render the <code>color</code> property on <code>&lt;input&gt;</code> elements with a pre-filled <code>value</code> until the user selects a range of text or changes the input's value."
+              ]
             },
             "opera": {
               "version_added": false
@@ -47,54 +53,6 @@
             "experimental": false,
             "standard_track": false,
             "deprecated": false
-          }
-        },
-        "input_color": {
-          "__compat": {
-            "description": "<code>color</code> property on <code>&lt;input&gt;<code> elements",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
-            }
           }
         }
       }

--- a/css/selectors/-ms-value.json
+++ b/css/selectors/-ms-value.json
@@ -12,12 +12,19 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "12",
-              "notes": [
-                "Edge 12-15 do not render the <code>color</code> property on <code>&lt;input&gt;</code> elements with a pre-filled <code>value</code> until the user selects a range of text or changes the input's value."
-              ]
-            },
+            "edge": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "15",
+                "partial_implementation": true,
+                "notes": [
+                  "Edge 12-15 do not render the <code>color</code> property on <code>&lt;input&gt;</code> elements with a pre-filled <code>value</code> until the user selects a range of text or changes the input's value."
+                ]
+              }
+            ],
             "edge_mobile": {
               "version_added": false
             },
@@ -29,6 +36,7 @@
             },
             "ie": {
               "version_added": "10",
+              "partial_implementation": true,
               "notes": [
                 "IE 10-11 do not render the <code>color</code> property on <code>&lt;input&gt;</code> elements with a pre-filled <code>value</code> until the user selects a range of text or changes the input's value."
               ]


### PR DESCRIPTION
### Links

* [mdn.io/css/::-ms-value](https://mdn.io/css/::-ms-value)
* [Test page](https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/04_20_42_001/spec/mdc-select/issues/3496.html)

### Test markup

```html
<input class="test-input" value="Value">

<select class="test-select" autofocus>
  <option>Option 1</option>
  <option>Option 2</option>
</select>

<style>
  .test-input,
  .test-select {
    border: 0;
  }

  .test-input::-ms-value,
  .test-select::-ms-value {
    outline: 2px dotted red;
    background-color: transparent;
    color: red;
  }
</style>
```

### Browser support

I verified that the following browsers display `outline: 2px dotted red` on `<input>` and `<select>` elements:

| Browser | Supported? |
| --- | --- |
| IE 8 | ✘ No |
| IE 9 | ✘ No |
| IE 10 | ✔︎ Yes |
| IE 11 | ✔︎ Yes |
| Edge 14 | ✔︎ Yes |
| Edge 15 | ✔︎ Yes |
| Edge 16 | ✔︎ Yes |
| Edge 17 | ✔︎ Yes |

I wasn't able to test in Edge 12 or 13, but I'm assuming that they behave the same as IE 11.

### Buggy `color` rendering

IE 10-11 and Edge 12-15 have a bug that causes the `color` property to be ignored until the user selects a range of text or changes the input's value:

![ie 11 ms-value bug](https://user-images.githubusercontent.com/409245/44967679-e06a0600-aef7-11e8-9bd9-54017bfd3270.gif)

I added `notes` to `ie` and `edge`, but I'm not sure if that's the correct way to annotate a bug.