### PR TITLE
Add compat data for the webextension 'find' optional permission

### DIFF
--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -286,6 +286,28 @@
             }
           }
         },
+        "find": {
+          "__compat": {
+            "description": "<code>find</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "57"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "geolocation": {
           "__compat": {
             "description": "<code>geolocation</code>",


### PR DESCRIPTION
As can be seen in Firefox's source [code](https://dxr.mozilla.org/mozilla-central/rev/c2e3be6a1dd352b969a45f0b85e87674e24ad284/browser/components/extensions/schemas/find.json#10), the 'find' API is available
as an optional permission. According to [MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/find), this API landed in
Firefox 57 and is only available to Firefox.