### PR TITLE
Adding data for flow-relative values of the resize property

### DIFF
--- a/css/properties/resize.json
+++ b/css/properties/resize.json
@@ -112,7 +112,7 @@
         },
         "flow_relative_support": {
           "__compat": {
-            "description": "Support for flow-relative values block and inline",
+            "description": "Support for flow-relative values <code>block</code> and <code>inline</code>",
             "support": {
               "webview_android": {
                 "version_added": false

--- a/css/properties/resize.json
+++ b/css/properties/resize.json
@@ -109,6 +109,57 @@
               "deprecated": false
             }
           }
+        },
+        "flow_relative_support": {
+          "__compat": {
+            "description": "Support for flow-relative values block and inline",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "63"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
These are currently being worked on for Blink and WebKit, I don't believe they are implemented anywhere else.

https://bugzilla.mozilla.org/show_bug.cgi?id=1464786