### PR TITLE
fix(api): Add Firefox note about <marquee> implementing HTMLDivElement

### DIFF
--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -18,11 +18,17 @@
           },
           "firefox": {
             "version_added": false,
-            "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+            "notes": [
+              "<code>&lt;marquee&gt;</code> implements the <code>HTMLDivElement</code> interface.",
+              "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+            ]
           },
           "firefox_android": {
             "version_added": false,
-            "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+            "notes": [
+              "<code>&lt;marquee&gt;</code> implements the <code>HTMLDivElement</code> interface.",
+              "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+            ]
           },
           "ie": {
             "version_added": "2"

--- a/html/elements/marquee.json
+++ b/html/elements/marquee.json
@@ -18,10 +18,14 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "partial_implementation": true,
+              "notes": "Implements the <code>HTMLDivElement</code> interface."
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "partial_implementation": true,
+              "notes": "Implements the <code>HTMLDivElement</code> interface."
             },
             "ie": {
               "version_added": "2"


### PR DESCRIPTION
See [bug 1425874](https://bugzil.la/1425874) for more details.

Also, I’ve now documented information about [`HTMLMarqueeElement` to MDN](https://developer.mozilla.org/docs/Web/API/HTMLMarqueeElement).

---

See also: https://github.com/mdn/data/pull/279