### PR TITLE
Fix and improve compatibility of insertAdjacent*() methods

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2015,19 +2015,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/insertAdjacentElement",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "2.3"
             },
             "chrome": {
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
               "version_added": "48"
@@ -2042,16 +2042,16 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -2066,7 +2066,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/insertAdjacentHTML",
           "support": {
             "webview_android": {
-              "version_added": true
+              "version_added": "2.3"
             },
             "chrome": {
               "version_added": "1"
@@ -2094,13 +2094,13 @@
               "version_added": "7"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2118,19 +2118,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/insertAdjacentText",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "2.3"
             },
             "chrome": {
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
               "version_added": "48"
@@ -2145,16 +2145,16 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -2036,7 +2036,7 @@
               "version_added": "48"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -2087,7 +2087,8 @@
               "version_added": "8"
             },
             "ie": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "Before Internet Explorer 10, throws an \"Invalid target element for this operation.\" error when called on a <code>&lt;table&gt;</code>, <code>&lt;tbody&gt;</code>, <code>&lt;thead&gt;</code>, or <code>&lt;tr&gt;</code> element."
             },
             "opera": {
               "version_added": "7"
@@ -2138,7 +2139,7 @@
               "version_added": "48"
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true

--- a/api/Element.json
+++ b/api/Element.json
@@ -2018,13 +2018,13 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "48"
@@ -2069,13 +2069,13 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "8"
@@ -2121,13 +2121,13 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "48"

--- a/api/Element.json
+++ b/api/Element.json
@@ -2015,7 +2015,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/insertAdjacentElement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -2118,7 +2118,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/insertAdjacentText",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true

--- a/api/Element.json
+++ b/api/Element.json
@@ -2014,9 +2014,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/insertAdjacentElement",
           "support": {
-            "webview_android": {
-              "version_added": "2.3"
-            },
             "chrome": {
               "version_added": true
             },
@@ -2052,6 +2049,9 @@
             },
             "samsunginternet_android": {
               "version_added": true
+            },
+            "webview_android": {
+              "version_added": "2.3"
             }
           },
           "status": {
@@ -2065,9 +2065,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/insertAdjacentHTML",
           "support": {
-            "webview_android": {
-              "version_added": "2.3"
-            },
             "chrome": {
               "version_added": "1"
             },
@@ -2104,6 +2101,9 @@
             },
             "samsunginternet_android": {
               "version_added": true
+            },
+            "webview_android": {
+              "version_added": "2.3"
             }
           },
           "status": {
@@ -2117,9 +2117,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/insertAdjacentText",
           "support": {
-            "webview_android": {
-              "version_added": "2.3"
-            },
             "chrome": {
               "version_added": true
             },
@@ -2155,6 +2152,9 @@
             },
             "samsunginternet_android": {
               "version_added": true
+            },
+            "webview_android": {
+              "version_added": "2.3"
             }
           },
           "status": {


### PR DESCRIPTION
Follow-up to #2316.

* [insertAdjacentHTML](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML): added in IE 4, issues with tables before IE 10
  * refs: [Can I use...](https://caniuse.com/#feat=insertadjacenthtml) – [article by John Resig](https://johnresig.com/blog/dom-insertadjacenthtml/)
* [insertAdjacentElement](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentElement) and [insertAdjacentText](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentText): added at least in IE 6, probably before but didn't find the version, so version unknown
  * refs: [Can I use...](https://caniuse.com/#feat=insert-adjacent)