### PR TITLE
Fix Chrome version for parseFromString (HTML) support

### DIFF
--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -244,7 +244,7 @@
             "description": "HTML (<code>text/html</code>) support",
             "support": {
               "chrome": {
-                "version_added": "30"
+                "version_added": "31"
               },
               "chrome_android": {
                 "version_added": null


### PR DESCRIPTION
References:
* [Can I use... - DOM Parsing and Serialization](https://caniuse.com/#search=innerhtml)
* https://github.com/Fyrd/caniuse/issues/4267