### PR TITLE
Add browser support info for innerHTML

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1964,43 +1964,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/innerHTML",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": true
             },
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
-              "version_added": null
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             }
           },
           "status": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -1963,9 +1963,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/innerHTML",
           "support": {
-            "webview_android": {
-              "version_added": true
-            },
             "chrome": {
               "version_added": "1"
             },
@@ -2001,6 +1998,9 @@
             },
             "samsunginternet_android": {
               "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
Basically it's the minimum version of each browser, except:
* Internet Explorer 4 (reference: [[1]](https://humanwhocodes.com/blog/2012/08/22/the-innovations-of-internet-explorer/))
* Opera 7 (references : [[1]](https://www.opera.com/docs/specs/opera7/), [[2]](https://www.opera.com/docs/specs/opera7/js/dom/html/), [[3]](https://www.experts-exchange.com/questions/20583698/innerHTML-in-Opera-6.html))
* Couldn't confirm the exact version with 100% certainty for Opera Mobile and Safari, so I left them out