### PR TITLE
Add compat data for the webextension 'tabHide' optional permission

### DIFF
--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -440,6 +440,28 @@
             }
           }
         },
+        "tabHide": {
+          "__compat": {
+            "description": "<code>tabHide</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "61"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "tabs": {
           "__compat": {
             "description": "<code>tabs</code>",


### PR DESCRIPTION
The tabHide permission, along with the activeTab and tabs permission,
can be [optional](https://dxr.mozilla.org/mozilla-central/rev/c2e3be6a1dd352b969a45f0b85e87674e24ad284/browser/components/extensions/schemas/tabs.json#16). According to [MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/hide), tabHide has been available to
Firefox Desktop since version 61.