### PR TITLE
Nodejs 10.9.0

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -60,6 +60,10 @@
         "10.4.0": {
           "release_date": "2018-06-06",
           "release_notes": "https://nodejs.org/en/blog/release/v10.4.0/"
+        },
+        "10.9.0": {
+          "release_date": "2018-08-16",
+          "release_notes": "https://nodejs.org/en/blog/release/v10.9.0/"
         }
       }
     }

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -2302,6 +2302,9 @@
                 {
                   "version_added": "0.12",
                   "version_removed": "4.0.0"
+                },
+                {
+                  "version_added": "10.9.0"
                 }
               ],
               "opera": {

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -2290,6 +2290,9 @@
               },
               "nodejs": [
                 {
+                  "version_added": "10.9.0"
+                },
+                {
                   "version_added": "6.5.0",
                   "notes": "The <code>--harmony-array-prototype-values</code> flag is required; the <code>--harmony</code> flag is not sufficient in this case.",
                   "flags": [
@@ -2302,9 +2305,6 @@
                 {
                   "version_added": "0.12",
                   "version_removed": "4.0.0"
-                },
-                {
-                  "version_added": "10.9.0"
                 }
               ],
               "opera": {


### PR DESCRIPTION
`Array.prototype.values` was added in Node.js 10.9.0. See [node.green](https://node.green/#ES2015-built-in-extensions-Array-prototype-methods-Array-prototype-values).

More precisely, `Array.prototype.values` was added in Node.js 0.12, removed in 4.0.0, and now added again. In this PR, I precisely mirrored this situation and added the following version info to [Array.json](https://github.com/mdn/browser-compat-data/blob/2348915f0933fb22277bc807cc4e82c83ff2c945/javascript/builtins/Array.json#L2291):

```json
{
  "version_added": "0.12",
  "version_removed": "4.0.0"
},
{
  "version_added": "10.9.0"
}
```

**Question: Is that too much?** The [Node.js box for Array.prototype.values() on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/values#Browser_compatibility) is already a bit crowded (because there's also version info for a flag) and the graphical rendering of `"version_added": "0.12", "version_removed": "4.0.0"` doesn't convey the meaning very well, I think:

![screenshot 2018-09-04 12 50 53](https://user-images.githubusercontent.com/607468/45027257-31394600-b041-11e8-95d8-37fcb4de24c9.png)

Maybe it would be better to remove the `{ "version_added": "0.12", "version_removed": "4.0.0" }` part and only keep the `{ "version_added": "10.9.0" }` part. What do you think? I'd be happy to update this PR accordingly.



