### PR TITLE
tabs.onHighlighted proper support

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1780,11 +1780,19 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "45"
-              },
+              "firefox": [
+                {
+                  "version_added": "63"
+                },
+                {
+                  "version_added": "45",
+                  "version_removed": "62",
+                  "notes": "Implemented as an alias for <code>onActivated</code>."
+                }
+              ],
               "firefox_android": {
-                "version_added": "54"
+                "version_added": "54",
+                "notes": "Implemented as an alias for <code>onActivated</code>."
               },
               "opera": {
                 "version_added": false


### PR DESCRIPTION
Firefox didn't support multiple tab selection before Firefox 63, so [`tabs.onHighlighted`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onHighlighted) was just an alias for `tabs.onActivated`. From 63 Firefox Desktop does support it, so `tabs.onHighlighted` is now fully supported on Desktop. On Android I think it is still an alias  for `tabs.onActivated`.

Implementation bug:
https://bugzilla.mozilla.org/show_bug.cgi?id=1474440

Diff for Desktop onHighlighted:
https://hg.mozilla.org/integration/autoland/diff/776150decf44/browser/components/extensions/parent/ext-tabs.js

Implementation on Android:
https://searchfox.org/mozilla-central/source/mobile/android/components/extensions/ext-tabs.js#117-127

