### PR TITLE
Add data for visible option to menus.create()

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -451,6 +451,27 @@
                 }
               }
             }
+          },
+          "visible": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "62"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "63"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
           }
         },
         "onClicked": {


### PR DESCRIPTION
Since version 62 Chrome has supported the `visible` option to the [`menus.create()`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/create) API.

Since version 63, Firefox does, too.

Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1482529.