### PR TITLE
Update 'upgrade-insecure-requests' safari compatibility

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1542,7 +1542,7 @@
                 "version_added": "30"
               },
               "safari": {
-                "version_added": "11.1"
+                "version_added": "10.1"
               },
               "safari_ios": {
                 "version_added": "10.3"

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1542,10 +1542,10 @@
                 "version_added": "30"
               },
               "safari": {
-                "version_added": false
+                "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "4.0"


### PR DESCRIPTION
I was recently looking into using this CSP header in a project, but was stopped in my tracks when I saw that it's unsupported in safari and safari iOS. Luckily a teammate pointed out that it is in fact supported in safari, at least according to caniuse.com: https://caniuse.com/#feat=upgradeinsecurerequests. It would be cool to update the compatibility table here https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests#Browser_compatibility so others don't run into the same issue.
![image](https://user-images.githubusercontent.com/4481594/45063994-3a490800-b07f-11e8-842e-9457ea70c018.png)
