### PR TITLE
update chrome browser data for Chrome 69 release

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -341,13 +341,17 @@
         "68": {
           "release_date": "2018-07-24",
           "release_notes": "https://chromereleases.googleblog.com/2018/07/stable-channel-update-for-desktop.html",
-          "status": "current"
+          "status": "retired"
         },
         "69": {
-          "release_date": "2018-09-04",
-          "status": "beta"
+          "release_date": "2018-09-05",
+          "release_notes": "https://chromereleases.googleblog.com/2018/09/stable-channel-update-for-desktop.html",
+          "status": "current"
         },
         "70": {
+          "status": "beta"
+        },
+        "71": {
           "status": "nightly"
         }
       }


### PR DESCRIPTION
[https://chromereleases.googleblog.com/2018/09/stable-channel-update-for-desktop.html](https://chromereleases.googleblog.com/2018/09/stable-channel-update-for-desktop.html)