### PR TITLE
feat(css): Add `gap` support in Multi-column Layout

### DIFF
--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -346,6 +346,67 @@
               }
             }
           }
+        },
+        "multicol_context": {
+          "__compat": {
+            "description": "Supported in Multi-column Layout",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gap",
+            "support": {
+              "chrome": {
+                "version_added": "66"
+              },
+              "chrome_android": {
+                "version_added": "66"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "61"
+              },
+              "firefox_android": {
+                "version_added": "61"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "53"
+              },
+              "opera_android": {
+                "version_added": "53"
+              },
+              "qq_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "uc_android": {
+                "version_added": null
+              },
+              "uc_chinese_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": "66"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Since `gap` is a shorthand property for `row-gap` and `column-gap`, it also affects Multi-column Layout.

review?(@Elchi3)