### PR TITLE
Firefox 52 ESR end of life

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -285,7 +285,7 @@
         "52": {
           "release_date": "2017-03-07",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/52",
-          "status": "esr"
+          "status": "retired"
         },
         "53": {
           "release_date": "2017-04-19",

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -231,7 +231,7 @@
         "52": {
           "release_date": "2017-03-07",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/52",
-          "status": "esr"
+          "status": "retired"
         },
         "53": {
           "release_date": "2017-04-19",


### PR DESCRIPTION
In addition to https://github.com/mdn/browser-compat-data/pull/2732 Firefox 52 ESR should be marked as retired