### PR TITLE
Bug 1419960 - Windows with noopener need standard features

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -820,10 +820,12 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "52"
+                  "version_added": "52",
+                  "notes": "Prior to Firefox 63, <code>rel=\"noopener\"</code> created windows with all features disabled by default. Starting with Firefox 63, these windows have the same features enabled by default as any other window."
                 },
                 "firefox_android": {
-                  "version_added": "52"
+                  "version_added": "52",
+                  "notes": "Prior to Firefox 63, <code>rel=\"noopener\"</code> created windows with all features disabled by default. Starting with Firefox 63, these windows have the same features enabled by default as any other window."
                 },
                 "ie": {
                   "version_added": false
@@ -845,7 +847,7 @@
                 }
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": false,
                 "deprecated": false
               }


### PR DESCRIPTION
Updated <link rel> information to say that noopener's
behavior has been changed on Firefox to no longer default
to creating windows with all window features disabled.