### PR TITLE
Note onCommand user action status

### DIFF
--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -57,7 +57,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "Before version 63, the <code>onCommand</code> listener was not treated as a <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/User_actions'>handler for a user action</a>."
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
-> https://bugzilla.mozilla.org/show_bug.cgi?id=1408129

WebExtension APIs have a concept of a "user action handler" (https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions). Before 63, Firefox did not treat a keyboard shortcut as a user action. This is fixed in 63.