### PR TITLE
Note access key support

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -410,6 +410,28 @@
               }
             }
           },
+          "accessKey": {
+            "__compat": {
+              "description": "<code>&</code> in <code>title</code> sets access key",
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "63"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
           "command": {
             "__compat": {
               "support": {


### PR DESCRIPTION
-> https://bugzilla.mozilla.org/show_bug.cgi?id=1320462

Firefox in version 63 added the ability to treat "&" in the `title` provided to [`menus.create()`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/create) as an access key for the item.

Already [supported in Chrome, apparently](https://bugzilla.mozilla.org/show_bug.cgi?id=1320462#c6), version unknown.

<img width="952" alt="screen shot 2018-09-05 at 3 42 57 pm" src="https://user-images.githubusercontent.com/432915/45125303-b9dbe300-b122-11e8-89ad-71f03662f390.png">
