### PR TITLE
Webrequest speculative

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -383,6 +383,27 @@
               }
             }
           },
+          "speculative": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "63"
+                },
+                "firefox_android": {
+                  "version_added": "63"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
           "web_manifest": {
             "__compat": {
               "support": {

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -224,6 +224,138 @@
               }
             }
           },
+          "beacon": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "csp_report": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "58"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "45"
+                }
+              }
+            }
+          },
+          "font": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "49"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "36"
+                }
+              }
+            }
+          },
+          "imageset": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "media": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "58"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": "45"
+                }
+              }
+            }
+          },
+          "object_subrequest": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "55",
+                  "notes": [
+                    "Requests have been reported as `object_subrequest` before, but the type was missing in the `ResourceType` object before Firefox 55."
+                  ]
+                },
+                "firefox_android": {
+                  "version_added": "55",
+                  "notes": [
+                    "Requests have been reported as `object_subrequest` before, but the type was missing in the `ResourceType` object before Firefox 55."
+                  ]
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
           "ping": {
             "__compat": {
               "support": {
@@ -251,11 +383,11 @@
               }
             }
           },
-          "font": {
+          "web_manifest": {
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "49"
+                  "version_added": false
                 },
                 "edge": {
                   "version_added": false
@@ -267,54 +399,12 @@
                   "version_added": "48"
                 },
                 "opera": {
-                  "version_added": "36"
-                }
-              }
-            }
-          },
-          "media": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "58"
-                },
-                "edge": {
                   "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": "45"
                 }
               }
             }
           },
           "websocket": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "58"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": "45"
-                }
-              }
-            }
-          },
-          "csp_report": {
             "__compat": {
               "support": {
                 "chrome": {
@@ -356,48 +446,6 @@
               }
             }
           },
-          "xslt": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            }
-          },
-          "beacon": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            }
-          },
           "xml_dtd": {
             "__compat": {
               "support": {
@@ -419,7 +467,7 @@
               }
             }
           },
-          "imageset": {
+          "xslt": {
             "__compat": {
               "support": {
                 "chrome": {
@@ -433,54 +481,6 @@
                 },
                 "firefox_android": {
                   "version_added": "48"
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            }
-          },
-          "web_manifest": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": {
-                  "version_added": false
-                }
-              }
-            }
-          },
-          "object_subrequest": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "55",
-                  "notes": [
-                    "Requests have been reported as `object_subrequest` before, but the type was missing in the `ResourceType` object before Firefox 55."
-                  ]
-                },
-                "firefox_android": {
-                  "version_added": "55",
-                  "notes": [
-                    "Requests have been reported as `object_subrequest` before, but the type was missing in the `ResourceType` object before Firefox 55."
-                  ]
                 },
                 "opera": {
                   "version_added": false


### PR DESCRIPTION
With the [`webRequest`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest) API extensions can use the [`ResourceType`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType) enumeration to intercept only requests for certain resource types.

Firefox 63 adds a new `ResourceType`, `"speculative"`. Desktop and Android.

-> https://bugzilla.mozilla.org/show_bug.cgi?id=1479565

This PR also orders the subfeatures of `ResourceType`, in a separate commit to make review easier (I hope).