### PR TITLE
Bug 1291515 / Bug 1444905 - Remove support for <style scoped>

### DIFF
--- a/api/HTMLStyleElement.json
+++ b/api/HTMLStyleElement.json
@@ -284,6 +284,7 @@
             "firefox": [
               {
                 "version_added": "55",
+                "version_removed": "61",
                 "flags": [
                   {
                     "type": "preference",
@@ -301,6 +302,7 @@
             "firefox_android": [
               {
                 "version_added": "55",
+                "version_removed": "61",
                 "flags": [
                   {
                     "type": "preference",

--- a/html/elements/style.json
+++ b/html/elements/style.json
@@ -227,12 +227,42 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "21"
-              },
-              "firefox_android": {
-                "version_added": "21"
-              },
+              "firefox": [
+                {
+                  "version_added": "55",
+                  "version_removed": "61",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.scoped-style.enabled",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": "This attribute was hidden behind a pref because no other browsers support it (See <a href='https://bugzil.la/1291515'>bug 1291515</a>)."
+                },
+                {
+                  "version_added": "21",
+                  "version_removed": "55"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "55",
+                  "version_removed": "61",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.scoped-style.enabled",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": "This attribute was hidden behind a pref because no other browsers support it (See <a href='https://bugzil.la/1291515'>bug 1291515</a>)."
+                },
+                {
+                  "version_added": "21",
+                  "version_removed": "55"
+                }
+              ],
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
## External links:
- https://bugzil.la/1291515
- https://bugzil.la/1444905
- https://www.fxsitecompat.com/en-CA/docs/2017/scoped-stylesheets-are-no-longer-supported/