### PR TITLE
Bug 1452569 - support Event.returnValue in Firefox

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -614,10 +614,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": false
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "ie": {
               "version_added": "6"
@@ -640,7 +640,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }


### PR DESCRIPTION
This updates Event.json to note Firefox support for
this property in 63.