### PR TITLE
Bug 218415 - Firefox 63 supports Window.event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1529,10 +1529,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "ie": {
               "version_added": true
@@ -1558,7 +1558,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
This is now supported in Firefox. Also, it is no longer
non-standard.