### PR TITLE
Add Edge support for the font-variation-settings CSS property.

### DIFF
--- a/css/properties/font-variation-settings.json
+++ b/css/properties/font-variation-settings.json
@@ -15,12 +15,10 @@
               "version_added": "62"
             },
             "edge": {
-              "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/fontvariationpropertieswithopentypevariablefontsupport/'>In development</a>."
+              "version_added": "17"
             },
             "edge_mobile": {
-              "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/fontvariationpropertieswithopentypevariablefontsupport/'>In development</a>."
+              "version_added": false
             },
             "firefox": [
               {

--- a/css/properties/font-variation-settings.json
+++ b/css/properties/font-variation-settings.json
@@ -18,7 +18,7 @@
               "version_added": "17"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": "17"
             },
             "firefox": [
               {


### PR DESCRIPTION
Resolves #2724.

https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings

Sources:
- [Edge Status](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/fontvariationpropertieswithopentypevariablefontsupport/)
- [caniuse](https://caniuse.com/#feat=variable-fontsc)

I'm not sure if Edge Mobile is built off the same engine as Edge, and I found no indication that it supported the property, so I left that as false for now.