### PR TITLE
Note Firefox 63 support for report-sample [DO NOT MERGE]

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1323,10 +1323,12 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "23"
+                "version_added": "23",
+                "notes": "Prior to Firefox 63, a sample was included in violation reports even if the <code>`report-sample`</code> expression was not present."
               },
               "firefox_android": {
-                "version_added": "23"
+                "version_added": "23",
+                "notes": "Prior to Firefox 63, a sample was included in violation reports even if the <code>`report-sample`</code> expression was not present."
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Previously, Firefox always included this info. Now the
expression is required.