### PR TITLE
Add data for Opera for "visible" parameter in menu api

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -490,7 +490,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": "49"
                 }
               }
             }


### PR DESCRIPTION
Opera support is apparently 49 -> https://bugzilla.mozilla.org/show_bug.cgi?id=1482529#c8.