### PR TITLE
Add data for set/get badge text color

### DIFF
--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -180,6 +180,28 @@
             }
           }
         },
+        "getBadgeTextColor": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getBadgeTextColor",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "63"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "getPopup": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getPopup",
@@ -532,6 +554,28 @@
                     "version_added": false
                   }
                 }
+              }
+            }
+          }
+        },
+        "setBadgeTextColor": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeTextColor",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "63"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
               }
             }
           }


### PR DESCRIPTION
[Bug 1424620](https://bugzilla.mozilla.org/show_bug.cgi?id=1424620) added 2 new methods to Firefox 63, desktop only:
* [`browserAction.getBadgeTextColor`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getBadgeTextColor)
* [`browserAction.setBadgeTextColor`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeTextColor)

-> https://hg.mozilla.org/integration/autoland/diff/d5950b441d27/browser/components/extensions/schemas/browser_action.json#l1.79
