### PR TITLE
Fix script integrity for Edge and Safari

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -219,7 +219,8 @@
                 "version_added": "45"
               },
               "edge": {
-                "version_added": false
+                "version_added": "17",
+                "partial_implementation": true
               },
               "edge_mobile": {
                 "version_added": false
@@ -234,14 +235,13 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null
               },
               "safari": {
-                "version_added": false,
-                "notes": "WebKit <a href='https://bugs.webkit.org/show_bug.cgi?id=148363'>bug 148363</a> tracks WebKit implementation of Subresource Integrity (which includes the <code>integrity</code> attribute)."
+                "version_added": true
               },
               "safari_ios": {
                 "version_added": false


### PR DESCRIPTION
Edge is added since [build 17063](https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/17063/) (also see [platform status page](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/subresourceintegrity/)). The referenced bug for WebKit has been fixed for a year.

Actually I have tested Opera myself and it seems to support this feature as well, but I can’t find any source. Shall I update the data cell for Opera in this case?