### PR TITLE
Add more Element subfeatures

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1487,7 +1487,7 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": true
@@ -1511,13 +1511,13 @@
             "description": "<code>x</code> and <code>y</code> properties",
             "support": {
               "webview_android": {
-                "version_added": null
+                "version_added": true
               },
               "chrome": {
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": false,
@@ -1537,10 +1537,10 @@
                 "notes": "Returns a <code>ClientRectList</code> with <a href='http://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a> objects (which do not contain <code>x</code> and <code>y</code> properties) instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMRect'><code>DOMRect</code></a> objects."
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": false
@@ -3264,15 +3264,15 @@
           "support": {
             "webview_android": {
               "version_added": true,
-              "alternative_name": "webkitRequestFullscreen"
+              "prefix": "webkit"
             },
             "chrome": {
-              "version_added": true,
-              "alternative_name": "webkitRequestFullscreen"
+              "version_added": "15",
+              "prefix": "webkit"
             },
             "chrome_android": {
               "version_added": true,
-              "alternative_name": "webkitRequestFullscreen"
+              "prefix": "webkit"
             },
             "edge": {
               "version_added": true
@@ -3315,14 +3315,30 @@
             ],
             "ie": {
               "version_added": "11",
-              "alternative_name": "msRequestFullscreen"
+              "prefix": "ms"
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "15",
+                "prefix": "o"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "14",
+                "prefix": "webkit"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "14",
+                "prefix": "o"
+              }
+            ],
             "safari": {
               "version_added": null
             },
@@ -3586,34 +3602,20 @@
               "edge_mobile": {
                 "version_added": null
               },
-              "firefox": [
-                {
-                  "version_added": "58",
-                  "notes": "No support for <code>inline</code> option."
-                },
-                {
-                  "version_added": "36",
-                  "version_removed": "58",
-                  "notes": [
-                    "No support for <code>inline</code> option.",
-                    "No support for <code>nearest</code> or <code>center</code> values for <code>block</code> option. See <a href='https://bugzil.la/1389274'>bug 1389274</a>."
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "58",
-                  "notes": "No support for <code>inline</code> option."
-                },
-                {
-                  "version_added": "36",
-                  "version_removed": "58",
-                  "notes": [
-                    "No support for <code>inline</code> option.",
-                    "No support for <code>nearest</code> or <code>center</code> values for <code>block</code> option. See <a href='https://bugzil.la/1389274'>bug 1389274</a>."
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "36",
+                "notes": [
+                  "No support for <code>inline</code> option.",
+                  "Before Firefox 58, <code>nearest</code> and <code>center</code> values for the <code>block</code> option was unsupported. See <a href='https://bugzil.la/1389274'>bug 1389274</a>."
+                ]
+              },
+              "firefox_android": {
+                "version_added": "36",
+                "notes": [
+                  "No support for <code>inline</code> option.",
+                  "Before Firefox 58, <code>nearest</code> and <code>center</code> values for the <code>block</code> option was unsupported. See <a href='https://bugzil.la/1389274'>bug 1389274</a>."
+                ]
+              },
               "ie": {
                 "version_added": false
               },

--- a/api/Element.json
+++ b/api/Element.json
@@ -3283,7 +3283,7 @@
             "firefox": [
               {
                 "version_added": "47",
-                "notes": "Before Firefox 44, Firefox incorrectly allowed elements inside a <code><frame></code> or an <code><object></code> to request, and to be granted, fullscreen. In Firefox 44 and onwards this has been fixed: only elements in the top-level document or in an <code><iframe></code> with the <code>allowfullscreen</code> attribute can be displayed fullscreen.",
+                "notes": "Before Firefox 44, Firefox incorrectly allowed elements inside a <code>&lt;frame&gt;</code> or an <code>&lt;object&gt;</code> to request, and to be granted, fullscreen. In Firefox 44 and onwards this has been fixed: only elements in the top-level document or in an <code><code>&lt;iframe&gt;</code></code> with the <code>allowfullscreen</code> attribute can be displayed fullscreen.",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/Element.json
+++ b/api/Element.json
@@ -1455,18 +1455,17 @@
             "deprecated": false
           }
         },
-        "width_and_height": {
+        "width": {
           "__compat": {
-            "description": "<code>width</code> and <code>height</code> properties",
             "support": {
               "webview_android": {
-                "version_added": null
+                "version_added": true
               },
               "chrome": {
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true
@@ -1506,9 +1505,110 @@
             }
           }
         },
-        "x_and_y": {
+        "height": {
           "__compat": {
-            "description": "<code>x</code> and <code>y</code> properties",
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "x": {
+          "__compat": {
+            "support": {
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false,
+                "notes": "Returns a <code>ClientRectList</code> with <a href='http://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a> objects (which do not contain <code>x</code> and <code>y</code> properties) instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMRect'><code>DOMRect</code></a> objects."
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false,
+                "notes": "Returns a <code>ClientRectList</code> with <a href='http://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a> objects (which do not contain <code>x</code> and <code>y</code> properties) instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMRect'><code>DOMRect</code></a> objects."
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "y": {
+          "__compat": {
             "support": {
               "webview_android": {
                 "version_added": true

--- a/api/Element.json
+++ b/api/Element.json
@@ -1418,19 +1418,19 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -1439,10 +1439,11 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "4",
+              "notes": "Safari for iOS will modify the effective viewport based on the user zoom. This results in incorrect values whenever the user has zoomed."
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1452,6 +1453,110 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "width_and_height": {
+          "__compat": {
+            "description": "<code>width</code> and <code>height</code> properties",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "x_and_y": {
+          "__compat": {
+            "description": "<code>x</code> and <code>y</code> properties",
+            "support": {
+              "webview_android": {
+                "version_added": null
+              },
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false,
+                "notes": "Returns a <code>ClientRectList</code> with <a href='http://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a> objects (which do not contain <code>x</code> and <code>y</code> properties) instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMRect'><code>DOMRect</code></a> objects."
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false,
+                "notes": "Returns a <code>ClientRectList</code> with <a href='http://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a> objects (which do not contain <code>x</code> and <code>y</code> properties) instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMRect'><code>DOMRect</code></a> objects."
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/Element.json
+++ b/api/Element.json
@@ -4070,19 +4070,21 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Returns a <code>ClientRectList</code> with <a href='http://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a> objects (which do not contain <code>x</code> and <code>y</code> properties) instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMRect'><code>DOMRect</code></a> objects."
             },
             "edge_mobile": {
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Returns a <code>ClientRectList</code> with <a href='http://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a> objects (which do not contain <code>x</code> and <code>y</code> properties) instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMRect'><code>DOMRect</code></a> objects."
             },
             "opera": {
               "version_added": null

--- a/api/Element.json
+++ b/api/Element.json
@@ -3457,7 +3457,7 @@
         },
         "returns_a_promise": {
           "__compat": {
-            "description": "Returns a Promise.",
+            "description": "Returns a <code>Promise</code>",
             "support": {
               "webview_android": {
                 "version_added": false

--- a/api/Element.json
+++ b/api/Element.json
@@ -3208,24 +3208,42 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/requestPointerLock",
           "support": {
-            "webview_android": {
-              "version_added": null
-            },
-            "chrome": {
-              "version_added": null
-            },
+            "webview_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ],
+            "chrome": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
-            "firefox": {
-              "version_added": null
-            },
+            "firefox": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": true,
+                "prefix": "moz"
+              }
+            ],
             "firefox_android": {
               "version_added": null
             },

--- a/api/Element.json
+++ b/api/Element.json
@@ -3429,7 +3429,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "8",

--- a/api/Element.json
+++ b/api/Element.json
@@ -3414,7 +3414,7 @@
               "version_added": true
             },
             "chrome": {
-              "version_added": true
+              "version_added": "29"
             },
             "chrome_android": {
               "version_added": true
@@ -3426,34 +3426,115 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "1"
             },
             "ie": {
-              "version_added": null
+              "version_added": "8",
+              "notes": "No support for <code>smooth</code> behavior or <code>center</code> options."
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
             },
             "opera_android": {
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "5",
+              "notes": "No support for <code>smooth</code> behavior or <code>center</code> options."
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5",
+              "notes": "No support for <code>smooth</code> behavior or <code>center</code> options."
             },
             "samsunginternet_android": {
               "version_added": null
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "scrollIntoViewOptions": {
+          "__compat": {
+            "description": "<code>scrollIntoViewOptions</code>",
+            "support": {
+              "webview_android": {
+                "version_added": "61",
+                "notes": "The <code>block</code> and <code>inline</code> options support the values <code>start</code>, <code>center</code>, <code>end</code>, <code>nearest</code>."
+              },
+              "chrome": {
+                "version_added": "61",
+                "notes": "The <code>block</code> and <code>inline</code> options support the values <code>start</code>, <code>center</code>, <code>end</code>, <code>nearest</code>."
+              },
+              "chrome_android": {
+                "version_added": "61",
+                "notes": "The <code>block</code> and <code>inline</code> options support the values <code>start</code>, <code>center</code>, <code>end</code>, <code>nearest</code>."
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "58",
+                  "notes": "No support for <code>inline</code> option."
+                },
+                {
+                  "version_added": "36",
+                  "version_removed": "58",
+                  "notes": [
+                    "No support for <code>inline</code> option.",
+                    "No support for <code>nearest</code> or <code>center</code> values for <code>block</code> option. See <a href='https://bugzil.la/1389274'>bug 1389274</a>."
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "58",
+                  "notes": "No support for <code>inline</code> option."
+                },
+                {
+                  "version_added": "36",
+                  "version_removed": "58",
+                  "notes": [
+                    "No support for <code>inline</code> option.",
+                    "No support for <code>nearest</code> or <code>center</code> values for <code>block</code> option. See <a href='https://bugzil.la/1389274'>bug 1389274</a>."
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "48",
+                "notes": "The <code>block</code> and <code>inline</code> options support the values <code>start</code>, <code>center</code>, <code>end</code>, <code>nearest</code>."
+              },
+              "opera_android": {
+                "version_added": "48",
+                "notes": "The <code>block</code> and <code>inline</code> options support the values <code>start</code>, <code>center</code>, <code>end</code>, <code>nearest</code>."
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/Element.json
+++ b/api/Element.json
@@ -3158,28 +3158,59 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/requestFullscreen",
           "support": {
             "webview_android": {
-              "version_added": true
+              "version_added": true,
+              "alternative_name": "webkitRequestFullscreen"
             },
             "chrome": {
-              "version_added": true
+              "version_added": true,
+              "alternative_name": "webkitRequestFullscreen"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": true,
+              "alternative_name": "webkitRequestFullscreen"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
+            "firefox": [
+              {
+                "version_added": "47",
+                "notes": "Before Firefox 44, Firefox incorrectly allowed elements inside a <code><frame></code> or an <code><object></code> to request, and to be granted, fullscreen. In Firefox 44 and onwards this has been fixed: only elements in the top-level document or in an <code><iframe></code> with the <code>allowfullscreen</code> attribute can be displayed fullscreen.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "full-screen-api.unprefix.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "9",
+                "alternative_name": "mozRequestFullScreen"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "47",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "full-screen-api.unprefix.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "9",
+                "alternative_name": "mozRequestFullScreen"
+              }
+            ],
             "ie": {
-              "version_added": null
+              "version_added": "11",
+              "alternative_name": "msRequestFullscreen"
             },
             "opera": {
               "version_added": true
@@ -3201,6 +3232,57 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "returns_a_promise": {
+          "__compat": {
+            "description": "Returns a Promise.",
+            "support": {
+              "webview_android": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/Element.json
+++ b/api/Element.json
@@ -3552,19 +3552,19 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -3573,10 +3573,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null


### PR DESCRIPTION
Part of #2494.

- [`Element.requestPointerLock`](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestPointerLock)
- [`Element.requestFullscreen`](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullscreen) and its subfeature
- [`Element.scrollIntoView`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) and its subfeature
- [`Element.scrollIntoViewIfNeeded`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoViewIfNeeded) 
- [`Element.getBoundingClientRect`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) and its subfeatures
- [`Element.getClientRects`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getClientRects) 

Most of this data was pulled from the current tables in their articles.