### PR TITLE
Describe isArticle naming issue

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -2103,6 +2103,35 @@
                   "version_added": false
                 }
               }
+            },
+            "properties": {
+              "isArticle": {
+                "__compat": {
+                  "support": {
+                    "chrome": {
+                      "version_added": false
+                    },
+                    "edge": {
+                      "version_added": false
+                    },
+                    "firefox": [
+                      {
+                        "version_added": "62"
+                      },
+                      {
+                        "version_added": "61",
+                        "alternative_name": "isarticle"
+                      }
+                    ],
+                    "firefox_android": {
+                      "version_added": false
+                    },
+                    "opera": {
+                      "version_added": false
+                    }
+                  }
+                }
+              }
             }
           }
         },


### PR DESCRIPTION
In version 61 Firefox added a new parameter `extraParameters` to [`tabs.onUpdated`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onUpdated). One of the properties of `extraParameters` was an object called `properties`, and one of the properties of *that* was a string. In 61 this string was called `isarticle`.

It should have been called `isArticle`. In [bug 1461695](https://bugzilla.mozilla.org/show_bug.cgi?id=1461695) this was fixed in 63 and uplifted to 62. The old name was kept as an alias but deprecated.

I've tried to document this using `alternative_name`:

<img width="954" alt="screen shot 2018-09-07 at 11 25 43 am" src="https://user-images.githubusercontent.com/432915/45236653-591ee880-b291-11e8-8efc-46a85d9dbdc4.png">

(aside: I appreciate how expressive the BCD syntax is for describing situations like this :)