### PR TITLE
Note these properties used to be mandatory

### DIFF
--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -127,7 +127,8 @@
                 "firefox": {
                   "version_added": "55",
                   "notes": [
-                    "Before version 59, the RGB array form was not supported for this property."
+                    "Before version 59, the RGB array form was not supported for this property.",
+                    "Before version 63, this property was mandatory."
                   ]
                 },
                 "firefox_android": {
@@ -676,7 +677,8 @@
                 "firefox": {
                   "version_added": "55",
                   "notes": [
-                    "Before version 59, the RGB array form was not supported for this property."
+                    "Before version 59, the RGB array form was not supported for this property.",
+                    "Before version 63, this property was mandatory."
                   ]
                 },
                 "firefox_android": {


### PR DESCRIPTION
In Firefox 63, the `colors.accentcolor` and `colors.textcolor` properties of the [`theme` manifest key](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme) were made optional: https://bugzilla.mozilla.org/show_bug.cgi?id=1413144

<img width="950" alt="screen shot 2018-09-07 at 11 50 49 am" src="https://user-images.githubusercontent.com/432915/45237762-7d2ff900-b294-11e8-9480-047564da71e7.png">
<img width="953" alt="screen shot 2018-09-07 at 11 51 02 am" src="https://user-images.githubusercontent.com/432915/45237764-7f925300-b294-11e8-8789-250b20a7ea5e.png">
