### PR TITLE
Add options and favicon to topSites data

### DIFF
--- a/webextensions/api/topSites.json
+++ b/webextensions/api/topSites.json
@@ -22,6 +22,27 @@
                 "version_added": true
               }
             }
+          },
+          "favicon": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "63"
+                },
+                "firefox_android": {
+                  "version_added": "63"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "get": {
@@ -42,6 +63,27 @@
               },
               "opera": {
                 "version_added": true
+              }
+            }
+          },
+          "options": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "63"
+                },
+                "firefox_android": {
+                  "version_added": "63"
+                },
+                "opera": {
+                  "version_added": false
+                }
               }
             }
           }


### PR DESCRIPTION
In [bug 1445836](https://bugzilla.mozilla.org/show_bug.cgi?id=1445836) Firefox 63 added:

* an `options` parameter to [`topSites.get()`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/topSites/get)<sup>[1]</sup>

<img width="875" alt="screen shot 2018-09-07 at 3 44 38 pm" src="https://user-images.githubusercontent.com/432915/45246303-6e0d7300-b2b5-11e8-993c-af06476855aa.png">

* a `favicon` property to [`topSites.MostVisitedURL`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/topSites/MostVisitedURL). 

<img width="874" alt="screen shot 2018-09-07 at 3 45 11 pm" src="https://user-images.githubusercontent.com/432915/45246319-7bc2f880-b2b5-11e8-9707-2e84a5ee509a.png">

diff: https://hg.mozilla.org/integration/autoland/diff/fc0d9d4bf1bf/toolkit/components/extensions/schemas/top_sites.json

[1] Technically, [`options` got added in Firefox 55](https://bugzilla.mozilla.org/show_bug.cgi?id=1361899), but because noone marked it dev-doc-needed it was never documented. But since the only option added at that time (`provider`) has now been deprecated, it seems better to pretend that it never existed before 63.