### PR TITLE
Fix typo in Node.ownerDocument notes

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -1774,7 +1774,7 @@
               },
               {
                 "version_added": "9",
-                "notes": "The <code>ownerDocument</code> of doctype nodes (that is, nodes for which <code>Node.nodeType</code> is Node.<code>DOCUMENT_TYPE_NODE</code> or 10) is no longer null. Instead, the <code>ownerDocument</code> is the document on which <code>document.implementation.createDocumentType()</code> was called."
+                "notes": "The <code>ownerDocument</code> of doctype nodes (that is, nodes for which <code>Node.nodeType</code> is <code>Node.DOCUMENT_TYPE_NODE</code> or 10) is no longer null. Instead, the <code>ownerDocument</code> is the document on which <code>document.implementation.createDocumentType()</code> was called."
               }
             ],
             "firefox_android": [
@@ -1783,7 +1783,7 @@
               },
               {
                 "version_added": "9",
-                "notes": "The <code>ownerDocument</code> of doctype nodes (that is, nodes for which <code>Node.nodeType</code> is Node.<code>DOCUMENT_TYPE_NODE</code> or 10) is no longer null. Instead, the <code>ownerDocument</code> is the document on which <code>document.implementation.createDocumentType()</code> was called."
+                "notes": "The <code>ownerDocument</code> of doctype nodes (that is, nodes for which <code>Node.nodeType</code> is <code>Node.DOCUMENT_TYPE_NODE</code> or 10) is no longer null. Instead, the <code>ownerDocument</code> is the document on which <code>document.implementation.createDocumentType()</code> was called."
               }
             ],
             "ie": {

--- a/api/Node.json
+++ b/api/Node.json
@@ -1774,7 +1774,7 @@
               },
               {
                 "version_added": "9",
-                "notes": "The <code>ownerDocument</code> of doctype nodes (that is, nodes for which <code>Node.nodeType</code> is Node. <code>DOCUMENT_TYPE_NODE</code> or 10) is no longer null. Instead, the <code>ownerDocument</code> is the document on which <code>document.implementation.createDocumentType()</code> was called."
+                "notes": "The <code>ownerDocument</code> of doctype nodes (that is, nodes for which <code>Node.nodeType</code> is Node.<code>DOCUMENT_TYPE_NODE</code> or 10) is no longer null. Instead, the <code>ownerDocument</code> is the document on which <code>document.implementation.createDocumentType()</code> was called."
               }
             ],
             "firefox_android": [
@@ -1783,7 +1783,7 @@
               },
               {
                 "version_added": "9",
-                "notes": "The <code>ownerDocument</code> of doctype nodes (that is, nodes for which <code>Node.nodeType</code> is Node. <code>DOCUMENT_TYPE_NODE</code> or 10) is no longer null. Instead, the <code>ownerDocument</code> is the document on which <code>document.implementation.createDocumentType()</code> was called."
+                "notes": "The <code>ownerDocument</code> of doctype nodes (that is, nodes for which <code>Node.nodeType</code> is Node.<code>DOCUMENT_TYPE_NODE</code> or 10) is no longer null. Instead, the <code>ownerDocument</code> is the document on which <code>document.implementation.createDocumentType()</code> was called."
               }
             ],
             "ie": {


### PR DESCRIPTION
Fixes https://github.com/mdn/browser-compat-data/issues/2614

Replace: Node. `DOCUMENT_TYPE_NODE`
with: Node.`DOCUMENT_TYPE_NODE`