### PR TITLE
Web APIs: adding compat data for SourceBufferList.SourceBuffer

### DIFF
--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -69,6 +69,66 @@
           "deprecated": false
         }
       },
+      "SourceBuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBufferList/SourceBuffer",
+          "support": {
+            "chrome": {
+              "version_added": "23"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.mediasource.enabled"
+                  }
+                ],
+                "notes": [
+                  "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "11",
+              "notes": [
+                "Only works on Windows 8+."
+              ]
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "33"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBufferList/length",


### PR DESCRIPTION
This replaces the compatibility matrix of [SourceBufferList.SourceBuffer()](https://developer.mozilla.org/en-US/docs/Web/API/SourceBufferList/SourceBuffer#Browser_compatibility) with compat data, as per issue https://github.com/mdn/browser-compat-data/issues/2467