### PR TITLE
Web APIs: adding compat data for FileException

### DIFF
--- a/api/FileException.json
+++ b/api/FileException.json
@@ -1,0 +1,54 @@
+{
+  "api": {
+    "FileException": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileException",
+        "support": {
+          "chrome": {
+            "version_added": "13",
+            "prefix": "webkit"
+          },
+          "chrome_android": {
+            "version_added": "18",
+            "prefix": "webkit"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/FileException.json
+++ b/api/FileException.json
@@ -6,10 +6,12 @@
         "support": {
           "chrome": {
             "version_added": "13",
+            "version_removed": "29",
             "prefix": "webkit"
           },
           "chrome_android": {
             "version_added": "18",
+            "version_removed": "29",
             "prefix": "webkit"
           },
           "edge": {
@@ -44,9 +46,9 @@
           }
         },
         "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
         }
       }
     }


### PR DESCRIPTION
This replaces the compatibility matrix of [FileException](https://developer.mozilla.org/docs/Web/API/FileException#Browser_compatibility) with compat data.