### PR TITLE
Web APIs: adding compat data for File.webkitRelativePath

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -320,6 +320,56 @@
             "deprecated": false
           }
         }
+      },
+      "webkitRelativePath": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/File/webkitRelativePath",
+          "support": {
+            "chrome": {
+              "version_added": "13",
+              "prefix": "webkit"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "prefix": "webkit"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": {
+              "version_added": "49"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This replaces the compatibility matrix of [File.webkitRelativePath](https://developer.mozilla.org/docs/Web/API/File/webkitRelativePath) with compat data.