### PR TITLE
Update standard status for immutable response

### DIFF
--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -97,7 +97,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }


### PR DESCRIPTION
The “immutable” attribute of “Cache-Control” header has been standardized in [RFC 8246](https://tools.ietf.org/html/rfc8246).