### PR TITLE
Update streaming support for Fetch API

### DIFF
--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -658,7 +658,17 @@
                 "version_added": "14"
               },
               "firefox": {
-                "version_added": false
+                "version_added": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.enabled"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.streams"
+                  }
+                ]
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
Copy from: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API

The note there will be removed once this is merged.