### PR TITLE
updated event.composedPath for safari, ie and edge

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -918,10 +918,10 @@
               }
             ],
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "52"
@@ -930,7 +930,7 @@
               "version_added": "52"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": [
               {
@@ -953,10 +953,10 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": 10
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": 10
             },
             "webview_android": [
               {


### PR DESCRIPTION
wanted to use it but saw no support for it, so i tested it with browserstack to try out all version of safari, ie and edge