### PR TITLE
Update HTMLFormElement.submit compat table

### DIFF
--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -775,10 +775,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
               "version_added": true
@@ -787,7 +787,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -796,16 +796,16 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
I did some research and discovered that `submit` is supported across all major browsers on even the oldest known versions of each that support javascript. The masking behaviour (when an input has the name or id of `"submit"`) is also the same on all the browsers.