### PR TITLE
`margin-inline-start` alternative fix for Chrome

### DIFF
--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -11,7 +11,7 @@
               },
               {
                 "version_added": "2",
-                "alternative_name": "-webkit-margin-end"
+                "alternative_name": "-webkit-margin-start"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "version_added": "18",
-                "alternative_name": "-webkit-margin-end"
+                "alternative_name": "-webkit-margin-start"
               }
             ],
             "edge": {


### PR DESCRIPTION
Probably a copy paste mistake from https://github.com/mdn/browser-compat-data/pull/2639