### PR TITLE
MediaCapabilities: changed experimental to false. 

### DIFF
--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -42,7 +42,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": false,
           "deprecated": false
         }
@@ -110,7 +110,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -158,7 +158,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }


### PR DESCRIPTION
This spec is NOT in the standards track, but has been implemented in FF, Chr and Opera

Not standards track: https://wicg.github.io/media-capabilities/

Implemented in 63: https://bugzilla.mozilla.org/show_bug.cgi?id=1409664