### PR TITLE
Add note to IE for DOMImplementation

### DIFF
--- a/api/DOMImplementation.json
+++ b/api/DOMImplementation.json
@@ -157,7 +157,8 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "6",
+              "notes": "The <code>title</code> parameter is required, but can be empty string."
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
According to the standard, the parameter should be optional. IE doesn’t actually comply to the standard, so the “6” there is kind of misleading.