### PR TITLE
clearing up data confusion about SVGPathElement and SVGGeometryElement

### DIFF
--- a/api/SVGGeometryElement.json
+++ b/api/SVGGeometryElement.json
@@ -259,10 +259,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Before version 53, this method was defined on the <a href='https://developer.mozilla.org/docs/Web/API/SVGPathElement'><code>SVGPathElement</code></a> interface, which inherits from this interface."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Before version 53, this method was defined on the <a href='https://developer.mozilla.org/docs/Web/API/SVGPathElement'><code>SVGPathElement</code></a> interface, which inherits from this interface."
             },
             "ie": {
               "version_added": null
@@ -307,10 +309,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Before version 53, this method was defined on the <a href='https://developer.mozilla.org/docs/Web/API/SVGPathElement'><code>SVGPathElement</code></a> interface, which inherits from this interface."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Before version 53, this method was defined on the <a href='https://developer.mozilla.org/docs/Web/API/SVGPathElement'><code>SVGPathElement</code></a> interface, which inherits from this interface."
             },
             "ie": {
               "version_added": null

--- a/api/SVGPathElement.json
+++ b/api/SVGPathElement.json
@@ -1109,14 +1109,15 @@
             },
             "firefox": {
               "version_added": true,
-              "version_removed": "53",
               "notes": [
-                "This method is currently only supported on <a href='https://developer.mozilla.org/docs/Web/SVG/Element/path'><code>&lt;path&gt;</code></a> elements (where it was already supported in earlier Firefox versions through the <a href='https://developer.mozilla.org/docs/Web/API/SVGPathElement'><code>SVGPathElement</code></a> interface). Support for other elements will be added in <a href='https://bugzil.la/1325320'>bug 1325320</a>."
+                "From version 53, this method is defined on the parent <a href='https://developer.mozilla.org/docs/Web/API/SVGGeometryElement'><code>SVGGeometryElement</code></a> interface."
               ]
             },
             "firefox_android": {
               "version_added": true,
-              "version_removed": "53"
+              "notes": [
+                "From version 53, this method is defined on the parent <a href='https://developer.mozilla.org/docs/Web/API/SVGGeometryElement'><code>SVGGeometryElement</code></a> interface."
+              ]
             },
             "ie": {
               "version_added": null
@@ -1162,14 +1163,15 @@
             },
             "firefox": {
               "version_added": true,
-              "version_removed": "53",
               "notes": [
-                "This method is currently only supported on <a href='https://developer.mozilla.org/docs/Web/SVG/Element/path'><code>&lt;path&gt;</code></a> elements (where it was already supported in earlier Firefox versions through the <a href='https://developer.mozilla.org/docs/Web/API/SVGPathElement'><code>SVGPathElement</code></a> interface). Support for other elements will be added in <a href='https://bugzil.la/1325320'>bug 1325320</a>."
+                "From version 53, this method is defined on the parent <a href='https://developer.mozilla.org/docs/Web/API/SVGGeometryElement'><code>SVGGeometryElement</code></a> interface."
               ]
             },
             "firefox_android": {
               "version_added": true,
-              "version_removed": "53"
+              "notes": [
+                "From version 53, this method is defined on the parent <a href='https://developer.mozilla.org/docs/Web/API/SVGGeometryElement'><code>SVGGeometryElement</code></a> interface."
+              ]
             },
             "ie": {
               "version_added": true


### PR DESCRIPTION
In particular the getTotalLength() and getPointAtLength() methods.

As per https://bugzilla.mozilla.org/show_bug.cgi?id=1325320