### PR TITLE
adding Early-Data http header

### DIFF
--- a/http/headers/early-data.json
+++ b/http/headers/early-data.json
@@ -1,0 +1,57 @@
+{
+  "http": {
+    "headers": {
+      "Age": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Early-Data",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "58"
+            },
+            "firefox_android": {
+              "version_added": "58"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/early-data.json
+++ b/http/headers/early-data.json
@@ -1,7 +1,7 @@
 {
   "http": {
     "headers": {
-      "Age": {
+      "Early-Data": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Early-Data",
           "support": {


### PR DESCRIPTION
I discovered that the 425 status code was already represented inside BCD, but I used this opportunity to add data for the Early-Data header, which is closely related to status 425.

Related bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1406908