### PR TITLE
add Safari 12 and iOS Safari 12 browser data

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -100,6 +100,10 @@
           "release_date": "2018-04-12",
           "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_11_1.html",
           "status": "current"
+        },
+        "12": {
+          "release_date": "2018-09-24",
+          "status": "beta"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -83,6 +83,10 @@
         },
         "11.1": {
           "status": "current"
+        },
+        "12": {
+          "release_date": "2018-09-17",
+          "status": "beta"
         }
       }
     }


### PR DESCRIPTION
WWDC took place last night and Apple gave the release date for both macOS Mojave and iOS 12 which will ship Safari 12.

iOS release date: https://mashable.com/article/ios12-release-date-apple-event-2018/?europe=true#BNlQT16Zciqw

macOS release date: https://mashable.com/article/apple-event-2018-macos-mojave-release-date/?europe=true#8Ge5bVgMEPqz