### PR TITLE
CSS clip-path property: added path() and removed compat for inset()

### DIFF
--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -221,24 +221,24 @@
                 "version_added": false
               },
               "firefox": {
-                  "version_added": "63",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.clip-path-path.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.clip-path-path.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
-                  "version_added": "63",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.clip-path-path.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.clip-path-path.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "ie": {
                 "version_added": false

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -201,18 +201,18 @@
             }
           }
         },
-        "inset": {
+        "path": {
           "__compat": {
-            "description": "<code>inset()</code>",
+            "description": "<code>path()</code>",
             "support": {
               "webview_android": {
-                "version_added": "55"
+                "version_added": false
               },
               "chrome": {
-                "version_added": "55"
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": "55"
+                "version_added": false
               },
               "edge": {
                 "version_added": false
@@ -220,44 +220,34 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "54"
-                },
-                {
-                  "version_added": "47",
+              "firefox": {
+                  "version_added": "63",
                   "flags": [
                     {
                       "type": "preference",
-                      "name": "layout.css.clip-path-shapes.enabled",
+                      "name": "layout.css.clip-path-path.enabled",
                       "value_to_set": "true"
                     }
                   ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "54"
-                },
-                {
-                  "version_added": "47",
+              },
+              "firefox_android": {
+                  "version_added": "63",
                   "flags": [
                     {
                       "type": "preference",
-                      "name": "layout.css.clip-path-shapes.enabled",
+                      "name": "layout.css.clip-path-path.enabled",
                       "value_to_set": "true"
                     }
                   ]
-                }
-              ],
+              },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": "42"
+                "version_added": false
               },
               "opera_android": {
-                "version_added": "42"
+                "version_added": false
               },
               "safari": {
                 "version_added": false
@@ -266,7 +256,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "6.0"
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
Removed inset() as all the browsers that support basic clip path support inset() at the same version.
Added path() as per https://bugzilla.mozilla.org/show_bug.cgi?id=1246764
Supported behind a flag in FF63.