### PR TITLE
RTCRtpStreamStats.isRemote default change in Firefox 28

### DIFF
--- a/api/RTCRtpStreamStats.json
+++ b/api/RTCRtpStreamStats.json
@@ -182,11 +182,11 @@
             },
             "firefox": {
               "version_added": "27",
-              "notes": "In Firefox 55, a default value of <code>false</code> was added for <code>isRemote</code>, to match a specification update."
+              "notes": "In Firefox 28, a default value of <code>false</code> was added for <code>isRemote</code>, to match a specification update."
             },
             "firefox_android": {
               "version_added": "27",
-              "notes": "In Firefox 55, a default value of <code>false</code> was added for <code>isRemote</code>, to match a specification update."
+              "notes": "In Firefox 28, a default value of <code>false</code> was added for <code>isRemote</code>, to match a specification update."
             },
             "ie": {
               "version_added": false

--- a/api/RTCRtpStreamStats.json
+++ b/api/RTCRtpStreamStats.json
@@ -181,10 +181,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "27"
+              "version_added": "27",
+              "notes": "In Firefox 55, a default value of <code>false</code> was added for <code>isRemote</code>, to match a specification update."
             },
             "firefox_android": {
-              "version_added": "27"
+              "version_added": "27",
+              "notes": "In Firefox 55, a default value of <code>false</code> was added for <code>isRemote</code>, to match a specification update."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Starting in Firefox 28, isRemote has the default value
false per a specification change. Before that, it did not
have a default.

https://bugzilla.mozilla.org/show_bug.cgi?id=908695
https://hg.mozilla.org/mozilla-central/rev/2b1230494e0b
https://hg.mozilla.org/mozilla-central/diff/2b1230494e0b/dom/webidl/RTCStatsReport.webidl#l1.13