### PR TITLE
Add compat data for :-moz-ui-valid, :-moz-submit-invalid, and :-moz-ui-invalid pseudo-classes 

### DIFF
--- a/css/selectors/-moz-submit-invalid.json
+++ b/css/selectors/-moz-submit-invalid.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "-moz-submit-invalid": {
+        "__compat": {
+          "description": "<code>:-moz-submit-invalid</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:-moz-submit-invalid",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/-moz-ui-invalid.json
+++ b/css/selectors/-moz-ui-invalid.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "-moz-ui-invalid": {
+        "__compat": {
+          "description": "<code>:-moz-ui-invalid</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:-moz-ui-invalid",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/-moz-ui-valid.json
+++ b/css/selectors/-moz-ui-valid.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "-moz-ui-valid": {
+        "__compat": {
+          "description": "<code>:-moz-ui-valid</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:-moz-ui-valid",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-ui-valid
https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-ui-invalid
https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-submit-invalid

Should these articles be redirected to `:valid` and `:invalid`? I'm not sure if they're equivalent since neither page mentions a `moz` prefixed version.

The `:-moz-submit-valid` pseudo-class has no standard equivalent as far as I can tell?