### PR TITLE
Mark the menuitem element as deprecated

### DIFF
--- a/html/elements/menuitem.json
+++ b/html/elements/menuitem.json
@@ -54,9 +54,9 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         },
         "checked": {
@@ -111,9 +111,9 @@
               }
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },
@@ -169,9 +169,9 @@
               }
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },
@@ -227,9 +227,9 @@
               }
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },
@@ -292,9 +292,9 @@
               }
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },
@@ -350,9 +350,9 @@
               }
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },
@@ -408,9 +408,9 @@
               }
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },
@@ -466,9 +466,9 @@
               }
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menuitem has `{{deprecated_header}}`, so this change marks it as deprecated here.