### PR TITLE
Add compat data for :blank CSS selectors level 4 pseudo-class.

### DIFF
--- a/css/selectors/blank.json
+++ b/css/selectors/blank.json
@@ -23,7 +23,7 @@
             },
             "firefox": {
               "version_added": true,
-              "alternative_name": "-moz-only-whitespace",
+              "alternative_name": ":-moz-only-whitespace",
               "notes": "See <a href='https://bugzil.la/1106296'>bug 1106296</a>."
             },
             "firefox_android": {

--- a/css/selectors/blank.json
+++ b/css/selectors/blank.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "empty": {
+        "__compat": {
+          "description": "<code>:blank</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:blank",
+          "support": {
+            "webview_android": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/blank.json
+++ b/css/selectors/blank.json
@@ -22,7 +22,9 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": true,
+              "alternative_name": "-moz-only-whitespace",
+              "notes": "See <a href='https://bugzil.la/1106296'>bug 1106296</a>."
             },
             "firefox_android": {
               "version_added": false

--- a/css/selectors/blank.json
+++ b/css/selectors/blank.json
@@ -7,43 +7,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:blank",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": false
             },
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/css/selectors/blank.json
+++ b/css/selectors/blank.json
@@ -27,7 +27,9 @@
               "notes": "See <a href='https://bugzil.la/1106296'>bug 1106296</a>."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true,
+              "alternative_name": ":-moz-only-whitespace",
+              "notes": "See <a href='https://bugzil.la/1106296'>bug 1106296</a>."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
TBD: create MDN page [1] (clone current `:empty` page [2] and edit according current draft [3]).

[1] https://developer.mozilla.org/en-US/docs/Web/CSS/:blank
[2] https://developer.mozilla.org/en-US/docs/Web/CSS/:empty
[3] https://drafts.csswg.org/selectors-4/#the-blank-pseudo