### PR TITLE
Rename fill-available as stretch

### DIFF
--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -59,7 +59,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "Chrome implements an earlier proposal for setting height to an intrinsic height: the keywords <code>intrinsic</code> (instead of <code>max-content</code>), and <code>min-intrinsic</code> (instead of <code>min-content</code>). There is no equivalent for <code>fill-available</code> or <code>fit-content</code>."
+                "notes": "Chrome implements an earlier proposal for setting height to an intrinsic height: the keywords <code>intrinsic</code> (instead of <code>max-content</code>), and <code>min-intrinsic</code> (instead of <code>min-content</code>). There is no equivalent for <code>stretch</code> or <code>fit-content</code>."
               },
               "chrome_android": {
                 "version_added": null
@@ -90,11 +90,11 @@
               },
               "safari": {
                 "version_added": "9",
-                "notes": "Safari implements an earlier proposal for setting height to an intrinsic height: the keywords <code>intrinsic</code> (instead of <code>max-content</code>), and <code>min-intrinsic</code> (instead of <code>min-content</code>). There is no equivalent for <code>fill-available</code> or <code>fit-content</code>."
+                "notes": "Safari implements an earlier proposal for setting height to an intrinsic height: the keywords <code>intrinsic</code> (instead of <code>max-content</code>), and <code>min-intrinsic</code> (instead of <code>min-content</code>). There is no equivalent for <code>stretch</code> or <code>fit-content</code>."
               },
               "safari_ios": {
                 "version_added": "9",
-                "notes": "Safari implements an earlier proposal for setting height to an intrinsic height: the keywords <code>intrinsic</code> (instead of <code>max-content</code>), and <code>min-intrinsic</code> (instead of <code>min-content</code>). There is no equivalent for <code>fill-available</code> or <code>fit-content</code>."
+                "notes": "Safari implements an earlier proposal for setting height to an intrinsic height: the keywords <code>intrinsic</code> (instead of <code>max-content</code>), and <code>min-intrinsic</code> (instead of <code>min-content</code>). There is no equivalent for <code>stretch</code> or <code>fit-content</code>."
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -110,9 +110,9 @@
             }
           }
         },
-        "fill-available": {
+        "stretch": {
           "__compat": {
-            "description": "<code>fill-available</code>",
+            "description": "<code>stretch</code>",
             "support": {
               "chrome": {
                 "version_added": false

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -108,7 +108,7 @@
             }
           }
         },
-        "fill-availble": {
+        "stretch": {
           "__compat": {
             "description": "<code>stretch</code>",
             "support": {

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -59,7 +59,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "Chrome implements an earlier proposal for setting width to an intrinsic width: the keywords <code>intrinsic</code> (instead of <code>max-content</code>), and <code>min-intrinsic</code> (instead of <code>min-content</code>). There is no equivalent for <code>fill-available</code> or <code>fit-content</code>."
+                "notes": "Chrome implements an earlier proposal for setting width to an intrinsic width: the keywords <code>intrinsic</code> (instead of <code>max-content</code>), and <code>min-intrinsic</code> (instead of <code>min-content</code>). There is no equivalent for <code>stretch</code> or <code>fit-content</code>."
               },
               "chrome_android": {
                 "version_added": null
@@ -89,7 +89,7 @@
               },
               "safari": {
                 "version_added": false,
-                "notes": "Safari implements an earlier proposal for setting width to an intrinsic width: the keywords <code>intrinsic</code> (instead of <code>max-content</code>), and <code>min-intrinsic</code> (instead of <code>min-content</code>). There is no equivalent for <code>fill-available</code> or <code>fit-content</code>."
+                "notes": "Safari implements an earlier proposal for setting width to an intrinsic width: the keywords <code>intrinsic</code> (instead of <code>max-content</code>), and <code>min-intrinsic</code> (instead of <code>min-content</code>). There is no equivalent for <code>stretch</code> or <code>fit-content</code>."
               },
               "safari_ios": {
                 "version_added": null
@@ -110,7 +110,7 @@
         },
         "fill-availble": {
           "__compat": {
-            "description": "<code>fill-available</code>",
+            "description": "<code>stretch</code>",
             "support": {
               "chrome": {
                 "version_added": false

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -111,7 +111,7 @@
             "support": {
               "chrome": {
                 "alternative_name": "-webkit-fill-available",
-                "version_added": "1"
+                "version_added": true
               },
               "chrome_android": {
                 "alternative_name": "-webkit-fill-available",

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -105,9 +105,9 @@
             }
           }
         },
-        "fill-available": {
+        "stretch": {
           "__compat": {
-            "description": "<code>fill-available</code>",
+            "description": "<code>stretch</code>",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -110,9 +110,11 @@
             "description": "<code>stretch</code>",
             "support": {
               "chrome": {
+                "alternative_name": "-webkit-fill-available",
                 "version_added": "1"
               },
               "chrome_android": {
+                "alternative_name": "-webkit-fill-available",
                 "version_added": true
               },
               "edge": {
@@ -131,21 +133,26 @@
                 "version_added": false
               },
               "opera": {
+                "alternative_name": "-webkit-fill-available",
                 "version_added": true
               },
               "opera_android": {
+                "alternative_name": "-webkit-fill-available",
                 "version_added": true
               },
               "safari": {
+                "alternative_name": "-webkit-fill-available",
                 "version_added": "9"
               },
               "safari_ios": {
                 "version_added": null
               },
               "samsunginternet_android": {
+                "alternative_name": "-webkit-fill-available",
                 "version_added": true
               },
               "webview_android": {
+                "alternative_name": "-webkit-fill-available",
                 "version_added": true
               }
             },

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -107,9 +107,9 @@
             }
           }
         },
-        "fill-available": {
+        "stretch": {
           "__compat": {
-            "description": "<code>fill-available</code>",
+            "description": "<code>stretch</code>",
             "support": {
               "chrome": {
                 "prefix": "-webkit-",

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -112,7 +112,7 @@
             "description": "<code>stretch</code>",
             "support": {
               "chrome": {
-                "prefix": "-webkit-",
+                "alternative_name": "-webkit-fill-available",
                 "version_added": "24"
               },
               "chrome_android": {

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -234,9 +234,9 @@
             }
           }
         },
-        "fill-available": {
+        "stretch": {
           "__compat": {
-            "description": "<code>fill-available</code>",
+            "description": "<code>stretch</code>",
             "support": {
               "chrome": {
                 "prefix": "-webkit-",

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -239,10 +239,11 @@
             "description": "<code>stretch</code>",
             "support": {
               "chrome": {
-                "prefix": "-webkit-",
+                "alternative_name": "-webkit-fill-available",
                 "version_added": "22"
               },
               "chrome_android": {
+                "alternative_name": "-webkit-fill-available",
                 "version_added": "46"
               },
               "edge": {
@@ -328,13 +329,14 @@
                 "version_added": null
               },
               "safari": {
-                "prefix": "-webkit-",
+                "alternative_name": "-webkit-fill-available",
                 "version_added": "6.1"
               },
               "safari_ios": {
                 "version_added": null
               },
               "samsunginternet_android": {
+                "alternative_name": "-webkit-fill-available",
                 "version_added": "5.0"
               },
               "webview_android": {


### PR DESCRIPTION
`fill-available` [was renamed as `fill` in 2013](https://github.com/w3c/csswg-drafts/commit/c865339293a44071dfa53fbf7d45d16004828602) and then [again renamed as `stretch` in 2017](https://github.com/w3c/csswg-drafts/commit/8b287d334c1a0bb0560ddc13f92cdb36184f505d#diff-a4403a9073e38ae7247def24db7b2eed). This PR reflects the changes.
