### PR TITLE
Updated for missing samsung and chrome data

### DIFF
--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -12,7 +12,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -42,7 +42,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -62,7 +62,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": "12"
@@ -92,7 +92,7 @@
                 "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               }
             },
             "status": {
@@ -164,7 +164,7 @@
                 "version_added": "21"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": "12"
@@ -194,7 +194,7 @@
                 "version_added": "4"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               }
             },
             "status": {

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -81,9 +81,9 @@
             "safari_ios": {
               "version_added": true
             },
-              "samsunginternet_android": {
-                "version_added": true
-              }
+            "samsunginternet_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -19,6 +19,9 @@
                 "version_added": "1"
               }
             ],
+            "chrome_android": {
+              "version_added": true
+            },
             "edge": [
               {
                 "version_added": "12"
@@ -77,7 +80,10 @@
             ],
             "safari_ios": {
               "version_added": true
-            }
+            },
+              "samsunginternet_android": {
+                "version_added": true
+              }
           },
           "status": {
             "experimental": false,
@@ -92,6 +98,9 @@
               "chrome": {
                 "version_added": true,
                 "notes": "Prior to Chrome 4, the slash <code>/</code> notation is unsupported. If two values are specified, an elliptical border is drawn on all four corners. <code>-webkit-border-radius: 40px 10px;</code> is equivalent to <code>border-radius: 40px/10px;</code>."
+              },
+              "chrome_android": {
+                "version_added": true
               },
               "edge": {
                 "version_added": "12"
@@ -117,6 +126,9 @@
               "safari": {
                 "version_added": true,
                 "notes": "Prior to Safari 4.1, the slash <code>/</code> notation is unsupported. If two values are specified, an elliptical border is drawn on all four corners. <code>-webkit-border-radius: 40px 10px;</code> is equivalent to <code>border-radius: 40px/10px;</code>."
+              },
+              "samsunginternet_android": {
+                "version_added": true
               }
             },
             "status": {
@@ -132,6 +144,9 @@
             "support": {
               "chrome": {
                 "version_added": "4"
+              },
+              "chrome_android": {
+                "version_added": true
               },
               "edge": {
                 "version_added": "12"
@@ -156,6 +171,9 @@
               },
               "safari": {
                 "version_added": "5"
+              },
+              "samsunginternet_android": {
+                "version_added": true
               }
             },
             "status": {
@@ -176,6 +194,9 @@
               "chrome": {
                 "version_added": true,
                 "notes": "<code>&lt;percentage&gt;</code> values are not supported in older Chrome and Safari versions (it was <a href='http://trac.webkit.org/changeset/66615'>fixed in Sepember 2010</a>)."
+              },
+              "chrome_android": {
+                "version_added": true
               },
               "edge": {
                 "version_added": "12"
@@ -207,6 +228,9 @@
               "safari_ios": {
                 "version_added": true,
                 "notes": "<code>&lt;percentage&gt;</code> values are not supported in older Chrome and Safari versions (it was <a href='http://trac.webkit.org/changeset/66615'>fixed in Sepember 2010</a>)."
+              },
+              "samsunginternet_android": {
+                "version_added": true
               }
             },
             "status": {


### PR DESCRIPTION
Not related to any ticket, but samsung and chrome for android both support border radius and background image shorthand.