### PR TITLE
Correct RTCPeerConnection.canTrickleIceCandidates support

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -179,13 +179,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/canTrickleIceCandidates",
           "support": {
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             },
             "chrome": {
-              "version_added": "56"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": false
             },
             "edge": {
               "version_added": "15"
@@ -194,7 +194,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "44"
@@ -202,26 +202,12 @@
             "ie": {
               "version_added": null
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": null
             },


### PR DESCRIPTION
* Not supported in Chrome (tested)
* Not supported in Opera (tested)
* Added in Firefox 44

I'm making the assumption that if Chrome Desktop and Opera Desktop don't
support it, the mobile versions will not either.

Fixes #2848