### PR TITLE
Add compat data for document.fonts

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3485,6 +3485,58 @@
           }
         }
       },
+      "fonts": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fonts",
+          "support": {
+            "chrome": {
+              "version_added": "35"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "41",
+              "notes": "First implemented in Firefox 35 behind the flag <code>layout.css.font-loading-api.enabled</code>. Enabled by default in Firefox 41."
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": "10.2"
+            },
+            "webview_android": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+                "version_added": "5.0"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "forms": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/forms",

--- a/api/Document.json
+++ b/api/Document.json
@@ -3527,7 +3527,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-                "version_added": "5.0"
+              "version_added": "5.0"
             }
           },
           "status": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -3490,10 +3490,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fonts",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "60"
             },
             "edge": {
               "version_added": false
@@ -3512,10 +3512,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": "10"
@@ -3523,11 +3523,11 @@
             "safari_ios": {
               "version_added": "10.2"
             },
-            "webview_android": {
-              "version_added": null
-            },
             "samsunginternet_android": {
               "version_added": "5.0"
+            },
+            "webview_android": {
+              "version_added": "60"
             }
           },
           "status": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -3501,10 +3501,22 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "41",
-              "notes": "First implemented in Firefox 35 behind the flag <code>layout.css.font-loading-api.enabled</code>. Enabled by default in Firefox 41."
-            },
+            "firefox": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "35",
+                "version_removed": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-loading-api.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": true
             },


### PR DESCRIPTION
Add compat data for [document.fonts](https://developer.mozilla.org/en-US/docs/Web/API/Document/fonts).