### PR TITLE
Updated Firefox compatibility for "pointer" and "hover" media features

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -855,12 +855,10 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+                "version_added": "64"
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+                "version_added": "64"
               },
               "ie": {
                 "version_added": false
@@ -1170,12 +1168,10 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+                "version_added": "64"
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+                "version_added": "64"
               },
               "ie": {
                 "version_added": null


### PR DESCRIPTION
[Bug 1035774](https://bugzilla.mozilla.org/show_bug.cgi?id=1035774) got fixed for Firefox 64, meaning that the media features `pointer` and `hover` got implemented.

This patch updates the compat data accordingly.