### PR TITLE
Update Date.json

### DIFF
--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -84,7 +84,7 @@
                 "version_added": null
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "6.0.0"
               },
               "opera": {
                 "version_added": null

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -84,7 +84,7 @@
                 "version_added": null
               },
               "nodejs": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null


### PR DESCRIPTION
Quick test done with node v10.11.0, function is not present.

To reproduce:
`node -p 'Date()[Symbol.toPrimitive]()'`