### PR TITLE
Update Opera browser data

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -316,7 +316,7 @@
         },
         "55": {
           "release_date": "2018-08-16",
-          "release_notes": "https://blogs.opera.com/desktop/2018/09/opera-55-0-2994-61-stable-update/",
+          "release_notes": "https://blogs.opera.com/desktop/2018/08/opera-55-offers-better-control-web-pages-accessible-bookmarks/",
           "status": "retired"
         },
         "56": {

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -307,22 +307,28 @@
         "53": {
           "release_date": "2018-05-10",
           "release_notes": "https://dev.opera.com/blog/opera-53/",
-          "status": "current"
+          "status": "retired"
         },
         "54": {
-          "status": "beta"
+          "release_date": "2018-06-28",
+          "release_notes": "https://dev.opera.com/blog/opera-54/",
+          "status": "retired"
         },
         "55": {
-          "status": "nightly"
+          "release_date": "2018-08-16",
+          "release_notes": "https://blogs.opera.com/desktop/2018/09/opera-55-0-2994-61-stable-update/",
+          "status": "retired"
         },
         "56": {
-          "status": "planned"
+          "release_date": "2018-09-25",
+          "release_notes": "https://dev.opera.com/blog/opera-56/",
+          "status": "current"
         },
         "57": {
-          "status": "planned"
+          "status": "beta"
         },
         "58": {
-          "status": "planned"
+          "status": "nightly"
         },
         "59": {
           "status": "planned"


### PR DESCRIPTION
Looks like the update to the Opera browser data was a bit overdue.

For some reason the official release post for O55 was never released on the dev blog? https://dev.opera.com/blog/

However I found the release date from https://blogs.opera.com/desktop/changelog-for-55/ when they tackled this task: 
```DNA-71701 Promote O55 to stable```