### PR TITLE
Add Array.prototype.{flat,flatMap} to Safari 12

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -557,10 +557,10 @@
                 "version_added": "56"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -611,10 +611,10 @@
                 "version_added": "56"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
closes #2871