### PR TITLE
Add Safari 12 release info

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -99,11 +99,12 @@
         "11.1": {
           "release_date": "2018-04-12",
           "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_11_1.html",
-          "status": "current"
+          "status": "retired"
         },
         "12": {
           "release_date": "2018-09-24",
-          "status": "beta"
+          "release_notes": "https://developer.apple.com/safari/whats-new/",
+          "status": "current"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -82,11 +82,12 @@
           "status": "retired"
         },
         "11.1": {
-          "status": "current"
+          "status": "retired"
         },
         "12": {
           "release_date": "2018-09-17",
-          "status": "beta"
+          "release_notes": "https://developer.apple.com/safari/whats-new/",
+          "status": "current"
         }
       }
     }


### PR DESCRIPTION
Safari 12 is out now with iOS 12 and macOS Mojave.

Unfortunately, it would seem that the release notes are now at https://developer.apple.com/safari/whats-new/, which isn't exactly a permalink and has less info than the previous release notes :/

Here's [the archive.org link in case it's ever needed](https://web.archive.org/web/20180921072830/https://developer.apple.com/safari/whats-new/).