### PR TITLE
Adding basic compat data for HTMLInputElement

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1,0 +1,193 @@
+{
+  "api": {
+    "HTMLInputElement": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement",
+        "support": {
+          "chrome": {
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "1"
+          },
+          "firefox_android": {
+            "version_added": true
+          },
+          "ie": {
+            "version_added": true
+          },
+          "nodejs": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "qq_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": true
+          },
+          "safari_ios": {
+            "version_added": true
+          },
+          "samsunginternet_android": {
+            "version_added": null
+          },
+          "uc_android": {
+            "version_added": null
+          },
+          "uc_chinese_android": {
+            "version_added": null
+          },
+          "webview_android": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "deprecated": false,
+          "experimental": false,
+          "standard_track": true
+        }
+      },
+      "setSelectionRange": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/setSelectionRange",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "nodejs": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "8"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "qq_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "uc_android": {
+              "version_added": null
+            },
+            "uc_chinese_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "deprecated": false,
+            "experimental": false,
+            "standard_track": true
+          }
+        },
+        "selectionDirection": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/setSelectionRange",
+            "support": {
+              "chrome": {
+                "version_added": "15"
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "8"
+              },
+              "firefox_android": {
+                "version_added": "8"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "qq_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "uc_android": {
+                "version_added": null
+              },
+              "uc_chinese_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false,
+              "standard_track": true
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -70,7 +70,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -115,7 +115,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -132,7 +132,7 @@
                 "version_added": "15"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true
@@ -177,7 +177,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": null
+                "version_added": true
               }
             },
             "status": {


### PR DESCRIPTION
Hi! This is my first attempt to add to the compat data repository, so apologies in advance if I have done things incorrectly.

Some points of confusion that I had:

- The compatibility table for `setSelectionRange` currently lists "Chrome Mobile" as a browser. It was unclear to me if that referred to `chrome_android`, `uc_android`, `uc_chinese_android` or `webview_android`, so I entered `null` for all of those browsers under that subelement
- I was unsure how best to include the addition of the `selectionDirection` argument that was added to the `setSelectionRange` method. Currently it is represented as its own row in the [compatibility table](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange#Browser_compatibility), but it could feasibly also be included in the browser `notes` fields. I included it as its own row, but also noticed that the test rendering did not include the data for the `selectionDirection`, so perhaps I am going about it wrong.