### PR TITLE
Update Samsung Internet browser data

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -73,6 +73,10 @@
         },
         "7.4": {
           "release_date": "2018-05-31",
+          "status": "current"
+        },
+        "8.2": {
+          "release_date": "2018-09-03",
           "status": "beta"
         }
       }

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -68,7 +68,7 @@
           "status": "retired"
         },
         "7.2": {
-          "release_date": "2018-03-07",
+          "release_date": "2018-06-20",
           "status": "retired"
         },
         "7.4": {

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -76,7 +76,6 @@
           "status": "current"
         },
         "8.2": {
-          "release_date": "2018-09-03",
           "status": "beta"
         }
       }

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -69,10 +69,10 @@
         },
         "7.2": {
           "release_date": "2018-03-07",
-          "status": "current"
+          "status": "retired"
         },
         "7.4": {
-          "release_date": "2018-05-31",
+          "release_date": "2018-09-12",
           "status": "current"
         },
         "8.2": {


### PR DESCRIPTION
Found out that the Samsung internet browser data was a bit out of date.

Managed to find two medium blog posts that helped me to get the data as up to date as I could

[https://medium.com/samsung-internet-dev/samsung-internet-7-4-is-stable-lets-check-out-what-s-new-d5c7b56897de](https://medium.com/samsung-internet-dev/samsung-internet-7-4-is-stable-lets-check-out-what-s-new-d5c7b56897de)
[https://medium.com/samsung-internet-dev/samsung-internet-7-4-is-stable-lets-check-out-what-s-new-d5c7b56897de](https://medium.com/samsung-internet-dev/hello-samsung-internet-8-2-beta-521e4b215fb3)