### PR TITLE
Enforce browser order in compatibility tables [MERGE #2889 FIRST]

### DIFF
--- a/test/sample-data.json
+++ b/test/sample-data.json
@@ -5,13 +5,6 @@
         "__compat": {
           "description": "Tests for various notes",
           "support": {
-            "webview_android": {
-              "version_added": "4",
-              "notes": [
-                "First note",
-                "Second note"
-              ]
-            },
             "chrome": {
               "version_added": "1",
               "notes": [
@@ -57,6 +50,13 @@
             },
             "samsunginternet_android": {
               "version_added": "5.0"
+            },
+            "webview_android": {
+              "version_added": "4",
+              "notes": [
+                "First note",
+                "Second note"
+              ]
             }
           },
           "status": {
@@ -69,9 +69,6 @@
       "featureWithSubfeatures": {
         "__compat": {
           "support": {
-            "webview_android": {
-              "version_added": "4"
-            },
             "chrome": {
               "version_added": "1",
               "notes": [
@@ -115,6 +112,9 @@
             },
             "samsunginternet_android": {
               "version_added": "5.0"
+            },
+            "webview_android": {
+              "version_added": "4"
             }
           },
           "status": {
@@ -127,9 +127,6 @@
           "__compat": {
             "description": "This is a sub feature with complex support statements",
             "support": {
-              "webview_android": {
-                "version_added": "4"
-              },
               "chrome": [
                 {
                   "version_added": "35",
@@ -233,6 +230,9 @@
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "4"
               }
             },
             "status": {

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -2,6 +2,26 @@
 const fs = require('fs');
 const path = require('path');
 
+function orderSupportBlock(name, val) {
+    if (name == 'support') {
+        /*
+        Return a new "support_block" object whose first-level properties
+        (browser names) have been ordered according to Array.prototype.sort,
+        and so will be stringified in that order as well. This relies on
+        guaranteed "own" property ordering, which is insertion order for
+        non-integer keys (which is our case). See:
+
+        http://2ality.com/2015/10/property-traversal-order-es6.html
+        http://node.green/#ES2015-misc-own-property-order
+        */
+        return Object.keys(val).sort().reduce(function(result, key) {
+            result[key] = val[key];
+            return result;
+        }, {});
+    }
+    return val;
+}
+
 function jsonDiff(actual, expected) {
   var actualLines = actual.split(/\n/);
   var expectedLines = expected.split(/\n/);
@@ -20,7 +40,7 @@ function jsonDiff(actual, expected) {
 function testStyle(filename) {
   let hasErrors = false;
   let actual = fs.readFileSync(filename, 'utf-8').trim();
-  let expected = JSON.stringify(JSON.parse(actual), null, 2);
+  let expected = JSON.stringify(JSON.parse(actual), orderSupportBlock, 2);
 
   const {platform} = require("os");
   if (platform() === "win32") { // prevent false positives from git.core.autocrlf on Windows


### PR DESCRIPTION
This PR is intended to enforce an alphabetical order in `__compat.support`, as originally proposed by #1474. This is one of two PRs that supersedes #1474, whereas the other one (#2889) sorts the browser compatibility order.

Warning: make sure to merge #2889 first before merging this one, else Travis tests will always fail.
Warning: Existing PRs will need to be updated to adhere to this new rule.