### PR TITLE
fix(css): `:-moz-any-link` is no longer supported

### DIFF
--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -25,20 +25,22 @@
             },
             "firefox": [
               {
-                "prefix": "-moz-",
-                "version_added": true
+                "version_added": "50"
               },
               {
-                "version_added": "50"
+                "version_added": true,
+                "version_removed": true,
+                "prefix": "-moz-"
               }
             ],
             "firefox_android": [
               {
-                "prefix": "-moz-",
-                "version_added": true
+                "version_added": "50"
               },
               {
-                "version_added": "50"
+                "version_added": true,
+                "version_removed": true,
+                "prefix": "-moz-"
               }
             ],
             "ie": {

--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -28,7 +28,7 @@
                 "version_added": "50"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "version_removed": true,
                 "prefix": "-moz-"
               }
@@ -38,7 +38,7 @@
                 "version_added": "50"
               },
               {
-                "version_added": true,
+                "version_added": "4",
                 "version_removed": true,
                 "prefix": "-moz-"
               }


### PR DESCRIPTION
Can be verified by running `document.querySelector(':-moz-any-link')`, which throws a `SyntaxError`, as `:-moz-any-link` is no longer supported.