### PR TITLE
Add json schema data to the .vscode/settings.json file.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,29 @@
     "status",
     "standard_track",
     "deprecated"
+  ],
+  "json.schemas": [
+    {
+      "fileMatch": [
+        "/api/*.json",
+        "/css/*.json",
+        "/html/*.json",
+        "/http/*.json",
+        "/javascript/*.json",
+        "/mathml/*.json",
+        "/svg/*.json",
+        "/webdriver/*.json",
+        "/webextensions/*.json",
+        "/xpath/*.json",
+        "/xslt/*.json",
+      ],
+      "url": "/schemas/compat-data.schema.json"
+    },
+    {
+      "fileMatch": [
+        "/browsers/*.json"
+      ],
+      "url": "/schemas/browsers.schema.json"
+    }
   ]
 }


### PR DESCRIPTION
With this change to `.vscode/settings.json`, VS Code will automatically point out errors with the current JSON file based on the schema. It'll also make the editor auto-suggest properties, display property descriptions (which the schemas don't currently have, but they could be added if we want them) and other nice things.

Value isn't accepted, lists accepted values:

<img width="619" alt="screen shot 2018-10-02 at 4 37 40 pm" src="https://user-images.githubusercontent.com/2977353/46380931-7f9e2c80-c661-11e8-958f-3f2b01cfb857.png">

An example of how descriptions would work if we added them to the schema:

<img width="336" alt="screen shot 2018-10-02 at 4 27 20 pm" src="https://user-images.githubusercontent.com/2977353/46380581-0f42db80-c660-11e8-8452-550c15c8a371.png">

A list of missing, required properties:

<img width="412" alt="screen shot 2018-10-02 at 4 31 18 pm" src="https://user-images.githubusercontent.com/2977353/46380723-a019b700-c660-11e8-9da7-82e9670c1f3b.png">

The list of properties that could be added (I used the command palette's "Trigger Suggest" function to show this, not sure how you'd get this to show otherwise):

<img width="567" alt="screen shot 2018-10-02 at 4 39 21 pm" src="https://user-images.githubusercontent.com/2977353/46381008-bd02ba00-c661-11e8-9506-f309cc747b81.png">

What happens when you have a URL that doesn't match the regex for `mdn_url`:

<img width="684" alt="screen shot 2018-10-02 at 4 47 15 pm" src="https://user-images.githubusercontent.com/2977353/46381293-e3752500-c662-11e8-8b39-d276822d02f5.png">

See also the relevant [VS Code Documentation](https://code.visualstudio.com/docs/languages/json#_mapping-to-a-schema-in-the-workspace) for this feature.