### PR TITLE
Add opera_android data

### DIFF
--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -60,7 +60,7 @@
               "version_added": "30"
             },
             {
-              "version_added": "12.10"
+              "version_added": "12.1"
             },
             {
               "prefix": "o",

--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -190,7 +190,7 @@
               "version_added": "31"
             },
             "opera_android": {
-              "version_added": "31"
+              "version_added": "32"
             },
             "safari": {
               "version_added": false

--- a/api/AudioListener.json
+++ b/api/AudioListener.json
@@ -142,7 +142,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -195,7 +195,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -248,7 +248,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -301,7 +301,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -354,7 +354,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -407,7 +407,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -518,7 +518,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -571,7 +571,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -624,7 +624,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -133,7 +133,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "6"
@@ -184,7 +184,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "6"

--- a/api/Body.json
+++ b/api/Body.json
@@ -121,7 +121,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": null

--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -23,7 +23,7 @@
             "version_added": "41"
           },
           "opera_android": {
-            "version_added": "41"
+            "version_added": "42"
           },
           "safari": {
             "version_added": false
@@ -65,7 +65,7 @@
               "version_added": "41"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -107,7 +107,7 @@
               "version_added": "41"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -149,7 +149,7 @@
               "version_added": "41"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -233,7 +233,7 @@
               "version_added": "41"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -275,7 +275,7 @@
               "version_added": "41"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false

--- a/api/Cache.json
+++ b/api/Cache.json
@@ -99,7 +99,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "31",
+              "version_added": "32",
               "notes": [
                 "Requires HTTPS from version 33."
               ]

--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -272,7 +272,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "41"
+                "version_added": "42"
               },
               {
                 "version_added": "27",

--- a/api/CanvasGradient.json
+++ b/api/CanvasGradient.json
@@ -33,7 +33,7 @@
             "version_added": "9"
           },
           "opera_android": {
-            "version_added": "10.0"
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "3.1"

--- a/api/CanvasPattern.json
+++ b/api/CanvasPattern.json
@@ -32,7 +32,7 @@
             "version_added": "9"
           },
           "opera_android": {
-            "version_added": "10.0"
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "3.1"

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -657,7 +657,7 @@
               "version_added": "41"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "42"
             },
             "safari": {
               "version_added": true

--- a/api/ChildNode.json
+++ b/api/ChildNode.json
@@ -32,7 +32,7 @@
             "version_added": "10"
           },
           "opera_android": {
-            "version_added": "10"
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "4"
@@ -184,7 +184,7 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "7"

--- a/api/ChildNode.json
+++ b/api/ChildNode.json
@@ -82,7 +82,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -133,7 +133,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -235,7 +235,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false

--- a/api/Clients.json
+++ b/api/Clients.json
@@ -136,7 +136,7 @@
               "version_added": "38"
             },
             "opera_android": {
-              "version_added": "38"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -258,7 +258,7 @@
                 "version_added": "38"
               },
               "opera_android": {
-                "version_added": "38"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": false
@@ -353,7 +353,7 @@
               "version_added": "38"
             },
             "opera_android": {
-              "version_added": "38"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false

--- a/api/Coordinates.json
+++ b/api/Coordinates.json
@@ -35,7 +35,7 @@
             }
           ],
           "opera_android": {
-            "version_added": "10.6"
+            "version_added": "11"
           },
           "safari": {
             "version_added": "5"
@@ -142,7 +142,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "10.6"
+              "version_added": "11"
             },
             "safari": {
               "version_added": "5"
@@ -199,7 +199,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "10.6"
+              "version_added": "11"
             },
             "safari": {
               "version_added": "5"
@@ -256,7 +256,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "10.6"
+              "version_added": "11"
             },
             "safari": {
               "version_added": "5"
@@ -313,7 +313,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "10.6"
+              "version_added": "11"
             },
             "safari": {
               "version_added": "5"
@@ -370,7 +370,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "10.6"
+              "version_added": "11"
             },
             "safari": {
               "version_added": "5"
@@ -427,7 +427,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "10.6"
+              "version_added": "11"
             },
             "safari": {
               "version_added": "5"
@@ -484,7 +484,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "10.6"
+              "version_added": "11"
             },
             "safari": {
               "version_added": "5"

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -87,7 +87,7 @@
             "version_added": "41"
           },
           "opera_android": {
-            "version_added": "41"
+            "version_added": "42"
           },
           "safari": {
             "version_added": "10.1"
@@ -328,7 +328,7 @@
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
-                "version_added": "41",
+                "version_added": "42",
                 "notes": "Support for 'Autonomous custom elements' only."
               }
             ],
@@ -475,7 +475,7 @@
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
-                "version_added": "41",
+                "version_added": "42",
                 "notes": "Support for 'Autonomous custom elements' only."
               }
             ],
@@ -673,7 +673,7 @@
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
-                "version_added": "41",
+                "version_added": "42",
                 "notes": "Support for 'Autonomous custom elements' only."
               }
             ],

--- a/api/Document.json
+++ b/api/Document.json
@@ -2076,7 +2076,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -3929,7 +3929,7 @@
               "version_added": "7"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -4482,7 +4482,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": true
@@ -6422,7 +6422,7 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.2"
@@ -6470,7 +6470,7 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.2"

--- a/api/Document.json
+++ b/api/Document.json
@@ -6901,7 +6901,7 @@
               "version_added": "31"
             },
             "opera_android": {
-              "version_added": "31"
+              "version_added": "32"
             },
             "safari": {
               "version_added": "9"

--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -134,7 +134,7 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.2"
@@ -185,7 +185,7 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.2"
@@ -237,7 +237,7 @@
               "version_added": "15"
             },
             "opera_android": {
-              "version_added": "5"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": false

--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -29,7 +29,7 @@
             "version_added": "40"
           },
           "opera_android": {
-            "version_added": "40"
+            "version_added": "42"
           },
           "safari": {
             "version_added": true
@@ -79,7 +79,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": true
@@ -130,7 +130,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": true
@@ -232,7 +232,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": true
@@ -283,7 +283,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": true
@@ -372,7 +372,7 @@
               "prefix": "webkit"
             },
             "opera_android": {
-              "version_added": "40",
+              "version_added": "42",
               "prefix": "webkit"
             },
             "safari": {
@@ -428,7 +428,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": true
@@ -479,7 +479,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": true
@@ -530,7 +530,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": true

--- a/api/Element.json
+++ b/api/Element.json
@@ -138,7 +138,7 @@
               "version_added": "23"
             },
             "opera_android": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "safari": {
               "version_added": null
@@ -319,7 +319,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10"
@@ -4520,7 +4520,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": true

--- a/api/Event.json
+++ b/api/Event.json
@@ -77,7 +77,7 @@
               "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": "11.6"
+              "version_added": "12"
             },
             "safari": {
               "version_added": "6"

--- a/api/Event.json
+++ b/api/Event.json
@@ -276,7 +276,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": null
@@ -346,11 +346,11 @@
             ],
             "opera_android": [
               {
-                "version_added": "40"
+                "version_added": "42"
               },
               {
                 "version_added": "37",
-                "version_removed": "40",
+                "version_removed": "42",
                 "alternative_name": "deepPath"
               }
             ],

--- a/api/EventListener.json
+++ b/api/EventListener.json
@@ -32,7 +32,7 @@
             "version_added": "7"
           },
           "opera_android": {
-            "version_added": "6"
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "1"
@@ -79,7 +79,7 @@
               "version_added": "7"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -32,7 +32,7 @@
             "version_added": "7"
           },
           "opera_android": {
-            "version_added": "7"
+            "version_added": "10.1"
           },
           "safari": [
             {
@@ -159,7 +159,7 @@
               "version_added": "7"
             },
             "opera_android": {
-              "version_added": "7"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -209,7 +209,7 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "11.6"
+                "version_added": "12"
               },
               "safari": {
                 "version_added": true
@@ -583,7 +583,7 @@
               "version_added": "7"
             },
             "opera_android": {
-              "version_added": "7"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -633,7 +633,7 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "11.6"
+                "version_added": "12"
               },
               "safari": {
                 "version_added": true

--- a/api/FileError.json
+++ b/api/FileError.json
@@ -44,7 +44,7 @@
           },
           "opera_android": {
             "version_added": true,
-            "version_removed": "40"
+            "version_removed": "42"
           },
           "safari": {
             "version_added": false

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -2283,7 +2283,7 @@
               "version_added": "17"
             },
             "opera_android": {
-              "version_added": "17"
+              "version_added": "18"
             },
             "safari": {
               "version_added": true
@@ -2334,7 +2334,7 @@
               "version_added": "17"
             },
             "opera_android": {
-              "version_added": "17"
+              "version_added": "18"
             },
             "safari": {
               "version_added": true

--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -286,7 +286,7 @@
               "version_added": "38"
             },
             "opera_android": {
-              "version_added": "38"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "11.1"

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -439,7 +439,7 @@
               "version_added": "38"
             },
             "opera_android": {
-              "version_added": "38"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "11.1"

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -33,7 +33,7 @@
             "notes": "Opera Mini 5.0 and later has partial support."
           },
           "opera_android": {
-            "version_added": "10",
+            "version_added": "10.1",
             "notes": "Opera Mini 5.0 and later has partial support."
           },
           "safari": {

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -237,7 +237,7 @@
               "version_added": "36"
             },
             "opera_android": {
-              "version_added": "38"
+              "version_added": "42"
             },
             "safari": {
               "version_added": null

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -1786,7 +1786,7 @@
               "version_added": "38"
             },
             "opera_android": {
-              "version_added": "38"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "11.1"

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -516,7 +516,7 @@
               "version_added": "38"
             },
             "opera_android": {
-              "version_added": "38"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "11.1"

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -172,7 +172,7 @@
               "version_added": "38"
             },
             "opera_android": {
-              "version_added": "38"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "11.1"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2119,7 +2119,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "52"

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -33,7 +33,7 @@
             "version_added": "2"
           },
           "opera_android": {
-            "version_added": "1"
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "1"
@@ -656,7 +656,7 @@
               "version_added": "2"
             },
             "opera_android": {
-              "version_added": "1"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -90,7 +90,7 @@
             "version_added": "40"
           },
           "opera_android": {
-            "version_added": "40"
+            "version_added": "42"
           },
           "safari": {
             "version_added": "10.1"
@@ -198,7 +198,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10.1"
@@ -307,7 +307,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10.1"

--- a/api/HashChangeEvent.json
+++ b/api/HashChangeEvent.json
@@ -32,7 +32,7 @@
             "version_added": "10.6"
           },
           "opera_android": {
-            "version_added": "11.0"
+            "version_added": "11"
           },
           "safari": {
             "version_added": "5"

--- a/api/IDBKeyRange.json
+++ b/api/IDBKeyRange.json
@@ -478,7 +478,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10.1"

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -32,7 +32,7 @@
             "version_added": "9"
           },
           "opera_android": {
-            "version_added": "10"
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "3.1"

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -440,7 +440,7 @@
               "version_added": "38"
             },
             "opera_android": {
-              "version_added": "38"
+              "version_added": "42"
             },
             "safari": {
               "version_added": true
@@ -491,7 +491,7 @@
                 "version_added": "38"
               },
               "opera_android": {
-                "version_added": "38"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": null
@@ -543,7 +543,7 @@
                 "version_added": "38"
               },
               "opera_android": {
-                "version_added": "38"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": null
@@ -594,7 +594,7 @@
                 "version_added": "38"
               },
               "opera_android": {
-                "version_added": "38"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": null
@@ -702,7 +702,7 @@
             },
             "opera_android": {
               "version_added": true,
-              "version_removed": "41"
+              "version_removed": "42"
             },
             "safari": {
               "version_added": "5.1"

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -203,7 +203,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "11"
@@ -310,11 +310,11 @@
             ],
             "opera_android": [
               {
-                "version_added": "40"
+                "version_added": "42"
               },
               {
                 "version_added": "34",
-                "version_removed": "40",
+                "version_removed": "42",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -201,7 +201,7 @@
             },
             "opera_android": {
               "version_added": true,
-              "version_removed": "39"
+              "version_removed": "42"
             },
             "safari": {
               "version_added": null
@@ -260,7 +260,7 @@
             },
             "opera_android": {
               "version_added": true,
-              "version_removed": "39"
+              "version_removed": "42"
             },
             "safari": {
               "version_added": null

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -674,7 +674,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "10.6"
+              "version_added": "11"
             },
             "safari": {
               "version_added": "5"

--- a/api/NavigatorGeolocation.json
+++ b/api/NavigatorGeolocation.json
@@ -38,7 +38,7 @@
             }
           ],
           "opera_android": {
-            "version_added": "10"
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "5"

--- a/api/Node.json
+++ b/api/Node.json
@@ -606,7 +606,7 @@
               "version_added": "41"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10.1"
@@ -899,7 +899,7 @@
               "version_added": "38"
             },
             "opera_android": {
-              "version_added": "38"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10.1"

--- a/api/NodeFilter.json
+++ b/api/NodeFilter.json
@@ -32,7 +32,7 @@
             "version_added": "9"
           },
           "opera_android": {
-            "version_added": "9"
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "3"
@@ -82,7 +82,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"

--- a/api/NodeIterator.json
+++ b/api/NodeIterator.json
@@ -32,7 +32,7 @@
             "version_added": "9"
           },
           "opera_android": {
-            "version_added": "9"
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "3"
@@ -84,7 +84,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -135,7 +135,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -288,7 +288,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -339,7 +339,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -392,7 +392,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -443,7 +443,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -494,7 +494,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"

--- a/api/NonDocumentTypeChildNode.json
+++ b/api/NonDocumentTypeChildNode.json
@@ -30,7 +30,7 @@
             "version_added": "10"
           },
           "opera_android": {
-            "version_added": "10"
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "4"
@@ -77,7 +77,7 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "4"
@@ -125,7 +125,7 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "4"
@@ -173,7 +173,7 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "4"

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -273,7 +273,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": null
@@ -324,7 +324,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": null
@@ -597,7 +597,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": null
@@ -1311,7 +1311,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": null
@@ -1413,7 +1413,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": null

--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -188,7 +188,7 @@
               "version_added": "38"
             },
             "opera_android": {
-              "version_added": "38"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false

--- a/api/ParentNode.json
+++ b/api/ParentNode.json
@@ -696,7 +696,7 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.2"

--- a/api/ParentNode.json
+++ b/api/ParentNode.json
@@ -593,7 +593,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10"
@@ -644,7 +644,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10"

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -23,7 +23,7 @@
             "version_added": "39"
           },
           "opera_android": {
-            "version_added": "39"
+            "version_added": "42"
           },
           "safari": {
             "version_added": "11"
@@ -107,7 +107,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "11"
@@ -149,7 +149,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "11"
@@ -191,7 +191,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "11"

--- a/api/PerformanceObserverEntryList.json
+++ b/api/PerformanceObserverEntryList.json
@@ -32,7 +32,7 @@
             "version_added": "39"
           },
           "opera_android": {
-            "version_added": "39"
+            "version_added": "42"
           },
           "safari": {
             "version_added": "11"
@@ -82,7 +82,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -133,7 +133,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -184,7 +184,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -184,7 +184,7 @@
               "version_added": "41"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -337,7 +337,7 @@
               "version_added": "41"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -898,7 +898,7 @@
               "version_added": "41"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false

--- a/api/PositionOptions.json
+++ b/api/PositionOptions.json
@@ -39,7 +39,7 @@
               "version_added": "16"
             },
             {
-              "version_added": "10",
+              "version_added": "10.1",
               "version_removed": "14"
             }
           ],
@@ -153,7 +153,7 @@
                 "version_added": "16"
               },
               {
-                "version_added": "10",
+                "version_added": "10.1",
                 "version_removed": "14"
               }
             ],
@@ -216,7 +216,7 @@
                 "version_added": "16"
               },
               {
-                "version_added": "10",
+                "version_added": "10.1",
                 "version_removed": "14"
               }
             ],
@@ -279,7 +279,7 @@
                 "version_added": "16"
               },
               {
-                "version_added": "10",
+                "version_added": "10.1",
                 "version_removed": "14"
               }
             ],

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -894,7 +894,7 @@
                 "notes": "Promise based version and unprefixed."
               },
               {
-                "version_added": "38",
+                "version_added": "42",
                 "notes": "Promise based version.",
                 "version_removed": "43"
               }

--- a/api/Range.json
+++ b/api/Range.json
@@ -952,7 +952,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": true
@@ -999,7 +999,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": "9"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": true

--- a/api/ReadableStreamDefaultController.json
+++ b/api/ReadableStreamDefaultController.json
@@ -55,7 +55,7 @@
             "version_added": "39"
           },
           "opera_android": {
-            "version_added": "39"
+            "version_added": "42"
           },
           "safari": {
             "version_added": null

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -29,7 +29,7 @@
             "version_added": "39"
           },
           "opera_android": {
-            "version_added": "39"
+            "version_added": "42"
           },
           "safari": {
             "version_added": null

--- a/api/Request.json
+++ b/api/Request.json
@@ -1300,7 +1300,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "11.1"

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -228,7 +228,7 @@
               "version_added": "38"
             },
             "opera_android": {
-              "version_added": "38"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "11.1"

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -79,7 +79,7 @@
               "version_added": "41"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10"

--- a/api/SVGRect.json
+++ b/api/SVGRect.json
@@ -32,7 +32,7 @@
             "version_added": "8"
           },
           "opera_android": {
-            "version_added": "8"
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "3.1"

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -749,7 +749,7 @@
                 "version_added": "39"
               },
               "opera_android": {
-                "version_added": "39"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": false
@@ -800,7 +800,7 @@
                 "version_added": "31"
               },
               "opera_android": {
-                "version_added": "31"
+                "version_added": "32"
               },
               "safari": {
                 "version_added": false

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -57,7 +57,7 @@
             "version_added": "40"
           },
           "opera_android": {
-            "version_added": "40"
+            "version_added": "42"
           },
           "safari": {
             "version_added": "10.1"
@@ -168,7 +168,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false,
@@ -249,7 +249,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10.1"
@@ -328,7 +328,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10.1"
@@ -407,7 +407,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10.1"

--- a/api/Slotable.json
+++ b/api/Slotable.json
@@ -90,7 +90,7 @@
             "version_added": "40"
           },
           "opera_android": {
-            "version_added": "40"
+            "version_added": "42"
           },
           "safari": {
             "version_added": "10.1"
@@ -198,7 +198,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10.1"

--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -255,7 +255,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "8"
@@ -321,7 +321,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "8"

--- a/api/Text.json
+++ b/api/Text.json
@@ -199,7 +199,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10.1"

--- a/api/TreeWalker.json
+++ b/api/TreeWalker.json
@@ -29,7 +29,7 @@
             "version_added": "9"
           },
           "opera_android": {
-            "version_added": "9"
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "3"
@@ -76,7 +76,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -126,7 +126,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -174,7 +174,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -222,7 +222,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -270,7 +270,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -318,7 +318,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -366,7 +366,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -414,7 +414,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -462,7 +462,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -510,7 +510,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -558,7 +558,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -606,7 +606,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"

--- a/api/Window.json
+++ b/api/Window.json
@@ -1602,7 +1602,7 @@
               "version_added": "41"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10.1"

--- a/api/Window.json
+++ b/api/Window.json
@@ -2540,7 +2540,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -2605,7 +2605,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -4049,7 +4049,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -4100,7 +4100,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -226,7 +226,7 @@
               },
               "opera_android": {
                 "version_added": true,
-                "version_removed": "38"
+                "version_removed": "42"
               },
               "safari": {
                 "version_added": true,

--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -437,7 +437,7 @@
                 "version_added": "39"
               },
               "opera_android": {
-                "version_added": "39"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": false
@@ -776,7 +776,7 @@
                 "version_added": "39"
               },
               "opera_android": {
-                "version_added": "39"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": "11.1"

--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -276,7 +276,7 @@
               "version_added": "4"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "4"
@@ -336,7 +336,7 @@
               "version_added": "4"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "4"
@@ -1100,7 +1100,7 @@
               "version_added": "4"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -1208,7 +1208,7 @@
               "version_added": "4"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -1,6 +1,7 @@
 {
   "browsers": {
     "opera_android": {
+      "name": "Opera Android",
       "releases": {
         "10.1": {
           "release_date": "2010-11-09",
@@ -209,15 +210,37 @@
         "51": {
           "release_date": "2018-02-07",
           "release_notes": "https://dev.opera.com/blog/opera-51/",
-          "status": "current"
+          "status": "retired"
         },
         "52": {
-          "status": "beta"
+          "release_date": "2018-03-22",
+          "release_notes": "https://dev.opera.com/blog/opera-52/",
+          "status": "retired"
         },
         "53": {
-          "status": "nightly"
+          "release_date": "2018-05-10",
+          "release_notes": "https://dev.opera.com/blog/opera-53/",
+          "status": "current"
         },
         "54": {
+          "status": "beta"
+        },
+        "55": {
+          "status": "nightly"
+        },
+        "56": {
+          "status": "planned"
+        },
+        "57": {
+          "status": "planned"
+        },
+        "58": {
+          "status": "planned"
+        },
+        "59": {
+          "status": "planned"
+        },
+        "60": {
           "status": "planned"
         }
       }

--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -19,6 +19,7 @@
           "status": "retired"
         },
         "11.5": {
+          "release_date": "2011-11-02",
           "status": "retired"
         },
         "12": {
@@ -37,211 +38,120 @@
           "status": "retired"
         },
         "15": {
+          "release_date": "2013-07-02",
+          "status": "retired"
+        },
+        "15.10": {
+          "release_date": "2013-08-08",
           "status": "retired"
         },
         "16": {
-          "status": "retired"
-        },
-        "17": {
+          "release_date": "2013-09-18",
+          "release_notes": "https://web.archive.org/web/20130921055319/http://my.opera.com/chooseopera/blog/2013/09/18/opera-16-for-android-is-released-2",
           "status": "retired"
         },
         "18": {
+          "release_date": "2013-11-20",
           "status": "retired"
         },
         "19": {
-          "release_date": "2014-01-28",
-          "release_notes": "https://dev.opera.com/blog/opera-19/",
+          "release_date": "2014-01-22",
           "status": "retired"
         },
         "20": {
-          "release_date": "2014-03-04",
-          "release_notes": "https://dev.opera.com/blog/opera-20/",
+          "release_date": "2014-03-06",
+          "status": "retired"
+        },
+        "20.10": {
+          "release_date": "2014-03-18",
           "status": "retired"
         },
         "21": {
-          "release_date": "2014-05-06",
-          "release_notes": "https://dev.opera.com/blog/opera-21/",
+          "release_date": "2014-04-22",
           "status": "retired"
         },
         "22": {
-          "release_date": "2014-06-03",
-          "release_notes": "https://dev.opera.com/blog/opera-22/",
-          "status": "retired"
-        },
-        "23": {
-          "release_date": "2014-07-22",
-          "release_notes": "https://dev.opera.com/blog/opera-23/",
+          "release_date": "2014-06-17",
           "status": "retired"
         },
         "24": {
-          "release_date": "2014-09-02",
-          "release_notes": "https://dev.opera.com/blog/opera-24/",
+          "release_date": "2014-09-10",
           "status": "retired"
         },
         "25": {
-          "release_date": "2014-10-15",
-          "release_notes": "https://dev.opera.com/blog/opera-25/",
+          "release_date": "2014-10-16",
           "status": "retired"
         },
         "26": {
-          "release_date": "2014-12-03",
-          "release_notes": "https://dev.opera.com/blog/opera-26/",
+          "release_date": "2014-12-15",
           "status": "retired"
         },
         "27": {
-          "release_date": "2015-01-27",
-          "release_notes": "https://dev.opera.com/blog/opera-27/",
+          "release_date": "2015-01-29",
           "status": "retired"
         },
         "28": {
           "release_date": "2015-03-10",
-          "release_notes": "https://dev.opera.com/blog/opera-28/",
           "status": "retired"
         },
         "29": {
           "release_date": "2015-04-28",
-          "release_notes": "https://dev.opera.com/blog/opera-29/",
           "status": "retired"
         },
         "30": {
-          "release_date": "2015-06-09",
-          "release_notes": "https://dev.opera.com/blog/opera-30/",
-          "status": "retired"
-        },
-        "31": {
-          "release_date": "2015-08-04",
-          "release_notes": "https://dev.opera.com/blog/opera-31/",
+          "release_date": "2015-06-10",
           "status": "retired"
         },
         "32": {
-          "release_date": "2015-09-15",
-          "release_notes": "https://dev.opera.com/blog/opera-32/",
+          "release_date": "2015-09-23",
           "status": "retired"
         },
         "33": {
-          "release_date": "2015-10-27",
-          "release_notes": "https://dev.opera.com/blog/opera-33/",
+          "release_date": "2015-11-02",
           "status": "retired"
         },
         "34": {
-          "release_date": "2015-12-08",
-          "release_notes": "https://dev.opera.com/blog/opera-34/",
+          "release_date": "2015-12-15",
           "status": "retired"
         },
         "35": {
-          "release_date": "2016-02-02",
-          "release_notes": "https://dev.opera.com/blog/opera-35/",
+          "release_date": "2016-02-03",
           "status": "retired"
         },
         "36": {
-          "release_date": "2016-03-15",
-          "release_notes": "https://dev.opera.com/blog/opera-36/",
+          "release_date": "2016-03-31",
           "status": "retired"
         },
         "37": {
-          "release_date": "2016-05-04",
-          "release_notes": "https://dev.opera.com/blog/opera-37/",
+          "release_date": "2016-06-15",
           "status": "retired"
         },
-        "38": {
-          "release_date": "2016-06-08",
-          "release_notes": "https://dev.opera.com/blog/opera-38/",
-          "status": "retired"
-        },
-        "39": {
-          "release_date": "2016-08-02",
-          "release_notes": "https://dev.opera.com/blog/opera-39/",
-          "status": "retired"
-        },
-        "40": {
-          "release_date": "2016-09-20",
-          "release_notes": "https://dev.opera.com/blog/opera-40/",
-          "status": "retired"
-        },
-        "41": {
-          "release_date": "2016-10-25",
-          "release_notes": "https://dev.opera.com/blog/opera-41/",
+        "37.10": {
+          "release_date": "2016-09-22",
           "status": "retired"
         },
         "42": {
-          "release_date": "2016-12-13",
-          "release_notes": "https://dev.opera.com/blog/opera-42/",
+          "release_date": "2017-02-20",
           "status": "retired"
         },
         "43": {
-          "release_date": "2017-02-07",
-          "release_notes": "https://dev.opera.com/blog/opera-43/",
-          "status": "retired"
-        },
-        "44": {
-          "release_date": "2017-03-21",
-          "release_notes": "https://dev.opera.com/blog/opera-44/",
-          "status": "retired"
-        },
-        "45": {
-          "release_date": "2017-05-10",
-          "release_notes": "https://dev.opera.com/blog/opera-45/",
-          "status": "retired"
-        },
-        "46": {
-          "release_date": "2017-06-22",
-          "release_notes": "https://dev.opera.com/blog/opera-46/",
-          "status": "retired"
-        },
-        "47": {
-          "release_date": "2017-08-09",
-          "release_notes": "https://dev.opera.com/blog/opera-47/",
-          "status": "retired"
-        },
-        "48": {
           "release_date": "2017-09-27",
           "status": "retired"
         },
-        "49": {
-          "release_date": "2017-11-08",
-          "release_notes": "https://dev.opera.com/blog/opera-49/",
+        "44": {
+          "release_date": "2017-12-11",
           "status": "retired"
         },
-        "50": {
-          "release_date": "2018-01-04",
-          "release_notes": "https://dev.opera.com/blog/opera-50/",
+        "45": {
+          "release_date": "2017-02-14",
           "status": "retired"
         },
-        "51": {
-          "release_date": "2018-02-07",
-          "release_notes": "https://dev.opera.com/blog/opera-51/",
-          "status": "retired"
-        },
-        "52": {
-          "release_date": "2018-03-22",
-          "release_notes": "https://dev.opera.com/blog/opera-52/",
-          "status": "retired"
-        },
-        "53": {
-          "release_date": "2018-05-10",
-          "release_notes": "https://dev.opera.com/blog/opera-53/",
+        "46": {
+          "release_date": "2017-05-14",
           "status": "current"
         },
-        "54": {
+        "47": {
           "status": "beta"
-        },
-        "55": {
-          "status": "nightly"
-        },
-        "56": {
-          "status": "planned"
-        },
-        "57": {
-          "status": "planned"
-        },
-        "58": {
-          "status": "planned"
-        },
-        "59": {
-          "status": "planned"
-        },
-        "60": {
-          "status": "planned"
         }
       }
     }

--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -1,142 +1,50 @@
 {
   "browsers": {
-    "opera": {
-      "name": "Opera",
+    "opera_android": {
       "releases": {
-        "2": {
-          "release_date": "1996-07-14",
-          "status": "retired"
-        },
-        "3": {
-          "release_date": "1997-12-01",
-          "status": "retired"
-        },
-        "3.5": {
-          "release_date": "1998-11-18",
-          "status": "retired"
-        },
-        "3.6": {
-          "release_date": "1999-05-06",
-          "status": "retired"
-        },
-        "4": {
-          "release_date": "2000-06-28",
-          "status": "retired"
-        },
-        "5": {
-          "release_date": "2000-12-06",
-          "status": "retired"
-        },
-        "5.1": {
-          "release_date": "2001-04-10",
-          "status": "retired"
-        },
-        "6": {
-          "release_date": "2001-12-18",
-          "status": "retired"
-        },
-        "7": {
-          "release_date": "2003-01-28",
-          "status": "retired"
-        },
-        "7.1": {
-          "release_date": "2003-04-11",
-          "status": "retired"
-        },
-        "7.2": {
-          "release_date": "2003-09-23",
-          "status": "retired"
-        },
-        "7.5": {
-          "release_date": "2004-05-12",
-          "status": "retired"
-        },
-        "8": {
-          "release_date": "2005-04-19",
-          "status": "retired"
-        },
-        "8.5": {
-          "release_date": "2005-09-20",
-          "status": "retired"
-        },
-        "9": {
-          "release_date": "2006-06-20",
-          "status": "retired"
-        },
-        "9.1": {
-          "release_date": "2006-12-18",
-          "status": "retired"
-        },
-        "9.2": {
-          "release_date": "2007-04-11",
-          "status": "retired"
-        },
-        "9.5": {
-          "release_date": "2008-06-12",
-          "status": "retired"
-        },
-        "9.6": {
-          "release_date": "2008-10-08",
-          "status": "retired"
-        },
-        "10": {
-          "release_date": "2009-09-01",
-          "status": "retired"
-        },
         "10.1": {
-          "release_date": "2009-11-23",
-          "status": "retired"
-        },
-        "10.5": {
-          "release_date": "2010-03-02",
-          "status": "retired"
-        },
-        "10.6": {
-          "release_date": "2010-07-01",
+          "release_date": "2010-11-09",
+          "release_notes": "https://dev.opera.com/blog/opera-mobile-10-1-beta-for-android-is-here/",
           "status": "retired"
         },
         "11": {
-          "release_date": "2010-12-16",
+          "release_date": "2011-03-22",
+          "release_notes": "https://dev.opera.com/blog/opera-mobile-11-for-maemo-meego-windows/",
           "status": "retired"
         },
         "11.1": {
-          "release_date": "2011-04-12",
+          "release_date": "2011-06-30",
+          "release_notes": "https://dev.opera.com/blog/opera-mobile-11-1-new-features-and-additions/",
           "status": "retired"
         },
         "11.5": {
-          "release_date": "2011-06-28",
-          "status": "retired"
-        },
-        "11.6": {
-          "release_date": "2011-12-06",
           "status": "retired"
         },
         "12": {
-          "release_date": "2012-06-14",
+          "release_date": "2012-02-25",
+          "release_notes": "https://dev.opera.com/blog/opera-mobile-12-and-introducing-opera-mini-next/",
           "status": "retired"
         },
         "12.1": {
-          "release_date": "2012-11-20",
+          "release_date": "2012-10-09",
+          "release_notes": "https://dev.opera.com/blog/opera-mobile-12-1-with-spdy-web-sockets-flexbox-and-more/",
+          "status": "retired"
+        },
+        "14": {
+          "release_date": "2013-05-21",
+          "release_notes": "https://dev.opera.com/blog/opera-14-for-android-is-out/",
           "status": "retired"
         },
         "15": {
-          "release_date": "2013-07-02",
-          "release_notes": "https://dev.opera.com/blog/introducing-opera-15-for-desktop-and-a-fast-release-cycle/",
           "status": "retired"
         },
         "16": {
-          "release_date": "2013-08-27",
-          "release_notes": "https://dev.opera.com/blog/opera-16-released-in-the-wild/",
           "status": "retired"
         },
         "17": {
-          "release_date": "2013-10-08",
-          "release_notes": "https://dev.opera.com/blog/opera-desktop-17-released/",
           "status": "retired"
         },
         "18": {
-          "release_date": "2013-11-19",
-          "release_notes": "https://dev.opera.com/blog/opera-desktop-18-released/",
           "status": "retired"
         },
         "19": {
@@ -301,43 +209,15 @@
         "51": {
           "release_date": "2018-02-07",
           "release_notes": "https://dev.opera.com/blog/opera-51/",
-          "status": "retired"
-        },
-        "52": {
-          "release_date": "2018-03-22",
-          "release_notes": "https://dev.opera.com/blog/opera-52/",
-          "status": "retired"
-        },
-        "53": {
-          "release_date": "2018-05-10",
-          "release_notes": "https://dev.opera.com/blog/opera-53/",
-          "status": "retired"
-        },
-        "54": {
-          "release_date": "2018-06-28",
-          "release_notes": "https://dev.opera.com/blog/opera-54/",
-          "status": "retired"
-        },
-        "55": {
-          "release_date": "2018-08-16",
-          "release_notes": "https://blogs.opera.com/desktop/2018/08/opera-55-offers-better-control-web-pages-accessible-bookmarks/",
-          "status": "retired"
-        },
-        "56": {
-          "release_date": "2018-09-25",
-          "release_notes": "https://dev.opera.com/blog/opera-56/",
           "status": "current"
         },
-        "57": {
+        "52": {
           "status": "beta"
         },
-        "58": {
+        "53": {
           "status": "nightly"
         },
-        "59": {
-          "status": "planned"
-        },
-        "60": {
+        "54": {
           "status": "planned"
         }
       }

--- a/css/at-rules/charset.json
+++ b/css/at-rules/charset.json
@@ -36,7 +36,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "4"

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -34,7 +34,7 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"
@@ -499,7 +499,7 @@
                 "version_added": "10"
               },
               "opera_android": {
-                "version_added": "10"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3.1"
@@ -549,7 +549,7 @@
                 "version_added": "10"
               },
               "opera_android": {
-                "version_added": "10"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3.1"

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -159,7 +159,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": "10",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -34,7 +34,7 @@
               "version_added": "9.2"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.3"
@@ -84,7 +84,7 @@
                 "version_added": "9.2"
               },
               "opera_android": {
-                "version_added": "9"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": false
@@ -135,7 +135,7 @@
                 "version_added": "9.2"
               },
               "opera_android": {
-                "version_added": "9"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1.3"

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -563,7 +563,7 @@
               },
               "opera_android": {
                 "prefix": "-o-",
-                "version_added": "8"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": null

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -33,7 +33,7 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -83,7 +83,7 @@
                 "version_added": "10.5"
               },
               "opera_android": {
-                "version_added": "10"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1.3"

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -33,7 +33,7 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": "5"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -66,7 +66,7 @@
               "notes": "In Opera prior to version 11.60, replaced elements with <code>border-radius</code> will not have rounded corners."
             },
             "opera_android": {
-              "version_added": ""
+              "version_added": "11"
             },
             "safari": [
               {

--- a/css/properties/clear.json
+++ b/css/properties/clear.json
@@ -33,7 +33,7 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -46,7 +46,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": null

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -33,7 +33,7 @@
               "version_added": "4"
             },
             "opera_android": {
-              "version_added": "9.5"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -83,7 +83,7 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": true

--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -33,7 +33,7 @@
               "version_added": "9.2"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"

--- a/css/properties/direction.json
+++ b/css/properties/direction.json
@@ -33,7 +33,7 @@
               "version_added": "9.2"
             },
             "opera_android": {
-              "version_added": "8"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.3"

--- a/css/properties/empty-cells.json
+++ b/css/properties/empty-cells.json
@@ -33,7 +33,7 @@
               "version_added": "4"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.2"

--- a/css/properties/filter.json
+++ b/css/properties/filter.json
@@ -122,7 +122,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "40"
+                "version_added": "42"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/float.json
+++ b/css/properties/float.json
@@ -33,7 +33,7 @@
               "version_added": "7"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -33,7 +33,7 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -33,7 +33,7 @@
               "version_added": "7"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -35,7 +35,7 @@
               "version_added": "7"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/font-variant-caps.json
+++ b/css/properties/font-variant-caps.json
@@ -59,7 +59,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": false

--- a/css/properties/font-variant-numeric.json
+++ b/css/properties/font-variant-numeric.json
@@ -59,7 +59,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "9.1"

--- a/css/properties/font-weight.json
+++ b/css/properties/font-weight.json
@@ -33,7 +33,7 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.3"

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -33,7 +33,7 @@
               "version_added": "7"
             },
             "opera_android": {
-              "version_added": "1"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/line-height.json
+++ b/css/properties/line-height.json
@@ -33,7 +33,7 @@
               "version_added": "7"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/list-style-image.json
+++ b/css/properties/list-style-image.json
@@ -33,7 +33,7 @@
               "version_added": "7"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/list-style.json
+++ b/css/properties/list-style.json
@@ -33,7 +33,7 @@
               "version_added": "7"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/margin-bottom.json
+++ b/css/properties/margin-bottom.json
@@ -33,7 +33,7 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/margin-left.json
+++ b/css/properties/margin-left.json
@@ -33,7 +33,7 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/margin-right.json
+++ b/css/properties/margin-right.json
@@ -33,7 +33,7 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/margin-top.json
+++ b/css/properties/margin-top.json
@@ -33,7 +33,7 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/margin.json
+++ b/css/properties/margin.json
@@ -33,7 +33,7 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/opacity.json
+++ b/css/properties/opacity.json
@@ -40,7 +40,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.2"

--- a/css/properties/outline.json
+++ b/css/properties/outline.json
@@ -41,7 +41,7 @@
               "version_added": "7"
             },
             "opera_android": {
-              "version_added": "7"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.2"

--- a/css/properties/table-layout.json
+++ b/css/properties/table-layout.json
@@ -33,7 +33,7 @@
               "version_added": "7"
             },
             "opera_android": {
-              "version_added": "9.8"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -107,7 +107,7 @@
                 }
               ],
               "opera_android": {
-                "version_added": "4",
+                "version_added": "10.1",
                 "notes": "The <code>blink</code> value does not have any effect."
               },
               "safari": {

--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -125,7 +125,7 @@
               },
               {
                 "prefix": "-o-",
-                "version_added": "10",
+                "version_added": "10.1",
                 "version_removed": "14"
               }
             ],

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -125,7 +125,7 @@
               },
               {
                 "prefix": "-o-",
-                "version_added": "10",
+                "version_added": "10.1",
                 "version_removed": "14"
               }
             ],

--- a/css/properties/unicode-bidi.json
+++ b/css/properties/unicode-bidi.json
@@ -33,7 +33,7 @@
               "version_added": "9.2"
             },
             "opera_android": {
-              "version_added": "8"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.3"

--- a/css/properties/visibility.json
+++ b/css/properties/visibility.json
@@ -37,7 +37,7 @@
               "version_added": "4"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/selectors/active.json
+++ b/css/selectors/active.json
@@ -34,7 +34,7 @@
               "version_added": "5"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/selectors/checked.json
+++ b/css/selectors/checked.json
@@ -34,7 +34,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9.5"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"

--- a/css/selectors/default.json
+++ b/css/selectors/default.json
@@ -34,7 +34,7 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "5"

--- a/css/selectors/disabled.json
+++ b/css/selectors/disabled.json
@@ -35,7 +35,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9.5"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"

--- a/css/selectors/empty.json
+++ b/css/selectors/empty.json
@@ -34,7 +34,7 @@
               "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"

--- a/css/selectors/enabled.json
+++ b/css/selectors/enabled.json
@@ -34,7 +34,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9.5"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"

--- a/css/selectors/first-child.json
+++ b/css/selectors/first-child.json
@@ -38,7 +38,7 @@
               "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "9.5"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"

--- a/css/selectors/first-of-type.json
+++ b/css/selectors/first-of-type.json
@@ -34,7 +34,7 @@
               "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.2"

--- a/css/selectors/focus.json
+++ b/css/selectors/focus.json
@@ -34,7 +34,7 @@
               "version_added": "7"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/selectors/invalid.json
+++ b/css/selectors/invalid.json
@@ -34,7 +34,7 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "5"

--- a/css/selectors/lang.json
+++ b/css/selectors/lang.json
@@ -34,7 +34,7 @@
               "version_added": "8"
             },
             "opera_android": {
-              "version_added": "8"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"

--- a/css/selectors/last-child.json
+++ b/css/selectors/last-child.json
@@ -34,7 +34,7 @@
               "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.2"

--- a/css/selectors/last-of-type.json
+++ b/css/selectors/last-of-type.json
@@ -34,7 +34,7 @@
               "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.2"

--- a/css/selectors/not.json
+++ b/css/selectors/not.json
@@ -34,7 +34,7 @@
               "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.2"

--- a/css/selectors/nth-child.json
+++ b/css/selectors/nth-child.json
@@ -35,7 +35,7 @@
               "notes": "Before Opera 15, Opera does not handle dynamically inserted elements for <code>:nth-child()</code>."
             },
             "opera_android": {
-              "version_added": "9.5",
+              "version_added": "10.1",
               "notes": "Before Opera 15, Opera does not handle dynamically inserted elements for <code>:nth-child()</code>."
             },
             "safari": {

--- a/css/selectors/nth-last-child.json
+++ b/css/selectors/nth-last-child.json
@@ -34,7 +34,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.2"

--- a/css/selectors/nth-last-of-type.json
+++ b/css/selectors/nth-last-of-type.json
@@ -34,7 +34,7 @@
               "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.2"

--- a/css/selectors/nth-of-type.json
+++ b/css/selectors/nth-of-type.json
@@ -34,7 +34,7 @@
               "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "9.5"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"

--- a/css/selectors/only-child.json
+++ b/css/selectors/only-child.json
@@ -34,7 +34,7 @@
               "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"

--- a/css/selectors/only-of-type.json
+++ b/css/selectors/only-of-type.json
@@ -34,7 +34,7 @@
               "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.2"

--- a/css/selectors/optional.json
+++ b/css/selectors/optional.json
@@ -34,7 +34,7 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "5"

--- a/css/selectors/required.json
+++ b/css/selectors/required.json
@@ -34,7 +34,7 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "5"

--- a/css/selectors/target.json
+++ b/css/selectors/target.json
@@ -34,7 +34,7 @@
               "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "9.5"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.3"

--- a/css/selectors/valid.json
+++ b/css/selectors/valid.json
@@ -34,7 +34,7 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "5"

--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -31,7 +31,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"

--- a/css/types/timing-function.json
+++ b/css/types/timing-function.json
@@ -34,7 +34,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -504,7 +504,7 @@
                 "version_added": "38"
               },
               "opera_android": {
-                "version_added": "38"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": "11.1"

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -532,7 +532,7 @@
                 "version_added": "38"
               },
               "opera_android": {
-                "version_added": "38"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": "11.1"

--- a/html/elements/blink.json
+++ b/html/elements/blink.json
@@ -36,7 +36,7 @@
               "version_removed": "15"
             },
             "opera_android": {
-              "version_added": "2",
+              "version_added": "10.1",
               "version_removed": "14"
             },
             "safari": {

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -614,7 +614,7 @@
                 "version_added": "38"
               },
               "opera_android": {
-                "version_added": "38"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": "11.1"
@@ -917,7 +917,7 @@
                   "version_added": "40"
                 },
                 "opera_android": {
-                  "version_added": "40"
+                  "version_added": "42"
                 },
                 "safari": {
                   "version_added": null

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -632,7 +632,7 @@
                 "version_added": "38"
               },
               "opera_android": {
-                "version_added": "38"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": "11.1"

--- a/html/elements/input/file.json
+++ b/html/elements/input/file.json
@@ -33,7 +33,7 @@
                 "version_added": "11"
               },
               "opera_android": {
-                "version_added": "1"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -532,7 +532,7 @@
                 "version_added": "38"
               },
               "opera_android": {
-                "version_added": "38"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": "11.1"

--- a/html/elements/slot.json
+++ b/html/elements/slot.json
@@ -86,7 +86,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10"
@@ -191,7 +191,7 @@
                 "version_added": "40"
               },
               "opera_android": {
-                "version_added": "40"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": "10"

--- a/html/elements/style.json
+++ b/html/elements/style.json
@@ -33,7 +33,7 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -82,7 +82,7 @@
                 "version_added": "3.5"
               },
               "opera_android": {
-                "version_added": "6"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -132,7 +132,7 @@
                 "version_added": "3.5"
               },
               "opera_android": {
-                "version_added": "6"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -182,7 +182,7 @@
                 "version_added": "3.5"
               },
               "opera_android": {
-                "version_added": "6"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1334,7 +1334,7 @@
               "version_added": "40"
             },
             "opera_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10",

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1233,7 +1233,7 @@
                 "version_added": "41"
               },
               "opera_android": {
-                "version_added": "41"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": false
@@ -1436,7 +1436,7 @@
                 "version_added": "39"
               },
               "opera_android": {
-                "version_added": "39"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": false

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -236,7 +236,7 @@
                 "version_added": "39"
               },
               "opera_android": {
-                "version_added": "39"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": false

--- a/http/headers/upgrade-insecure-requests.json
+++ b/http/headers/upgrade-insecure-requests.json
@@ -33,7 +33,7 @@
               "version_added": "31"
             },
             "opera_android": {
-              "version_added": "31"
+              "version_added": "32"
             },
             "safari": {
               "version_added": "10.1"

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -36,7 +36,7 @@
               "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": "11.6"
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5.1"
@@ -143,7 +143,7 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "11.6"
+                "version_added": "12"
               },
               "safari": {
                 "version_added": "5.1"
@@ -251,7 +251,7 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "11.6"
+                "version_added": "12"
               },
               "safari": {
                 "version_added": "5.1"

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -36,7 +36,7 @@
               "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": "11.6"
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5.1"

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -36,7 +36,7 @@
               "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": "11.6"
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5.1"

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -36,7 +36,7 @@
               "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": "11.6"
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5.1"

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -36,7 +36,7 @@
               "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": "11.6"
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5.1"

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -36,7 +36,7 @@
               "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": "11.6"
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5.1"

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -1029,7 +1029,7 @@
                 "version_added": "38"
               },
               "opera_android": {
-                "version_added": "38"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": "10"

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -648,7 +648,7 @@
                 "version_added": "41"
               },
               "opera_android": {
-                "version_added": "41"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": "10.1"
@@ -2519,7 +2519,7 @@
                 "version_added": "41"
               },
               "opera_android": {
-                "version_added": "41"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": "10.1"

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -921,7 +921,7 @@
                 "version_added": "38"
               },
               "opera_android": {
-                "version_added": "38"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": "10"

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -706,7 +706,7 @@
                 "version_added": "38"
               },
               "opera_android": {
-                "version_added": "38"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": "10"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -36,7 +36,7 @@
               "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": "11.6"
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5.1"
@@ -364,7 +364,7 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "11.6"
+                "version_added": "12"
               },
               "safari": {
                 "version_added": "5.1"
@@ -418,7 +418,7 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "11.6"
+                "version_added": "12"
               },
               "safari": {
                 "version_added": "5.1"
@@ -472,7 +472,7 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "11.6"
+                "version_added": "12"
               },
               "safari": {
                 "version_added": "5.1"
@@ -526,7 +526,7 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "11.6"
+                "version_added": "12"
               },
               "safari": {
                 "version_added": "5.1"
@@ -1351,7 +1351,7 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "11.6"
+                "version_added": "12"
               },
               "safari": {
                 "version_added": "5.1"
@@ -1517,7 +1517,7 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "11.6"
+                "version_added": "12"
               },
               "safari": {
                 "version_added": "5.1"
@@ -1625,7 +1625,7 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "11.6"
+                "version_added": "12"
               },
               "safari": {
                 "version_added": "5.1"
@@ -1841,7 +1841,7 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "11.6"
+                "version_added": "12"
               },
               "safari": {
                 "version_added": "5.1"
@@ -2057,7 +2057,7 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "11.6"
+                "version_added": "12"
               },
               "safari": {
                 "version_added": "5.1"

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -36,7 +36,7 @@
               "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": "11.6"
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5.1"

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -36,7 +36,7 @@
               "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": "11.6"
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5.1"

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -36,7 +36,7 @@
               "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": "11.6"
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5.1"

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -36,7 +36,7 @@
               "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": "11.6"
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5.1"

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -47,7 +47,7 @@
               "version_added": "23"
             },
             "opera_android": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "safari": {
               "version_added": "8"
@@ -349,7 +349,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": "8"
@@ -416,7 +416,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": "8"
@@ -483,7 +483,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": "8"
@@ -548,7 +548,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": "8"
@@ -617,7 +617,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": "8"

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -36,7 +36,7 @@
               "version_added": "23"
             },
             "opera_android": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "safari": {
               "version_added": "9"
@@ -197,7 +197,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": "9"
@@ -312,7 +312,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": "9"
@@ -366,7 +366,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": "9"
@@ -420,7 +420,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": "9"

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -653,7 +653,7 @@
               "version_added": "31"
             },
             "opera_android": {
-              "version_added": "31"
+              "version_added": "32"
             },
             "safari": {
               "version_added": "9"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -2024,7 +2024,7 @@
               "version_added": "17"
             },
             "opera_android": {
-              "version_added": "17"
+              "version_added": "18"
             },
             "safari": {
               "version_added": "10"

--- a/mathml/elements/math.json
+++ b/mathml/elements/math.json
@@ -42,7 +42,7 @@
               "notes": "Only supported in XHTML documents."
             },
             "opera_android": {
-              "version_added": "9.5",
+              "version_added": "10.1",
               "version_removed": "14",
               "partial_implementation": true,
               "notes": "Only supported in XHTML documents."

--- a/svg/elements/a.json
+++ b/svg/elements/a.json
@@ -279,7 +279,7 @@
                 "version_added": "38"
               },
               "opera_android": {
-                "version_added": "38"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": "11.1"

--- a/svg/elements/animate.json
+++ b/svg/elements/animate.json
@@ -33,7 +33,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9.5"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "4"

--- a/svg/elements/filter.json
+++ b/svg/elements/filter.json
@@ -33,7 +33,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "9.5"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"

--- a/svg/elements/foreignObject.json
+++ b/svg/elements/foreignObject.json
@@ -33,7 +33,7 @@
               "version_added": "2"
             },
             "opera_android": {
-              "version_added": "2"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -79,7 +79,7 @@
                 "version_added": "2"
               },
               "opera_android": {
-                "version_added": "2"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -126,7 +126,7 @@
                 "version_added": "2"
               },
               "opera_android": {
-                "version_added": "2"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -173,7 +173,7 @@
                 "version_added": "2"
               },
               "opera_android": {
-                "version_added": "2"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -220,7 +220,7 @@
                 "version_added": "2"
               },
               "opera_android": {
-                "version_added": "2"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"


### PR DESCRIPTION
Supersedes and closes #1712, also closes #591.  This PR is to rebase the original one as well as apply the changes requested by @Elchi3.  Conflicting files that reference non-existent Opera Android versions with lower numbers than what has been confirmed to exist have been rounded up to the closest version, however there are [MANY files that reference non-existent Opera Android versions](https://gist.github.com/vinyldarkscratch/1a77a0fff99f7f4fe6dfd1716717abc1) (hence why Travis is failing).  It's possible that none of such features left are actually supported.

This PR isn't ready to merge until all files have been resolved.  Alternatively, all conflicting opera_android version entries can be set to `null` if desired.