### PR TITLE
Update Firefox's supported iframe sandbox attrs

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -905,10 +905,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": null
+                  "version_added": "50"
                 },
                 "firefox_android": {
-                  "version_added": null
+                  "version_added": "50"
                 },
                 "ie": {
                   "version_added": false
@@ -956,10 +956,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "ie": {
                   "version_added": false


### PR DESCRIPTION
We do not support allow-top-navigation-by-user-activation
https://bugzilla.mozilla.org/show_bug.cgi?id=1359867

We've supported allow-presentation since Firefox 50
https://bugzilla.mozilla.org/show_bug.cgi?id=1268758