### PR TITLE
Subfeature for responding to onMessage by Promise

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -772,7 +772,7 @@
                   "version_added": true
                 },
                 "firefox_android": {
-                  "version_added:" true
+                  "version_added": true
                 }
               }
             }
@@ -810,7 +810,7 @@
                   "version_added": true
                 },
                 "firefox_android": {
-                  "version_added:" true
+                  "version_added": true
                 }
               }
             }

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -814,7 +814,7 @@
                 },
                 "edge": {
                   "version_added": false
-                }
+                },
                 "firefox": {
                   "version_added": true
                 },

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -763,9 +763,12 @@
           },
           "return_promise": {
             "__compat": {
-              "description": "Respond with Promise",
+              "description": "Respond with <code>Promise</code>",
               "support": {
                 "chrome": {
+                  "version_added": false
+                },
+                "edge": {
                   "version_added": false
                 },
                 "firefox": {
@@ -773,6 +776,9 @@
                 },
                 "firefox_android": {
                   "version_added": true
+                }
+                "opera": {
+                  "version_added": false
                 }
               }
             }
@@ -801,16 +807,22 @@
           },
           "return_promise": {
             "__compat": {
-              "description": "Respond with Promise",
+              "description": "Respond with <code>Promise</code>",
               "support": {
                 "chrome": {
                   "version_added": false
                 },
+                "edge": {
+                  "version_added": false
+                }
                 "firefox": {
                   "version_added": true
                 },
                 "firefox_android": {
                   "version_added": true
+                },
+                "opera": {
+                  "version_added": false
                 }
               }
             }

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -776,7 +776,7 @@
                 },
                 "firefox_android": {
                   "version_added": true
-                }
+                },
                 "opera": {
                   "version_added": false
                 }

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -760,6 +760,22 @@
                 "version_added": "15"
               }
             }
+          },
+          "return_promise": {
+            "__compat": {
+              "description": "Respond with Promise",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added:" true
+                }
+              }
+            }
           }
         },
         "onMessageExternal": {
@@ -780,6 +796,22 @@
               },
               "opera": {
                 "version_added": "15"
+              }
+            }
+          },
+          "return_promise": {
+            "__compat": {
+              "description": "Respond with Promise",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added:" true
+                }
               }
             }
           }


### PR DESCRIPTION
In Firefox, you can return a Promise instead of calling `sendResponse` in a messaging listener. This is also documented on the respective event pages, but not part of the compatibility info yet.

Maybe this should be marked as experimental or as on standards track (though it has been "on track" for over a year now...).