### PR TITLE
navigator.mediaDevices.enumerateDevices: fіx safari information

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -155,10 +155,10 @@
               "version_added": "34"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": null


### PR DESCRIPTION
This shipped in Safari 11 alongside getUserMedia.

Fixing things one wrong stackoverflow post at a time: https://stackoverflow.com/a/52669050/4352772
:-)