### PR TITLE
webdriver: fix typo and link to capabilities on mdn

### DIFF
--- a/webdriver/commands/AcceptAlert.json
+++ b/webdriver/commands/AcceptAlert.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/AcceptAlert.json
+++ b/webdriver/commands/AcceptAlert.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/AddCookie.json
+++ b/webdriver/commands/AddCookie.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/AddCookie.json
+++ b/webdriver/commands/AddCookie.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/Back.json
+++ b/webdriver/commands/Back.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/Back.json
+++ b/webdriver/commands/Back.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/CloseWindow.json
+++ b/webdriver/commands/CloseWindow.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/CloseWindow.json
+++ b/webdriver/commands/CloseWindow.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/DeleteAllCookies.json
+++ b/webdriver/commands/DeleteAllCookies.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/DeleteAllCookies.json
+++ b/webdriver/commands/DeleteAllCookies.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/DeleteCookie.json
+++ b/webdriver/commands/DeleteCookie.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/DeleteCookie.json
+++ b/webdriver/commands/DeleteCookie.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/DeleteSession.json
+++ b/webdriver/commands/DeleteSession.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/DeleteSession.json
+++ b/webdriver/commands/DeleteSession.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/DismissAlert.json
+++ b/webdriver/commands/DismissAlert.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/DismissAlert.json
+++ b/webdriver/commands/DismissAlert.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/ElementClear.json
+++ b/webdriver/commands/ElementClear.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/ElementClear.json
+++ b/webdriver/commands/ElementClear.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/ElementClick.json
+++ b/webdriver/commands/ElementClick.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/ElementClick.json
+++ b/webdriver/commands/ElementClick.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/ElementSendKeys.json
+++ b/webdriver/commands/ElementSendKeys.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/ElementSendKeys.json
+++ b/webdriver/commands/ElementSendKeys.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/ExecuteAsyncScript.json
+++ b/webdriver/commands/ExecuteAsyncScript.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/ExecuteAsyncScript.json
+++ b/webdriver/commands/ExecuteAsyncScript.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/ExecuteScript.json
+++ b/webdriver/commands/ExecuteScript.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/ExecuteScript.json
+++ b/webdriver/commands/ExecuteScript.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/FindElement.json
+++ b/webdriver/commands/FindElement.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/FindElement.json
+++ b/webdriver/commands/FindElement.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/FindElementFromElement.json
+++ b/webdriver/commands/FindElementFromElement.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/FindElementFromElement.json
+++ b/webdriver/commands/FindElementFromElement.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/FindElements.json
+++ b/webdriver/commands/FindElements.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/FindElements.json
+++ b/webdriver/commands/FindElements.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/FindElementsFromElement.json
+++ b/webdriver/commands/FindElementsFromElement.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/FindElementsFromElement.json
+++ b/webdriver/commands/FindElementsFromElement.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/Forward.json
+++ b/webdriver/commands/Forward.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/Forward.json
+++ b/webdriver/commands/Forward.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/FullscreenWindow.json
+++ b/webdriver/commands/FullscreenWindow.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/FullscreenWindow.json
+++ b/webdriver/commands/FullscreenWindow.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/GetActiveElement.json
+++ b/webdriver/commands/GetActiveElement.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/GetActiveElement.json
+++ b/webdriver/commands/GetActiveElement.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/GetAlertText.json
+++ b/webdriver/commands/GetAlertText.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/GetAlertText.json
+++ b/webdriver/commands/GetAlertText.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/GetAllCookies.json
+++ b/webdriver/commands/GetAllCookies.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/GetAllCookies.json
+++ b/webdriver/commands/GetAllCookies.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/GetCurrentURL.json
+++ b/webdriver/commands/GetCurrentURL.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/GetCurrentURL.json
+++ b/webdriver/commands/GetCurrentURL.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/GetElementAttribute.json
+++ b/webdriver/commands/GetElementAttribute.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/GetElementAttribute.json
+++ b/webdriver/commands/GetElementAttribute.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/GetElementCSSValue.json
+++ b/webdriver/commands/GetElementCSSValue.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/GetElementCSSValue.json
+++ b/webdriver/commands/GetElementCSSValue.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/GetElementProperty.json
+++ b/webdriver/commands/GetElementProperty.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/GetElementProperty.json
+++ b/webdriver/commands/GetElementProperty.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/GetElementRect.json
+++ b/webdriver/commands/GetElementRect.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/GetElementRect.json
+++ b/webdriver/commands/GetElementRect.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/GetElementTagName.json
+++ b/webdriver/commands/GetElementTagName.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/GetElementTagName.json
+++ b/webdriver/commands/GetElementTagName.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/GetElementText.json
+++ b/webdriver/commands/GetElementText.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/GetElementText.json
+++ b/webdriver/commands/GetElementText.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/GetNamedCookie.json
+++ b/webdriver/commands/GetNamedCookie.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/GetNamedCookie.json
+++ b/webdriver/commands/GetNamedCookie.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/GetPageSource.json
+++ b/webdriver/commands/GetPageSource.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/GetPageSource.json
+++ b/webdriver/commands/GetPageSource.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/GetTimeouts.json
+++ b/webdriver/commands/GetTimeouts.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/GetTimeouts.json
+++ b/webdriver/commands/GetTimeouts.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/GetTitle.json
+++ b/webdriver/commands/GetTitle.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/GetTitle.json
+++ b/webdriver/commands/GetTitle.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/GetWindowHandle.json
+++ b/webdriver/commands/GetWindowHandle.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/GetWindowHandle.json
+++ b/webdriver/commands/GetWindowHandle.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/GetWindowHandles.json
+++ b/webdriver/commands/GetWindowHandles.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/GetWindowHandles.json
+++ b/webdriver/commands/GetWindowHandles.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/GetWindowRect.json
+++ b/webdriver/commands/GetWindowRect.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/GetWindowRect.json
+++ b/webdriver/commands/GetWindowRect.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/IsElementEnabled.json
+++ b/webdriver/commands/IsElementEnabled.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/IsElementEnabled.json
+++ b/webdriver/commands/IsElementEnabled.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/IsElementSelected.json
+++ b/webdriver/commands/IsElementSelected.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/IsElementSelected.json
+++ b/webdriver/commands/IsElementSelected.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/MaximizeWindow.json
+++ b/webdriver/commands/MaximizeWindow.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/MaximizeWindow.json
+++ b/webdriver/commands/MaximizeWindow.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/MinimizeWindow.json
+++ b/webdriver/commands/MinimizeWindow.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/MinimizeWindow.json
+++ b/webdriver/commands/MinimizeWindow.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/NavigateTo.json
+++ b/webdriver/commands/NavigateTo.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/NavigateTo.json
+++ b/webdriver/commands/NavigateTo.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/NewSession.json
+++ b/webdriver/commands/NewSession.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/NewSession.json
+++ b/webdriver/commands/NewSession.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/PerformActions.json
+++ b/webdriver/commands/PerformActions.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/PerformActions.json
+++ b/webdriver/commands/PerformActions.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/Refresh.json
+++ b/webdriver/commands/Refresh.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/Refresh.json
+++ b/webdriver/commands/Refresh.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/ReleaseActions.json
+++ b/webdriver/commands/ReleaseActions.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/ReleaseActions.json
+++ b/webdriver/commands/ReleaseActions.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/SendAlertText.json
+++ b/webdriver/commands/SendAlertText.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/SendAlertText.json
+++ b/webdriver/commands/SendAlertText.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/SetTimeouts.json
+++ b/webdriver/commands/SetTimeouts.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/SetTimeouts.json
+++ b/webdriver/commands/SetTimeouts.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/SetWindowRect.json
+++ b/webdriver/commands/SetWindowRect.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/SetWindowRect.json
+++ b/webdriver/commands/SetWindowRect.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/Status.json
+++ b/webdriver/commands/Status.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/Status.json
+++ b/webdriver/commands/Status.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/SwitchToFrame.json
+++ b/webdriver/commands/SwitchToFrame.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/SwitchToFrame.json
+++ b/webdriver/commands/SwitchToFrame.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/SwitchToParentFrame.json
+++ b/webdriver/commands/SwitchToParentFrame.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/SwitchToParentFrame.json
+++ b/webdriver/commands/SwitchToParentFrame.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/SwitchToWindow.json
+++ b/webdriver/commands/SwitchToWindow.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/SwitchToWindow.json
+++ b/webdriver/commands/SwitchToWindow.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/TakeElementScreenshot.json
+++ b/webdriver/commands/TakeElementScreenshot.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/TakeElementScreenshot.json
+++ b/webdriver/commands/TakeElementScreenshot.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {

--- a/webdriver/commands/TakeScreenshot.json
+++ b/webdriver/commands/TakeScreenshot.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
             }
           },
           "status": {

--- a/webdriver/commands/TakeScreenshot.json
+++ b/webdriver/commands/TakeScreenshot.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "edge": {
               "version_added": false,
@@ -32,11 +32,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             },
             "safari": {
               "version_added": false,
@@ -52,7 +52,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabiliites when running the command."
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the capabilities when running the command."
             }
           },
           "status": {


### PR DESCRIPTION
This fixes the typo “capabiliites” and provides a link to the [capabilities](https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities) documentation on MDN.