### PR TITLE
update(api.HTMLElement.tabIndex): update Edge and IE compatibility

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1848,11 +1848,20 @@
             "chrome_android": {
               "version_added": true
             },
-            "edge": {
-              "version_added": true
-            },
+            "edge": [
+              {
+                "version_added": "18"
+              },
+              {
+                "version_added": true,
+                "partial_implementation": true,
+                "notes": "Returns incorrect value for elements without an explicit tabindex attribute. See <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4365703/'>issue 4365703</a> for details."
+              }
+            ],
             "edge_mobile": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Returns incorrect value for elements without an explicit tabindex attribute. See <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4365703/'>issue 4365703</a> for details."
             },
             "firefox": {
               "version_added": "1"
@@ -1861,7 +1870,9 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "7",
+              "partial_implementation": true,
+              "notes": "Returns incorrect value for elements without an explicit tabindex attribute. See <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4365703/'>issue 4365703</a> for details."
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
Edge and IE have a buggy implementation of the `tabIndex` IDL attribute.

https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4365703/