### PR TITLE
edge_mobile supports html input type=date

### DIFF
--- a/html/elements/input/date.json
+++ b/html/elements/input/date.json
@@ -17,7 +17,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": true
               },
               "firefox": {
                 "version_added": "57"


### PR DESCRIPTION
Example support screenshot from a Windows phone running Edge mobile.
![wp_ss_20181006_0001](https://user-images.githubusercontent.com/6014956/46577456-476e5500-c9a5-11e8-8e0c-0e83792ea9f9.png)

