### PR TITLE
IE _sort of_ implements `HTMLHyperlinkElementUtils.pathname`

### DIFF
--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -404,7 +404,10 @@
               ]
             },
             "ie": {
-              "version_added": false
+              "version_added": false,
+              "notes": [
+                "Internet Explorer implements a similar attribute with the same name, but there is no leading <code>\"/\"</code>."
+              ]
             },
             "opera": {
               "version_added": false

--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -405,8 +405,9 @@
             },
             "ie": {
               "version_added": false,
+              "partial_implementation": true,
               "notes": [
-                "Internet Explorer implements a similar attribute with the same name, but there is no leading <code>\"/\"</code>."
+                "Internet Explorer implements this attribute with no leading <code>\"/\"</code>."
               ]
             },
             "opera": {


### PR DESCRIPTION
Its version behaves differently, but it's there.

I couldn't find much documentation about this, so I can't tell you which version it first appeared in. Also, I assumed that I should say that it doesn't implement it, since it technically doesn't. It's good enough for Google Analytics to have a kind of shim within its code, though.

Is this alright? I'm quite new to this.