### PR TITLE
update CSS :matches()

### DIFF
--- a/css/selectors/matches.json
+++ b/css/selectors/matches.json
@@ -22,7 +22,10 @@
               },
               {
                 "version_added": "12",
-                "alternative_name": ":-webkit-any"
+                "alternative_name": ":-webkit-any",
+                "notes": [
+                  "It does not support combinators."
+                ]
               }
             ],
             "chrome_android": [
@@ -41,7 +44,10 @@
               },
               {
                 "version_added": "18",
-                "alternative_name": ":-webkit-any"
+                "alternative_name": ":-webkit-any",
+                "notes": [
+                  "It does not support combinators."
+                ]
               }
             ],
             "edge": {
@@ -52,22 +58,34 @@
             },
             "firefox": {
               "version_added": "4",
-              "alternative_name": ":-moz-any"
+              "alternative_name": ":-moz-any",
+              "notes": [
+                "It does not support combinators."
+              ]
             },
             "firefox_android": {
               "version_added": "4",
-              "alternative_name": ":-moz-any"
+              "alternative_name": ":-moz-any",
+              "notes": [
+                "It does not support combinators."
+              ]
             },
             "ie": {
               "version_added": false
             },
             "opera": {
               "version_added": true,
-              "alternative_name": ":-webkit-any"
+              "alternative_name": ":-webkit-any",
+              "notes": [
+                "It does not support combinators."
+              ]
             },
             "opera_android": {
               "version_added": true,
-              "alternative_name": ":-webkit-any"
+              "alternative_name": ":-webkit-any",
+              "notes": [
+                "It does not support combinators."
+              ]
             },
             "safari": [
               {
@@ -75,7 +93,10 @@
               },
               {
                 "version_added": "5",
-                "alternative_name": ":-webkit-any"
+                "alternative_name": ":-webkit-any",
+                "notes": [
+                  "It does not support combinators."
+                ]
               }
             ],
             "safari_ios": [
@@ -84,7 +105,10 @@
               },
               {
                 "version_added": "5",
-                "alternative_name": ":-webkit-any"
+                "alternative_name": ":-webkit-any",
+                "notes": [
+                  "It does not support combinators."
+                ]
               }
             ],
             "samsunginternet_android": {
@@ -106,7 +130,10 @@
               },
               {
                 "version_added": true,
-                "alternative_name": ":-webkit-any"
+                "alternative_name": ":-webkit-any",
+                "notes": [
+                  "It does not support combinators."
+                ]
               }
             ]
           },

--- a/css/selectors/matches.json
+++ b/css/selectors/matches.json
@@ -8,27 +8,12 @@
           "support": {
             "chrome": [
               {
-                "version_added": "66",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features",
-                    "value_to_set": "enabled"
-                  }
-                ],
-                "notes": [
-                  "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-                ]
-              },
-              {
                 "version_added": "12",
                 "alternative_name": ":-webkit-any",
                 "notes": [
                   "Doesn't support combinators."
                 ]
-              }
-            ],
-            "chrome_android": [
+              },
               {
                 "version_added": "66",
                 "flags": [
@@ -41,12 +26,27 @@
                 "notes": [
                   "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
                 ]
-              },
+              }
+            ],
+            "chrome_android": [
               {
                 "version_added": "18",
                 "alternative_name": ":-webkit-any",
                 "notes": [
                   "Doesn't support combinators."
+                ]
+              },
+              {
+                "version_added": "66",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features",
+                    "value_to_set": "enabled"
+                  }
+                ],
+                "notes": [
+                  "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
                 ]
               }
             ],
@@ -116,6 +116,13 @@
             },
             "webview_android": [
               {
+                "version_added": true,
+                "alternative_name": ":-webkit-any",
+                "notes": [
+                  "Doesn't support combinators."
+                ]
+              },
+              {
                 "version_added": "66",
                 "flags": [
                   {
@@ -126,13 +133,6 @@
                 ],
                 "notes": [
                   "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-                ]
-              },
-              {
-                "version_added": true,
-                "alternative_name": ":-webkit-any",
-                "notes": [
-                  "Doesn't support combinators."
                 ]
               }
             ]

--- a/css/selectors/matches.json
+++ b/css/selectors/matches.json
@@ -73,20 +73,50 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true,
-              "alternative_name": ":-webkit-any",
-              "notes": [
-                "Doesn't support combinators."
-              ]
-            },
-            "opera_android": {
-              "version_added": true,
-              "alternative_name": ":-webkit-any",
-              "notes": [
-                "Doesn't support combinators."
-              ]
-            },
+            "opera": [
+              {
+                "version_added": true,
+                "alternative_name": ":-webkit-any",
+                "notes": [
+                  "Doesn't support combinators."
+                ]
+              },
+              {
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features",
+                    "value_to_set": "enabled"
+                  }
+                ],
+                "notes": [
+                  "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                ]
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": true,
+                "alternative_name": ":-webkit-any",
+                "notes": [
+                  "Doesn't support combinators."
+                ]
+              },
+              {
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features",
+                    "value_to_set": "enabled"
+                  }
+                ],
+                "notes": [
+                  "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                ]
+              }
+            ],
             "safari": [
               {
                 "version_added": "9"

--- a/css/selectors/matches.json
+++ b/css/selectors/matches.json
@@ -151,19 +151,6 @@
                 "notes": [
                   "Doesn't support combinators."
                 ]
-              },
-              {
-                "version_added": "66",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features",
-                    "value_to_set": "enabled"
-                  }
-                ],
-                "notes": [
-                  "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-                ]
               }
             ]
           },

--- a/css/selectors/matches.json
+++ b/css/selectors/matches.json
@@ -17,14 +17,14 @@
                   }
                 ],
                 "notes": [
-                  "It has issues with combinators (<a href='https://crbug.com/842157'>Chromium bug 842157</a>)"
+                  "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
                 ]
               },
               {
                 "version_added": "12",
                 "alternative_name": ":-webkit-any",
                 "notes": [
-                  "It does not support combinators."
+                  "Doesn't support combinators."
                 ]
               }
             ],
@@ -39,14 +39,14 @@
                   }
                 ],
                 "notes": [
-                  "It has issues with combinators (<a href='https://crbug.com/842157'>Chromium bug 842157</a>)"
+                  "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
                 ]
               },
               {
                 "version_added": "18",
                 "alternative_name": ":-webkit-any",
                 "notes": [
-                  "It does not support combinators."
+                  "Doesn't support combinators."
                 ]
               }
             ],
@@ -60,14 +60,14 @@
               "version_added": "4",
               "alternative_name": ":-moz-any",
               "notes": [
-                "It does not support combinators."
+                "Doesn't support combinators."
               ]
             },
             "firefox_android": {
               "version_added": "4",
               "alternative_name": ":-moz-any",
               "notes": [
-                "It does not support combinators."
+                "Doesn't support combinators."
               ]
             },
             "ie": {
@@ -77,14 +77,14 @@
               "version_added": true,
               "alternative_name": ":-webkit-any",
               "notes": [
-                "It does not support combinators."
+                "Doesn't support combinators."
               ]
             },
             "opera_android": {
               "version_added": true,
               "alternative_name": ":-webkit-any",
               "notes": [
-                "It does not support combinators."
+                "Doesn't support combinators."
               ]
             },
             "safari": [
@@ -95,7 +95,7 @@
                 "version_added": "5",
                 "alternative_name": ":-webkit-any",
                 "notes": [
-                  "It does not support combinators."
+                  "Doesn't support combinators."
                 ]
               }
             ],
@@ -107,7 +107,7 @@
                 "version_added": "5",
                 "alternative_name": ":-webkit-any",
                 "notes": [
-                  "It does not support combinators."
+                  "Doesn't support combinators."
                 ]
               }
             ],
@@ -125,14 +125,14 @@
                   }
                 ],
                 "notes": [
-                  "It has issues with combinators (<a href='https://crbug.com/842157'>Chromium bug 842157</a>)"
+                  "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
                 ]
               },
               {
                 "version_added": true,
                 "alternative_name": ":-webkit-any",
                 "notes": [
-                  "It does not support combinators."
+                  "Doesn't support combinators."
                 ]
               }
             ]

--- a/css/selectors/matches.json
+++ b/css/selectors/matches.json
@@ -8,7 +8,17 @@
           "support": {
             "chrome": [
               {
-                "version_added": "66"
+                "version_added": "66",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ],
+                "notes": [
+                  "It has issues with combinators (<a href='https://bugs.chromium.org/p/chromium/issues/detail?id=842157'>Chromium bug 842157</a>)"
+                ]
               },
               {
                 "version_added": "12",
@@ -17,7 +27,17 @@
             ],
             "chrome_android": [
               {
-                "version_added": "66"
+                "version_added": "66",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ],
+                "notes": [
+                  "It has issues with combinators (<a href='https://bugs.chromium.org/p/chromium/issues/detail?id=842157'>Chromium bug 842157</a>)"
+                ]
               },
               {
                 "version_added": "18",
@@ -72,7 +92,17 @@
             },
             "webview_android": [
               {
-                "version_added": "66"
+                "version_added": "66",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ],
+                "notes": [
+                  "It has issues with combinators (<a href='https://bugs.chromium.org/p/chromium/issues/detail?id=842157'>Chromium bug 842157</a>)"
+                ]
               },
               {
                 "version_added": true,

--- a/css/selectors/matches.json
+++ b/css/selectors/matches.json
@@ -24,15 +24,9 @@
                 "alternative_name": ":-webkit-any"
               }
             ],
-            "edge": [
-              {
-                "version_added": "15"
-              },
-              {
-                "version_added": "12",
-                "alternative_name": ":-ms-matches"
-              }
-            ],
+            "edge": {
+              "version_added": false
+            },
             "edge_mobile": {
               "version_added": false
             },

--- a/css/selectors/matches.json
+++ b/css/selectors/matches.json
@@ -12,7 +12,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
+                    "name": "Experimental Web Platform Features",
                     "value_to_set": "enabled"
                   }
                 ],
@@ -34,7 +34,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
+                    "name": "Experimental Web Platform Features",
                     "value_to_set": "enabled"
                   }
                 ],
@@ -120,7 +120,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
+                    "name": "Experimental Web Platform Features",
                     "value_to_set": "enabled"
                   }
                 ],

--- a/css/selectors/matches.json
+++ b/css/selectors/matches.json
@@ -144,15 +144,13 @@
             "samsunginternet_android": {
               "version_added": false
             },
-            "webview_android": [
-              {
-                "version_added": true,
-                "alternative_name": ":-webkit-any",
-                "notes": [
-                  "Doesn't support combinators."
-                ]
-              }
-            ]
+            "webview_android": {
+              "version_added": true,
+              "alternative_name": ":-webkit-any",
+              "notes": [
+                "Doesn't support combinators."
+              ]
+            }
           },
           "status": {
             "experimental": false,

--- a/css/selectors/matches.json
+++ b/css/selectors/matches.json
@@ -17,7 +17,7 @@
                   }
                 ],
                 "notes": [
-                  "It has issues with combinators (<a href='https://bugs.chromium.org/p/chromium/issues/detail?id=842157'>Chromium bug 842157</a>)"
+                  "It has issues with combinators (<a href='https://crbug.com/842157'>Chromium bug 842157</a>)"
                 ]
               },
               {
@@ -39,7 +39,7 @@
                   }
                 ],
                 "notes": [
-                  "It has issues with combinators (<a href='https://bugs.chromium.org/p/chromium/issues/detail?id=842157'>Chromium bug 842157</a>)"
+                  "It has issues with combinators (<a href='https://crbug.com/842157'>Chromium bug 842157</a>)"
                 ]
               },
               {
@@ -125,7 +125,7 @@
                   }
                 ],
                 "notes": [
-                  "It has issues with combinators (<a href='https://bugs.chromium.org/p/chromium/issues/detail?id=842157'>Chromium bug 842157</a>)"
+                  "It has issues with combinators (<a href='https://crbug.com/842157'>Chromium bug 842157</a>)"
                 ]
               },
               {

--- a/css/selectors/matches.json
+++ b/css/selectors/matches.json
@@ -8,12 +8,27 @@
           "support": {
             "chrome": [
               {
+                "version_added": "66",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features",
+                    "value_to_set": "enabled"
+                  }
+                ],
+                "notes": [
+                  "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                ]
+              },
+              {
                 "version_added": "12",
                 "alternative_name": ":-webkit-any",
                 "notes": [
                   "Doesn't support combinators."
                 ]
-              },
+              }
+            ],
+            "chrome_android": [
               {
                 "version_added": "66",
                 "flags": [
@@ -26,27 +41,12 @@
                 "notes": [
                   "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
                 ]
-              }
-            ],
-            "chrome_android": [
+              },
               {
                 "version_added": "18",
                 "alternative_name": ":-webkit-any",
                 "notes": [
                   "Doesn't support combinators."
-                ]
-              },
-              {
-                "version_added": "66",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features",
-                    "value_to_set": "enabled"
-                  }
-                ],
-                "notes": [
-                  "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
                 ]
               }
             ],
@@ -75,13 +75,6 @@
             },
             "opera": [
               {
-                "version_added": true,
-                "alternative_name": ":-webkit-any",
-                "notes": [
-                  "Doesn't support combinators."
-                ]
-              },
-              {
                 "version_added": "53",
                 "flags": [
                   {
@@ -92,18 +85,18 @@
                 ],
                 "notes": [
                   "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                ]
+              },
+              {
+                "version_added": true,
+                "alternative_name": ":-webkit-any",
+                "notes": [
+                  "Doesn't support combinators."
                 ]
               }
             ],
             "opera_android": [
               {
-                "version_added": true,
-                "alternative_name": ":-webkit-any",
-                "notes": [
-                  "Doesn't support combinators."
-                ]
-              },
-              {
                 "version_added": "53",
                 "flags": [
                   {
@@ -114,6 +107,13 @@
                 ],
                 "notes": [
                   "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                ]
+              },
+              {
+                "version_added": true,
+                "alternative_name": ":-webkit-any",
+                "notes": [
+                  "Doesn't support combinators."
                 ]
               }
             ],

--- a/css/selectors/matches.json
+++ b/css/selectors/matches.json
@@ -16,16 +16,12 @@
                     "value_to_set": "enabled"
                   }
                 ],
-                "notes": [
-                  "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-                ]
+                "notes": "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
               {
                 "version_added": "12",
                 "alternative_name": ":-webkit-any",
-                "notes": [
-                  "Doesn't support combinators."
-                ]
+                "notes": "Doesn't support combinators."
               }
             ],
             "chrome_android": [
@@ -38,16 +34,12 @@
                     "value_to_set": "enabled"
                   }
                 ],
-                "notes": [
-                  "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-                ]
+                "notes": "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
               {
                 "version_added": "18",
                 "alternative_name": ":-webkit-any",
-                "notes": [
-                  "Doesn't support combinators."
-                ]
+                "notes": "Doesn't support combinators."
               }
             ],
             "edge": {
@@ -59,16 +51,12 @@
             "firefox": {
               "version_added": "4",
               "alternative_name": ":-moz-any",
-              "notes": [
-                "Doesn't support combinators."
-              ]
+              "notes": "Doesn't support combinators."
             },
             "firefox_android": {
               "version_added": "4",
               "alternative_name": ":-moz-any",
-              "notes": [
-                "Doesn't support combinators."
-              ]
+              "notes": "Doesn't support combinators."
             },
             "ie": {
               "version_added": false
@@ -83,16 +71,12 @@
                     "value_to_set": "enabled"
                   }
                 ],
-                "notes": [
-                  "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-                ]
+                "notes": "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
               {
                 "version_added": true,
                 "alternative_name": ":-webkit-any",
-                "notes": [
-                  "Doesn't support combinators."
-                ]
+                "notes": "Doesn't support combinators."
               }
             ],
             "opera_android": [
@@ -105,16 +89,12 @@
                     "value_to_set": "enabled"
                   }
                 ],
-                "notes": [
-                  "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-                ]
+                "notes": "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
               {
                 "version_added": true,
                 "alternative_name": ":-webkit-any",
-                "notes": [
-                  "Doesn't support combinators."
-                ]
+                "notes": "Doesn't support combinators."
               }
             ],
             "safari": [
@@ -124,9 +104,7 @@
               {
                 "version_added": "5",
                 "alternative_name": ":-webkit-any",
-                "notes": [
-                  "Doesn't support combinators."
-                ]
+                "notes": "Doesn't support combinators."
               }
             ],
             "safari_ios": [
@@ -136,9 +114,7 @@
               {
                 "version_added": "5",
                 "alternative_name": ":-webkit-any",
-                "notes": [
-                  "Doesn't support combinators."
-                ]
+                "notes": "Doesn't support combinators."
               }
             ],
             "samsunginternet_android": {
@@ -147,9 +123,7 @@
             "webview_android": {
               "version_added": true,
               "alternative_name": ":-webkit-any",
-              "notes": [
-                "Doesn't support combinators."
-              ]
+              "notes": "Doesn't support combinators."
             }
           },
           "status": {

--- a/css/selectors/matches.json
+++ b/css/selectors/matches.json
@@ -51,12 +51,18 @@
             "firefox": {
               "version_added": "4",
               "alternative_name": ":-moz-any",
-              "notes": "Doesn't support combinators."
+              "notes": [
+                "Doesn't support combinators.",
+                "See <a href='https://bugzil.la/906353>bug 906353</a>"
+              ]
             },
             "firefox_android": {
               "version_added": "4",
               "alternative_name": ":-moz-any",
-              "notes": "Doesn't support combinators."
+              "notes": [
+                "Doesn't support combinators.",
+                "See <a href='https://bugzil.la/906353>bug 906353</a>"
+              ]
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
* fix Edge status (support is not available)
* fix Chrome status (Chrome never shipped it and its experimental support is partial)
* add notes that `:-moz-any()` and `:-webkit-any()` are subset of `:matches()`