### PR TITLE
Everyone supports srcObject as MediaStream-only

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2086,28 +2086,28 @@
             "chrome": {
               "version_added": "52",
               "partial_implementation": true,
-              "notes": "Only MediaStream is supported"
+              "notes": "Currently only supports <code>MediaStream</code> objects."
             },
             "chrome_android": {
               "version_added": "52",
               "partial_implementation": true,
-              "notes": "Only MediaStream is supported"
+              "notes": "Currently only supports <code>MediaStream</code> objects."
             },
             "edge": {
               "version_added": true,
               "partial_implementation": true,
-              "notes": "Only MediaStream is supported"
+              "notes": "Currently only supports <code>MediaStream</code> objects."
             },
             "edge_mobile": {
               "version_added": true,
               "partial_implementation": true,
-              "notes": "Only MediaStream is supported"
+              "notes": "Currently only supports <code>MediaStream</code> objects."
             },
             "firefox": [
               {
                 "version_added": true,
                 "partial_implementation": true,
-                "notes": "Only MediaStream is supported"
+                "notes": "Currently only supports <code>MediaStream</code> objects."
               },
               {
                 "version_added": "18",
@@ -2119,7 +2119,7 @@
               {
                 "version_added": true,
                 "partial_implementation": true,
-                "notes": "Only MediaStream is supported"
+                "notes": "Currently only supports <code>MediaStream</code> objects."
               },
               {
                 "version_added": "18",
@@ -2130,17 +2130,17 @@
             "opera": {
               "version_added": "39",
               "partial_implementation": true,
-              "notes": "Only MediaStream is supported"
+              "notes": "Currently only supports <code>MediaStream</code> objects."
             },
             "opera_android": {
               "version_added": "39",
               "partial_implementation": true,
-              "notes": "Only MediaStream is supported"
+              "notes": "Currently only supports <code>MediaStream</code> objects."
             },
             "webview_android": {
               "version_added": "52",
               "partial_implementation": true,
-              "notes": "Only MediaStream is supported"
+              "notes": "Currently only supports <code>MediaStream</code> objects."
             }
           },
           "status": {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=886194
https://bugs.chromium.org/p/chromium/issues/detail?id=506273

Safari is said to support MediaSource but not sure about Blob support.