### PR TITLE
Update FontFaceSet.json Chromium and Opera support

### DIFF
--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -52,13 +52,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/status",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "48"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "edge": {
               "version_added": null
@@ -76,10 +76,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "safari": {
               "version_added": null
@@ -100,13 +100,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/onloading",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "48"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "edge": {
               "version_added": null
@@ -124,10 +124,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "safari": {
               "version_added": null
@@ -148,13 +148,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/onloadingdone",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "48"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "edge": {
               "version_added": null
@@ -172,10 +172,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "safari": {
               "version_added": null
@@ -196,13 +196,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/onloadingerror",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "48"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "edge": {
               "version_added": null
@@ -220,10 +220,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "safari": {
               "version_added": null
@@ -244,13 +244,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/add",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "48"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "edge": {
               "version_added": null
@@ -268,10 +268,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "safari": {
               "version_added": null
@@ -364,10 +364,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "safari": {
               "version_added": null
@@ -388,13 +388,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/delete",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "chrome": {
-              "version_added": null
+              "version_added": "48"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "edge": {
               "version_added": null
@@ -412,10 +412,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "safari": {
               "version_added": null
@@ -460,10 +460,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "safari": {
               "version_added": null
@@ -508,10 +508,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "safari": {
               "version_added": null


### PR DESCRIPTION
According to:
https://googlechrome.github.io/samples/font-face-set/
https://www.chromestatus.com/feature/4594172182921216