### PR TITLE
Add hanging-punctuation CSS property

### DIFF
--- a/css/properties/hanging-punctuation.json
+++ b/css/properties/hanging-punctuation.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "hanging-punctuation": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/hanging-punctuation",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": "10"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2880.

- [MDN Article](https://developer.mozilla.org/docs/Web/CSS/hanging-punctuation)
- [caniuse](https://caniuse.com/#feat=css-hanging-punctuation)
- [W3C Spec](https://www.w3.org/TR/css-text-3/#hanging-punctuation0)