### PR TITLE
Async functions are supported from Edge 15

### DIFF
--- a/javascript/operators/async_function_expression.json
+++ b/javascript/operators/async_function_expression.json
@@ -13,7 +13,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": null
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": null


### PR DESCRIPTION
Resolves #2940.

- [MDN article](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/async_function)
- [caniuse](https://caniuse.com/#feat=async-functions)
- [Edge Status](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/asyncfunctions/)

Edge Status says it's supported in Edge Mobile as well, can I assume that means Edge Mobile 15?