### PR TITLE
Update compat data for margins, padding and border logical properties

### DIFF
--- a/css/properties/border-block-end-color.json
+++ b/css/properties/border-block-end-color.json
@@ -6,6 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end-color",
           "support": {
             "chrome": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
               "version_added": false
             },
             "firefox": [
@@ -44,10 +50,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -56,7 +62,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-block-end-style.json
+++ b/css/properties/border-block-end-style.json
@@ -6,6 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end-style",
           "support": {
             "chrome": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
               "version_added": false
             },
             "firefox": [
@@ -44,10 +50,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -56,7 +62,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-block-end-width.json
+++ b/css/properties/border-block-end-width.json
@@ -6,6 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end-width",
           "support": {
             "chrome": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
               "version_added": false
             },
             "firefox": [
@@ -44,10 +50,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -56,7 +62,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-block-end.json
+++ b/css/properties/border-block-end.json
@@ -8,6 +8,12 @@
             "chrome": {
               "version_added": false
             },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/border-block-start-color.json
+++ b/css/properties/border-block-start-color.json
@@ -6,6 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start-color",
           "support": {
             "chrome": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
               "version_added": false
             },
             "firefox": [
@@ -44,10 +50,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -56,7 +62,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-block-start-style.json
+++ b/css/properties/border-block-start-style.json
@@ -8,6 +8,12 @@
             "chrome": {
               "version_added": false
             },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
             "firefox": [
               {
                 "version_added": "41"
@@ -44,10 +50,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -56,7 +62,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-block-start-width.json
+++ b/css/properties/border-block-start-width.json
@@ -6,6 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start-width",
           "support": {
             "chrome": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
               "version_added": false
             },
             "firefox": [
@@ -44,10 +50,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -56,7 +62,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-block-start.json
+++ b/css/properties/border-block-start.json
@@ -8,6 +8,12 @@
             "chrome": {
               "version_added": false
             },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/border-inline-end-color.json
+++ b/css/properties/border-inline-end-color.json
@@ -6,6 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end-color",
           "support": {
             "chrome": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
               "version_added": false
             },
             "firefox": [
@@ -52,10 +58,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -64,7 +70,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-inline-end-style.json
+++ b/css/properties/border-inline-end-style.json
@@ -6,6 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end-style",
           "support": {
             "chrome": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
               "version_added": false
             },
             "firefox": [
@@ -52,10 +58,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -64,7 +70,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-inline-end-width.json
+++ b/css/properties/border-inline-end-width.json
@@ -6,6 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end-width",
           "support": {
             "chrome": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
               "version_added": false
             },
             "firefox": [
@@ -52,10 +58,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -64,7 +70,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-inline-start-color.json
+++ b/css/properties/border-inline-start-color.json
@@ -6,6 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-start-color",
           "support": {
             "chrome": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
               "version_added": false
             },
             "firefox": [
@@ -52,10 +58,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -64,7 +70,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-inline-start-style.json
+++ b/css/properties/border-inline-start-style.json
@@ -6,6 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-start-style",
           "support": {
             "chrome": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
               "version_added": false
             },
             "firefox": [
@@ -52,10 +58,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -64,7 +70,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-inline-start-width.json
+++ b/css/properties/border-inline-start-width.json
@@ -6,6 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-start-width",
           "support": {
             "chrome": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
               "version_added": false
             },
             "firefox": [
@@ -44,10 +50,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -56,7 +62,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/margin-block-end.json
+++ b/css/properties/margin-block-end.json
@@ -12,10 +12,10 @@
               "version_added": "69"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {

--- a/css/properties/margin-block-start.json
+++ b/css/properties/margin-block-start.json
@@ -12,10 +12,10 @@
               "version_added": "69"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {

--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -24,10 +24,10 @@
               }
             ],
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -24,10 +24,10 @@
               }
             ],
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {

--- a/css/properties/padding-block-end.json
+++ b/css/properties/padding-block-end.json
@@ -12,10 +12,10 @@
               "version_added": "69"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {

--- a/css/properties/padding-block-start.json
+++ b/css/properties/padding-block-start.json
@@ -12,10 +12,10 @@
               "version_added": "69"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -24,10 +24,10 @@
               }
             ],
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -24,10 +24,10 @@
               }
             ],
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {


### PR DESCRIPTION
Now available in Chrome, and Opera as detailed in this issue https://bugs.chromium.org/p/chromium/issues/detail?id=850000

I also added Edge and/or flagged Edge as false rather than null as Edge has not implemented these.