### PR TITLE
Fix status data for several HTTP headers

### DIFF
--- a/http/headers/if-modified-since.json
+++ b/http/headers/if-modified-since.json
@@ -46,9 +46,9 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": true
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/if-unmodified-since.json
+++ b/http/headers/if-unmodified-since.json
@@ -46,9 +46,9 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": true
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/keep-alive.json
+++ b/http/headers/keep-alive.json
@@ -46,9 +46,9 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": true
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/last-modified.json
+++ b/http/headers/last-modified.json
@@ -46,9 +46,9 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": true
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/location.json
+++ b/http/headers/location.json
@@ -46,9 +46,9 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": true
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
This change fixes the status data for several HTTP headers so that the data correctly indicates they are standard headers, not deprecated, and not experimental. Without this change, that status data incorrectly indicates they are non-standard, experimental, and deprecated.