### PR TITLE
Fix status data for DOMException

### DIFF
--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -47,7 +47,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": true
+          "deprecated": false
         }
       },
       "DOMException": {
@@ -96,9 +96,9 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -149,7 +149,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -200,7 +200,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -251,7 +251,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
This change fixes the status data for the DOMException type so that the data correctly indicates it’s not deprecated. Without this change, that status data incorrectly indicates it’s deprecated — which it’s not: https://heycam.github.io/webidl/#idl-DOMException