### PR TITLE
Fix status data for Request: integrity & keepalive

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -986,7 +986,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -1037,7 +1037,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
This change fixes the status data for the Request: integrity and Request: keepalive properties to indicate they are not deprecated.  Without this change, that status data incorrectly indicates they are deprecated.

* https://fetch.spec.whatwg.org/#dom-request-integrity
* https://fetch.spec.whatwg.org/#dom-request-keepalive