### PR TITLE
Fix status data for DOMPointReadOnly: toJSON

### DIFF
--- a/api/DOMPointReadOnly.json
+++ b/api/DOMPointReadOnly.json
@@ -428,7 +428,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
This change fixes the status data for the DOMPointReadOnly: toJSON method so that the data correctly indicates it’s not deprecated. Without this change, that status data incorrectly indicates they it’s deprecated.

https://drafts.fxtf.org/geometry/#dom-dompointreadonly-tojson