### PR TITLE
Fix status data for some HTMLLabelElement props

### DIFF
--- a/api/HTMLLabelElement.json
+++ b/api/HTMLLabelElement.json
@@ -91,7 +91,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -139,7 +139,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -187,7 +187,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
This change fixes the status data for several HTMLLabelElement properties so that the data correctly indicates they are not deprecated.  Without this change, that status data incorrectly indicates they are deprecated.

https://html.spec.whatwg.org/multipage/forms.html#dom-label-control
https://html.spec.whatwg.org/multipage/forms.html#dom-label-form
https://html.spec.whatwg.org/multipage/forms.html#dom-label-htmlfor