### PR TITLE
Mark HTMLDocument as deprecated: false

### DIFF
--- a/api/HTMLDocument.json
+++ b/api/HTMLDocument.json
@@ -44,7 +44,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": true
+          "deprecated": false
         }
       }
     }


### PR DESCRIPTION
This change updates the status data for HTMLDocument to indicate that it’s not deprecated. That’s appropriate given that in the HTML spec https://html.spec.whatwg.org/multipage/window-object.html#htmldocument it’s normatively specified (though just as an alias for Document) and given that browsers are required to implement/expose it.

There are no plans to remove it from the platform, so marking it as deprecated is misleading.