### PR TITLE
Remove deprecated flag from some NavigatorID props

### DIFF
--- a/api/NavigatorID.json
+++ b/api/NavigatorID.json
@@ -91,7 +91,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -139,7 +139,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -187,7 +187,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -283,7 +283,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -379,7 +379,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
This change updates the status data for several properties of NavigatorID to indicate that they are not deprecated. While it’s true that the properties aren’t reliably useful, that doesn’t mean they’re formally deprecated — they’re not in fact, because normative requirements for their values are defined in the HTML spec.

https://html.spec.whatwg.org/multipage/system-state.html#client-identification

So it’s misleading to mark them as deprecated.