### PR TITLE
Mark the Navigator: oscpu property as deprecated

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1424,7 +1424,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
This change updates the status data for the Navigator: oscpu property to indicate that it’s deprecated. That’s appropriate in this case, given that no browser engines other then Gecko support it — and given that the HTML spec doesn’t require any browser engines to support it.