### PR TITLE
Remove deprecated flag from Navigator: vendorSub

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2090,7 +2090,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
This change updates the status data for Navigator: vendorSub to indicate
that it’s not deprecated. While it’s true that the property isn’t
reliably useful, that doesn’t mean it’s formally deprecated — it’s not
in fact, because the HTML spec defines normative requirements for it.

https://html.spec.whatwg.org/multipage/system-state.html#client-identification

So it’s misleading to mark it as deprecated.