### PR TITLE
Fix status data for @media color-index

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -463,7 +463,7 @@
             "status": {
               "experimental": false,
               "standard_track": false,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },


### PR DESCRIPTION
This change marks @media color-index as not deprecated, because it’s not actually deprecated.