### PR TITLE
Fix status data for PushSubscription properties

### DIFF
--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -357,7 +357,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -408,7 +408,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
This change updates the status data for some PushSubscription properties that were marked as deprecated but in fact aren’t deprecated.