### PR TITLE
Mark AudioListener as not deprecated

### DIFF
--- a/api/AudioListener.json
+++ b/api/AudioListener.json
@@ -47,7 +47,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": true
+          "deprecated": false
         }
       },
       "dopplerFactor": {


### PR DESCRIPTION
This change updates the status data for AudioListener to accurately represent its status as not deprecated.