### PR TITLE
Drop WorkerNavigator: sendBeacon

### DIFF
--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -152,57 +152,6 @@
           }
         }
       },
-      "sendBeacon": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerNavigator/sendBeacon",
-          "support": {
-            "webview_android": {
-              "version_added": "39"
-            },
-            "chrome": {
-              "version_added": "39"
-            },
-            "chrome_android": {
-              "version_added": "39"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "26"
-            },
-            "opera_android": {
-              "version_added": "26"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "serviceWorker": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerNavigator/serviceWorker",


### PR DESCRIPTION
This change drops all data for WorkerNavigator: sendBeacon. It was removed from the spec and has never been implemented.

Closes https://github.com/mdn/browser-compat-data/issues/2953