### PR TITLE
Update IE support for window.scrollBy

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5535,7 +5535,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": 11,
+              "version_added": "11",
               "notes": "Only <code>scrollBy(x-coord, y-coord)</code> is supported."
             },
             "opera": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -5523,6 +5523,7 @@
             },
             "edge": {
               "version_added": true,
+              "partial_implementation": true,
               "notes": "Only <code>scrollBy(x-coord, y-coord)</code> is supported."
             },
             "edge_mobile": {
@@ -5536,6 +5537,7 @@
             },
             "ie": {
               "version_added": "11",
+              "partial_implementation": true,
               "notes": "Only <code>scrollBy(x-coord, y-coord)</code> is supported."
             },
             "opera": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -5522,7 +5522,8 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Only <code>scrollBy(x-coord, y-coord)</code> is supported."
             },
             "edge_mobile": {
               "version_added": null
@@ -5534,7 +5535,8 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": 11,
+              "notes": "Only <code>scrollBy(x-coord, y-coord)</code> is supported."
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This was determined experimentally and by relying on https://msdn.microsoft.com/en-us/ie/ms536728(v=vs.94)