### PR TITLE
 Update Chrome's and Opera's compat data for MediaRecorder

### DIFF
--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -111,7 +111,7 @@
                 "version_added": null
               },
               "chrome": {
-                "version_added": false
+                "version_added": "49"
               },
               "chrome_android": {
                 "version_added": false
@@ -164,14 +164,7 @@
             },
             "chrome": {
               "version_added": "47",
-              "notes": "Currently only video is supported, not audio.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform features",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "notes": "Prior to Chrome 49, only video is supported, not audio."
             },
             "chrome_android": {
               "version_added": false
@@ -223,14 +216,7 @@
             },
             "chrome": {
               "version_added": "47",
-              "notes": "Currently only video is supported, not audio.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform features",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "notes": "Prior to Chrome 49, only video is supported, not audio."
             },
             "chrome_android": {
               "version_added": false
@@ -282,14 +268,7 @@
             },
             "chrome": {
               "version_added": "47",
-              "notes": "Currently only video is supported, not audio.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform features",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "notes": "Prior to Chrome 49, only video is supported, not audio."
             },
             "chrome_android": {
               "version_added": false

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -523,7 +523,14 @@
               "version_added": null
             },
             "chrome": {
-              "version_added": null
+              "version_added": "47",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": null

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -108,13 +108,13 @@
             "description": "<code>options</code> object",
             "support": {
               "webview_android": {
-                "version_added": null
+                "version_added": "49"
               },
               "chrome": {
                 "version_added": "49"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "49"
               },
               "edge": {
                 "version_added": null
@@ -160,14 +160,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/mimeType",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "chrome": {
               "version_added": "47",
               "notes": "Prior to Chrome 49, only video is supported, not audio."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -212,14 +212,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/state",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "chrome": {
               "version_added": "47",
               "notes": "Prior to Chrome 49, only video is supported, not audio."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -264,14 +264,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/stream",
           "support": {
             "webview_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "chrome": {
               "version_added": "47",
               "notes": "Prior to Chrome 49, only video is supported, not audio."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -520,7 +520,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/pause",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "chrome": {
               "version_added": "47",
@@ -530,10 +530,11 @@
                   "name": "Experimental Web Platform features",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Full support since Chrome 49."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -578,7 +579,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/requestData",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "chrome": {
               "version_added": "47",
@@ -588,10 +589,11 @@
                   "name": "Experimental Web Platform features",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Full support since Chrome 49."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -636,7 +638,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/resume",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "chrome": {
               "version_added": "47",
@@ -646,10 +648,11 @@
                   "name": "Experimental Web Platform features",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Full support since Chrome 49."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -745,7 +748,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/stop",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "chrome": {
               "version_added": "47",
@@ -755,10 +758,11 @@
                   "name": "Experimental Web Platform features",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Full support since Chrome 49."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -803,7 +807,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/ondataavailable",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "chrome": {
               "version_added": "47",
@@ -813,10 +817,11 @@
                   "name": "Experimental Web Platform features",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Full support since Chrome 49."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -861,7 +866,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/onerror",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "chrome": {
               "version_added": "47",
@@ -871,10 +876,11 @@
                   "name": "Experimental Web Platform features",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Full support since Chrome 49."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -919,7 +925,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/onpause",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "chrome": {
               "version_added": "47",
@@ -929,10 +935,11 @@
                   "name": "Experimental Web Platform features",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Full support since Chrome 49."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -977,7 +984,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/onresume",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "chrome": {
               "version_added": "47",
@@ -987,10 +994,11 @@
                   "name": "Experimental Web Platform features",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Full support since Chrome 49."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -1035,7 +1043,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/onstart",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "chrome": {
               "version_added": "47",
@@ -1045,10 +1053,11 @@
                   "name": "Experimental Web Platform features",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Full support since Chrome 49."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -1093,7 +1102,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/onstop",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "chrome": {
               "version_added": "47",
@@ -1103,10 +1112,11 @@
                   "name": "Experimental Web Platform features",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Full support since Chrome 49."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -1151,7 +1161,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/onwarning",
           "support": {
             "webview_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "chrome": {
               "version_added": "47",
@@ -1161,10 +1171,11 @@
                   "name": "Experimental Web Platform features",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Full support since Chrome 49."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "edge": {
               "version_added": null

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -31,10 +31,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": "36"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "36"
           },
           "safari": {
             "version_added": null
@@ -82,10 +82,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -132,10 +132,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": "36"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "36"
               },
               "safari": {
                 "version_added": null
@@ -185,10 +185,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -237,10 +237,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -289,10 +289,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -340,10 +340,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -391,10 +391,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -442,10 +442,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -493,10 +493,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -552,10 +552,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -611,10 +611,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -670,10 +670,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -721,10 +721,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -780,10 +780,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -839,10 +839,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -898,10 +898,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -957,10 +957,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -1016,10 +1016,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -1075,10 +1075,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -1134,10 +1134,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -1193,10 +1193,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null


### PR DESCRIPTION
The MediaRecorder API should be completely supported since Chrome 49 for both desktop & mobile. ~~Unfortunately I am only able to confirm this on desktop versions of Chrome, so I left the data for `webview_android` and `chrome_android` unchanged.~~ Also added data for Opera desktop/Android.