### PR TITLE
Edge 17: fieldset disabled attribute not working

### DIFF
--- a/html/elements/fieldset.json
+++ b/html/elements/fieldset.json
@@ -61,7 +61,9 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "partial_implementation": true,
+                "version_added": true,
+                "notes": "Does not work with nested fieldsets. E.g.: <code>&lt;fieldset disabled&gt;&lt;fieldset&gt;&lt;!--Still enabled--&gt;&lt;/fieldset&gt;&lt;/fieldset&gt;</code>"
               },
               "edge_mobile": {
                 "version_added": null

--- a/html/elements/fieldset.json
+++ b/html/elements/fieldset.json
@@ -63,7 +63,7 @@
               "edge": {
                 "partial_implementation": true,
                 "version_added": true,
-                "notes": "Does not work with nested fieldsets. E.g.: <code>&lt;fieldset disabled&gt;&lt;fieldset&gt;&lt;!--Still enabled--&gt;&lt;/fieldset&gt;&lt;/fieldset&gt;</code>"
+                "notes": "Does not work with nested fieldsets. For example: <code>&lt;fieldset disabled&gt;&lt;fieldset&gt;&lt;!--Still enabled--&gt;&lt;/fieldset&gt;&lt;/fieldset&gt;</code>"
               },
               "edge_mobile": {
                 "version_added": null

--- a/html/elements/fieldset.json
+++ b/html/elements/fieldset.json
@@ -61,10 +61,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": true


### PR DESCRIPTION
The disabled attribute on a fieldset has no effect in Edge 17.

This is also reflected in https://www.w3schools.com/TAgs/att_fieldset_disabled.asp