### PR TITLE
Add `intrinsicsize` to HTML Media elements (img, video)

### DIFF
--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -401,6 +401,74 @@
             }
           }
         },
+        "intrinsicsize": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "71",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-productivity-features"
+                  }
+                ]
+              },
+              "chrome_android": {
+                "version_added": "71",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-productivity-features"
+                  }
+                ]
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "58"
+              },
+              "opera_android": {
+                "version_added": "58"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": "71",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-productivity-features"
+                  }
+                ]
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "ismap": {
           "__compat": {
             "support": {
@@ -1023,56 +1091,6 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "intrinsicsize": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "71"
-              },
-              "chrome_android": {
-                "version_added": "71"
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "58"
-              },
-              "opera_android": {
-                "version_added": "58"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              },
-              "webview_android": {
-                "version_added": "71"
-              }
-            },
-            "status": {
-              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -302,6 +302,74 @@
             }
           }
         },
+        "intrinsicsize": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "71",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-productivity-features"
+                  }
+                ]
+              },
+              "chrome_android": {
+                "version_added": "71",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-productivity-features"
+                  }
+                ]
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "58"
+              },
+              "opera_android": {
+                "version_added": "58"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": "71",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-productivity-features"
+                  }
+                ]
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "loop": {
           "__compat": {
             "support": {
@@ -647,56 +715,6 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "intrinsicsize": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "71"
-              },
-              "chrome_android": {
-                "version_added": "71"
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "58"
-              },
-              "opera_android": {
-                "version_added": "58"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              },
-              "webview_android": {
-                "version_added": "71"
-              }
-            },
-            "status": {
-              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -651,6 +651,56 @@
               "deprecated": false
             }
           }
+        },
+        "intrinsicsize": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "71"
+              },
+              "chrome_android": {
+                "version_added": "71"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "58"
+              },
+              "opera_android": {
+                "version_added": "58"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": "71"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Experimental `intrinsicsize` attribute added.
Explainer: https://github.com/ojanvafai/intrinsicsize-attribute

Chrome: `Experimental Web Platform features` flag, Version >= Chrome 71. https://www.chromestatus.com/feature/4704436815396864

Tested: no
Primarily done through manual `JSON.parse` and `JSON.stringify` ... may need changes for `standard_track` but not certain.