### PR TITLE
Add spec_url data for JavaScript features

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -4,6 +4,7 @@
       "Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-array-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -57,6 +58,7 @@
         "concat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/concat",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.concat",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -111,6 +113,7 @@
         "copyWithin": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.copywithin",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -165,6 +168,7 @@
         "entries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/entries",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.entries",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -219,6 +223,7 @@
         "every": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/every",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.every",
             "support": {
               "chrome": {
                 "version_added": true
@@ -273,6 +278,7 @@
         "fill": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/fill",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.fill",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -338,6 +344,7 @@
         "filter": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/filter",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.filter",
             "support": {
               "chrome": {
                 "version_added": true
@@ -392,6 +399,7 @@
         "find": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/find",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.find",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -457,6 +465,7 @@
         "findIndex": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.findIndex",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -522,6 +531,7 @@
         "flat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flat",
+            "spec_url": "https://tc39.github.io/proposal-flatMap/#sec-Array.prototype.flat",
             "support": {
               "chrome": {
                 "version_added": "69"
@@ -576,6 +586,7 @@
         "flatMap": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap",
+            "spec_url": "https://tc39.github.io/proposal-flatMap/#sec-Array.prototype.flatMap",
             "support": {
               "chrome": {
                 "version_added": "69"
@@ -630,6 +641,7 @@
         "forEach": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.foreach",
             "support": {
               "chrome": {
                 "version_added": true
@@ -684,6 +696,7 @@
         "from": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/from",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.from",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -738,6 +751,7 @@
         "includes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/includes",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.includes",
             "support": {
               "chrome": {
                 "version_added": "47"
@@ -803,6 +817,7 @@
         "indexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.indexof",
             "support": {
               "chrome": {
                 "version_added": true
@@ -857,6 +872,7 @@
         "isArray": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.isarray",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -911,6 +927,7 @@
         "join": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/join",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.join",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -965,6 +982,7 @@
         "keys": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/keys",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.keys",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1019,6 +1037,7 @@
         "lastIndexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.lastindexof",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1073,6 +1092,7 @@
         "length": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/length",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-properties-of-array-instances-length",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1127,6 +1147,7 @@
         "map": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/map",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.map",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1236,6 +1257,7 @@
         "of": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/of",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.of",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1290,6 +1312,7 @@
         "pop": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/pop",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.pop",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1344,6 +1367,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1398,6 +1422,7 @@
         "push": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/push",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.push",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1452,6 +1477,7 @@
         "reduce": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.reduce",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1506,6 +1532,7 @@
         "reduceRight": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reduceRight",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.reduceright",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1560,6 +1587,7 @@
         "reverse": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.reverse",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1614,6 +1642,7 @@
         "shift": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/shift",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.shift",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1668,6 +1697,7 @@
         "slice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/slice",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.slice",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1722,6 +1752,7 @@
         "some": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/some",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.some",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1776,6 +1807,7 @@
         "sort": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/sort",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.sort",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1830,6 +1862,7 @@
         "splice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/splice",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.splice",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1884,6 +1917,10 @@
         "toLocaleString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toLocaleString",
+            "spec_url": [
+              "https://tc39.github.io/ecma262/#sec-array.prototype.tolocalestring",
+              "https://tc39.github.io/ecma402/#sup-array.prototype.tolocalestring"
+            ],
             "support": {
               "chrome": {
                 "version_added": true
@@ -2100,6 +2137,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toString",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2209,6 +2247,7 @@
         "unshift": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.unshift",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2263,6 +2302,7 @@
         "values": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/values",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.values",
             "support": {
               "chrome": {
                 "version_added": "66"
@@ -2333,6 +2373,7 @@
         "@@iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype-@@iterator",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -2415,6 +2456,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@species",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-array-@@species",
             "support": {
               "chrome": {
                 "version_added": null
@@ -2480,6 +2522,7 @@
         "@@unscopables": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@unscopables",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype-@@unscopables",
             "support": {
               "chrome": {
                 "version_added": null

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -4,6 +4,7 @@
       "ArrayBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-arraybuffer-constructor",
           "support": {
             "chrome": {
               "version_added": "7"
@@ -111,6 +112,7 @@
         "byteLength": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/byteLength",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-arraybuffer.prototype.bytelength",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -165,6 +167,7 @@
         "isView": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/isView",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-arraybuffer.isview",
             "support": {
               "chrome": {
                 "version_added": true
@@ -219,6 +222,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-arraybuffer.prototype",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -273,6 +277,7 @@
         "slice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/slice",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-arraybuffer.prototype.slice",
             "support": {
               "chrome": {
                 "version_added": true
@@ -329,6 +334,7 @@
         "transfer": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer",
+            "spec_url": "https://github.com/domenic/proposal-arraybuffer-transfer/#arraybufferprototypetransfer",
             "support": {
               "chrome": {
                 "version_added": false
@@ -383,6 +389,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/@@species",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-arraybuffer-@@species",
             "support": {
               "chrome": {
                 "version_added": null

--- a/javascript/builtins/AsyncFunction.json
+++ b/javascript/builtins/AsyncFunction.json
@@ -4,6 +4,7 @@
       "AsyncFunction": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncFunction",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-async-function-objects",
           "support": {
             "chrome": {
               "version_added": "55"
@@ -68,6 +69,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncFunction/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-async-function-constructor-prototype",
             "support": {
               "chrome": {
                 "version_added": "55"

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -4,6 +4,7 @@
       "Atomics": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-atomics-object",
           "support": {
             "chrome": [
               {
@@ -120,6 +121,7 @@
         "add": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/add",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.add",
             "support": {
               "chrome": [
                 {
@@ -237,6 +239,7 @@
         "and": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/and",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.and",
             "support": {
               "chrome": [
                 {
@@ -354,6 +357,7 @@
         "compareExchange": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/compareExchange",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.compareexchange",
             "support": {
               "chrome": [
                 {
@@ -471,6 +475,7 @@
         "exchange": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/exchange",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.exchange",
             "support": {
               "chrome": [
                 {
@@ -588,6 +593,7 @@
         "isLockFree": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/isLockFree",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.islockfree",
             "support": {
               "chrome": [
                 {
@@ -705,6 +711,7 @@
         "load": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/load",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.load",
             "support": {
               "chrome": [
                 {
@@ -822,6 +829,7 @@
         "notify": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/notify",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.notify",
             "support": {
               "chrome": [
                 {
@@ -995,6 +1003,7 @@
         "or": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/or",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.or",
             "support": {
               "chrome": [
                 {
@@ -1112,6 +1121,7 @@
         "store": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/store",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.store",
             "support": {
               "chrome": [
                 {
@@ -1229,6 +1239,7 @@
         "sub": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/sub",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.sub",
             "support": {
               "chrome": [
                 {
@@ -1346,6 +1357,7 @@
         "wait": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.wait",
             "support": {
               "chrome": [
                 {
@@ -1489,6 +1501,7 @@
         "xor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/xor",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.xor",
             "support": {
               "chrome": [
                 {

--- a/javascript/builtins/Boolean.json
+++ b/javascript/builtins/Boolean.json
@@ -4,6 +4,7 @@
       "Boolean": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-boolean-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -57,6 +58,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-boolean.prototype",
             "support": {
               "chrome": {
                 "version_added": true
@@ -165,6 +167,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean/toString",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-boolean.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -219,6 +222,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean/valueOf",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-boolean.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -4,6 +4,7 @@
       "DataView": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-dataview-constructor",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -165,6 +166,7 @@
         "buffer": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/buffer",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-dataview.prototype.buffer",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -273,6 +275,7 @@
         "byteLength": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/byteLength",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-dataview.prototype.bytelength",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -327,6 +330,7 @@
         "byteOffset": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/byteOffset",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-dataview.prototype.byteoffset",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -381,6 +385,7 @@
         "getFloat32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getFloat32",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.getfloat32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -435,6 +440,7 @@
         "getFloat64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getFloat64",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.getfloat64",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -489,6 +495,7 @@
         "getInt16": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getInt16",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.getint16",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -543,6 +550,7 @@
         "getInt32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getInt32",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.getint32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -597,6 +605,7 @@
         "getInt8": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getInt8",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.getint8",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -651,6 +660,7 @@
         "getUint16": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getUint16",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.getuint16",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -705,6 +715,7 @@
         "getUint32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getUint32",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.getuint32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -759,6 +770,7 @@
         "getUint8": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getUint8",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.getuint8",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -813,6 +825,7 @@
         "setFloat32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setFloat32",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.setfloat32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -867,6 +880,7 @@
         "setFloat64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setFloat64",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.setfloat64",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -921,6 +935,7 @@
         "setInt16": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setInt16",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.setint16",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -975,6 +990,7 @@
         "setInt32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setInt32",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.setint32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1029,6 +1045,7 @@
         "setInt8": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setInt8",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.setint8",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1083,6 +1100,7 @@
         "setUint16": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setUint16",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.setuint16",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1137,6 +1155,7 @@
         "setUint32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setUint32",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.setuint32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1191,6 +1210,7 @@
         "setUint8": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setUint8",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.setuint8",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1245,6 +1265,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype",
             "support": {
               "chrome": {
                 "version_added": "9"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -4,6 +4,7 @@
       "Date": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-date-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -58,6 +59,7 @@
         "@@toPrimitive": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/@@toPrimitive",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype-@@toprimitive",
             "support": {
               "chrome": {
                 "version_added": null
@@ -112,6 +114,7 @@
         "UTC": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/UTC",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.utc",
             "support": {
               "chrome": {
                 "version_added": true
@@ -166,6 +169,7 @@
         "getDate": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getdate",
             "support": {
               "chrome": {
                 "version_added": true
@@ -220,6 +224,7 @@
         "getDay": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getday",
             "support": {
               "chrome": {
                 "version_added": true
@@ -274,6 +279,7 @@
         "getFullYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getFullYear",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getfullyear",
             "support": {
               "chrome": {
                 "version_added": true
@@ -328,6 +334,7 @@
         "getHours": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getHours",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.gethours",
             "support": {
               "chrome": {
                 "version_added": true
@@ -382,6 +389,7 @@
         "getMilliseconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getMilliseconds",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getmilliseconds",
             "support": {
               "chrome": {
                 "version_added": true
@@ -436,6 +444,7 @@
         "getMinutes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getMinutes",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getminutes",
             "support": {
               "chrome": {
                 "version_added": true
@@ -490,6 +499,7 @@
         "getMonth": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getmonth",
             "support": {
               "chrome": {
                 "version_added": true
@@ -544,6 +554,7 @@
         "getSeconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getSeconds",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getseconds",
             "support": {
               "chrome": {
                 "version_added": true
@@ -598,6 +609,7 @@
         "getTime": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.gettime",
             "support": {
               "chrome": {
                 "version_added": true
@@ -652,6 +664,7 @@
         "getTimezoneOffset": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.gettimezoneoffset",
             "support": {
               "chrome": {
                 "version_added": true
@@ -706,6 +719,7 @@
         "getUTCDate": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDate",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getutcdate",
             "support": {
               "chrome": {
                 "version_added": true
@@ -760,6 +774,7 @@
         "getUTCDay": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDay",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getutcday",
             "support": {
               "chrome": {
                 "version_added": true
@@ -814,6 +829,7 @@
         "getUTCFullYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCFullYear",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getutcfullyear",
             "support": {
               "chrome": {
                 "version_added": true
@@ -868,6 +884,7 @@
         "getUTCHours": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCHours",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getutchours",
             "support": {
               "chrome": {
                 "version_added": true
@@ -922,6 +939,7 @@
         "getUTCMilliseconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMilliseconds",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getutcmilliseconds",
             "support": {
               "chrome": {
                 "version_added": true
@@ -976,6 +994,7 @@
         "getUTCMinutes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMinutes",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getutcminutes",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1030,6 +1049,7 @@
         "getUTCMonth": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMonth",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getutcmonth",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1084,6 +1104,7 @@
         "getUTCSeconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCSeconds",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getutcseconds",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1138,6 +1159,7 @@
         "getYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getYear",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getyear",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1192,6 +1214,7 @@
         "now": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/now",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.now",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -1246,6 +1269,7 @@
         "parse": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/parse",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.parse",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1354,6 +1378,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-properties-of-the-date-prototype-object",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1462,6 +1487,7 @@
         "setDate": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setDate",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setdate",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1516,6 +1542,7 @@
         "setFullYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setFullYear",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setfullyear",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1570,6 +1597,7 @@
         "setHours": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setHours",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.sethours",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1624,6 +1652,7 @@
         "setMilliseconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setMilliseconds",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setmilliseconds",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1678,6 +1707,7 @@
         "setMinutes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setMinutes",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setminutes",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1732,6 +1762,7 @@
         "setMonth": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setMonth",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setmonth",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1786,6 +1817,7 @@
         "setSeconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setSeconds",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setseconds",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1840,6 +1872,7 @@
         "setTime": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setTime",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.settime",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1894,6 +1927,7 @@
         "setUTCDate": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCDate",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setutcdate",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1948,6 +1982,7 @@
         "setUTCFullYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCFullYear",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setutcfullyear",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2002,6 +2037,7 @@
         "setUTCHours": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCHours",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setutchours",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2056,6 +2092,7 @@
         "setUTCMilliseconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMilliseconds",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setutcmilliseconds",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2110,6 +2147,7 @@
         "setUTCMinutes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMinutes",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setutcminutes",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2164,6 +2202,7 @@
         "setUTCMonth": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMonth",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setutcmonth",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2218,6 +2257,7 @@
         "setUTCSeconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCSeconds",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setutcseconds",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2272,6 +2312,7 @@
         "setYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setYear",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setyear",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2326,6 +2367,7 @@
         "toDateString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toDateString",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.todatestring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2380,6 +2422,7 @@
         "toGMTString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toGMTString",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.togmtstring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2434,6 +2477,7 @@
         "toISOString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.toisostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2488,6 +2532,7 @@
         "toJSON": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.tojson",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2542,6 +2587,10 @@
         "toLocaleDateString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString",
+            "spec_url": [
+              "https://tc39.github.io/ecma262/#sec-date.prototype.tolocaledatestring",
+              "https://tc39.github.io/ecma402/#sec-Date.prototype.toLocaleDateString"
+            ],
             "support": {
               "chrome": {
                 "version_added": true
@@ -2812,6 +2861,10 @@
         "toLocaleString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString",
+            "spec_url": [
+              "https://tc39.github.io/ecma262/#sec-date.prototype.tolocalestring",
+              "https://tc39.github.io/ecma402/#sec-Date.prototype.toLocaleString"
+            ],
             "support": {
               "chrome": {
                 "version_added": true
@@ -3026,6 +3079,10 @@
         "toLocaleTimeString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString",
+            "spec_url": [
+              "https://tc39.github.io/ecma262/#sec-date.prototype.tolocalestring",
+              "https://tc39.github.io/ecma402/#sec-Date.prototype.toLocaleTimeString"
+            ],
             "support": {
               "chrome": {
                 "version_added": true
@@ -3294,6 +3351,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toString",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -3348,6 +3406,7 @@
         "toTimeString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toTimeString",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.totimestring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -3402,6 +3461,7 @@
         "toUTCString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toUTCString",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.toutcstring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -3456,6 +3516,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/valueOf",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -4,6 +4,7 @@
       "Error": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-error-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -57,6 +58,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-error.prototype",
             "support": {
               "chrome": {
                 "version_added": true
@@ -273,6 +275,7 @@
         "message": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/message",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-error.prototype.message",
             "support": {
               "chrome": {
                 "version_added": true
@@ -327,6 +330,7 @@
         "name": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/name",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-error.prototype.name",
             "support": {
               "chrome": {
                 "version_added": true
@@ -489,6 +493,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/toString",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-error.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/EvalError.json
+++ b/javascript/builtins/EvalError.json
@@ -4,6 +4,7 @@
       "EvalError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/EvalError",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-evalerror",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -4,6 +4,7 @@
       "Float32Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array",
+          "spec_url": "https://tc39.github.io/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -4,6 +4,7 @@
       "Float64Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float64Array",
+          "spec_url": "https://tc39.github.io/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -4,6 +4,7 @@
       "Function": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-function-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -57,6 +58,7 @@
         "arguments": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/arguments",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-arguments-object",
             "support": {
               "chrome": {
                 "version_added": true
@@ -273,6 +275,7 @@
         "length": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/length",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-function-instances-length",
             "support": {
               "chrome": {
                 "version_added": true
@@ -381,6 +384,7 @@
         "name": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/name",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-function-instances-name",
             "support": {
               "chrome": {
                 "version_added": "15"
@@ -543,6 +547,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-function-instances-prototype",
             "support": {
               "chrome": {
                 "version_added": true
@@ -597,6 +602,7 @@
         "apply": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/apply",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-function.prototype.apply",
             "support": {
               "chrome": {
                 "version_added": true
@@ -705,6 +711,7 @@
         "bind": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/bind",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-function.prototype.bind",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -759,6 +766,7 @@
         "call": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/call",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-function.prototype.call",
             "support": {
               "chrome": {
                 "version_added": true
@@ -923,6 +931,10 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/toString",
+            "spec_url": [
+              "https://tc39.github.io/Function-prototype-toString-revision/#sec-introduction",
+              "https://tc39.github.io/ecma262/#sec-function.prototype.tostring"
+            ],
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/Generator.json
+++ b/javascript/builtins/Generator.json
@@ -4,6 +4,7 @@
       "Generator": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Generator",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-generator-objects",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -68,6 +69,7 @@
         "next": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Generator/next",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-generator.prototype.next",
             "support": {
               "chrome": {
                 "version_added": "39"
@@ -122,6 +124,7 @@
         "return": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Generator/return",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-generator.prototype.return",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -176,6 +179,7 @@
         "throw": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Generator/throw",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-generator.prototype.throw",
             "support": {
               "chrome": {
                 "version_added": "39"

--- a/javascript/builtins/GeneratorFunction.json
+++ b/javascript/builtins/GeneratorFunction.json
@@ -4,6 +4,7 @@
       "GeneratorFunction": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/GeneratorFunction",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-generatorfunction-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -57,6 +58,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/GeneratorFunction/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-generatorfunction.prototype",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -4,6 +4,7 @@
       "Int16Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int16Array",
+          "spec_url": "https://tc39.github.io/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -4,6 +4,7 @@
       "Int32Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int32Array",
+          "spec_url": "https://tc39.github.io/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -4,6 +4,7 @@
       "Int8Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int8Array",
+          "spec_url": "https://tc39.github.io/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -4,6 +4,7 @@
       "Intl": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl",
+          "spec_url": "https://tc39.github.io/ecma402/#intl-object",
           "support": {
             "chrome": {
               "version_added": "24"
@@ -57,6 +58,7 @@
         "getCanonicalLocales": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales",
+            "spec_url": "https://tc39.github.io/ecma402/#sec-intl.getcanonicallocales",
             "support": {
               "chrome": {
                 "version_added": "54"
@@ -111,6 +113,7 @@
         "Collator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator",
+            "spec_url": "https://tc39.github.io/ecma402/#collator-objects",
             "support": {
               "chrome": {
                 "version_added": "24"
@@ -218,6 +221,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/prototype",
+              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.Collator.prototype",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -272,6 +276,7 @@
           "compare": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/compare",
+              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.Collator.prototype.compare",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -326,6 +331,7 @@
           "resolvedOptions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/resolvedOptions",
+              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.Collator.prototype.resolvedOptions",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -380,6 +386,7 @@
           "supportedLocalesOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/supportedLocalesOf",
+              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.Collator.supportedLocalesOf",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -435,6 +442,7 @@
         "DateTimeFormat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat",
+            "spec_url": "https://tc39.github.io/ecma402/#datetimeformat-objects",
             "support": {
               "chrome": {
                 "version_added": "24"
@@ -595,6 +603,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/prototype",
+              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.DateTimeFormat.prototype",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -649,6 +658,7 @@
           "format": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/format",
+              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.DateTimeFormat.prototype.format",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -703,6 +713,7 @@
           "formatToParts": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatToParts",
+              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.DateTimeFormat.prototype.formatToParts",
               "support": {
                 "chrome": [
                   {
@@ -769,6 +780,7 @@
           "resolvedOptions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/resolvedOptions",
+              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.DateTimeFormat.prototype.resolvedOptions",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -877,6 +889,7 @@
           "supportedLocalesOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/supportedLocalesOf",
+              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.Collator.supportedLocalesOf",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -932,6 +945,7 @@
         "NumberFormat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat",
+            "spec_url": "https://tc39.github.io/ecma402/#numberformat-objects",
             "support": {
               "chrome": {
                 "version_added": "24"
@@ -985,6 +999,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/prototype",
+              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.NumberFormat.prototype",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -1039,6 +1054,7 @@
           "format": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/format",
+              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.NumberFormat.prototype.format",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -1093,6 +1109,7 @@
           "formatToParts": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/formatToParts",
+              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.NumberFormat.prototype.formatToParts",
               "support": {
                 "chrome": {
                   "version_added": "63",
@@ -1161,6 +1178,7 @@
           "resolvedOptions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/resolvedOptions",
+              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.NumberFormat.prototype.resolvedOptions",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -1215,6 +1233,7 @@
           "supportedLocalesOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/supportedLocalesOf",
+              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.NumberFormat.supportedLocalesOf",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -1270,6 +1289,7 @@
         "PluralRules": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/PluralRules",
+            "spec_url": "https://tc39.github.io/ecma402/#pluralrules-objects",
             "support": {
               "chrome": {
                 "version_added": "63"

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -4,6 +4,7 @@
       "JSON": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-json-object",
           "support": {
             "chrome": {
               "version_added": true
@@ -57,6 +58,7 @@
         "parse": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-json.parse",
             "support": {
               "chrome": {
                 "version_added": true
@@ -111,6 +113,7 @@
         "stringify": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-json.stringify",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -4,6 +4,7 @@
       "Map": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-map-objects",
           "support": {
             "chrome": {
               "version_added": "38"
@@ -295,6 +296,7 @@
         "clear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/clear",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.clear",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -349,6 +351,7 @@
         "delete": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/delete",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.delete",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -414,6 +417,7 @@
         "entries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/entries",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.entries",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -468,6 +472,7 @@
         "forEach": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.foreach",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -522,6 +527,7 @@
         "get": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/get",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.get",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -576,6 +582,7 @@
         "has": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/has",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.has",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -630,6 +637,7 @@
         "keys": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/keys",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.keys",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -684,6 +692,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -738,6 +747,7 @@
         "set": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/set",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.set",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -794,6 +804,7 @@
         "size": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/size",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-map.prototype.size",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -850,6 +861,7 @@
         "values": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/values",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.values",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -904,6 +916,7 @@
         "@@iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/@@iterator",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype-@@iterator",
             "support": {
               "chrome": {
                 "version_added": true
@@ -986,6 +999,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/@@species",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-map-@@species",
             "support": {
               "chrome": {
                 "version_added": "51"
@@ -1051,6 +1065,7 @@
         "@@toStringTag": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/@@toStringTag",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype-@@tostringtag",
             "support": {
               "chrome": {
                 "version_added": "44"

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -5,6 +5,7 @@
         "E": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/E",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.e",
             "support": {
               "chrome": {
                 "version_added": true
@@ -59,6 +60,7 @@
         "LN2": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LN2",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.ln2",
             "support": {
               "chrome": {
                 "version_added": true
@@ -113,6 +115,7 @@
         "LN10": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LN10",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.ln10",
             "support": {
               "chrome": {
                 "version_added": true
@@ -167,6 +170,7 @@
         "LOG2E": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LOG2E",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.log2e",
             "support": {
               "chrome": {
                 "version_added": true
@@ -221,6 +225,7 @@
         "LOG10E": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LOG10E",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.log10e",
             "support": {
               "chrome": {
                 "version_added": true
@@ -275,6 +280,7 @@
         "PI": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/PI",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.pi",
             "support": {
               "chrome": {
                 "version_added": true
@@ -329,6 +335,7 @@
         "SQRT1_2": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/SQRT1_2",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.sqrt1_2",
             "support": {
               "chrome": {
                 "version_added": true
@@ -383,6 +390,7 @@
         "SQRT2": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/SQRT2",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.sqrt2",
             "support": {
               "chrome": {
                 "version_added": true
@@ -437,6 +445,7 @@
         "abs": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/abs",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.abs",
             "support": {
               "chrome": {
                 "version_added": true
@@ -491,6 +500,7 @@
         "acos": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/acos",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.acos",
             "support": {
               "chrome": {
                 "version_added": true
@@ -545,6 +555,7 @@
         "acosh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/acosh",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.acosh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -599,6 +610,7 @@
         "asin": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/asin",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.asin",
             "support": {
               "chrome": {
                 "version_added": true
@@ -653,6 +665,7 @@
         "asinh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/asinh",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.asinh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -707,6 +720,7 @@
         "atan": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/atan",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.atan",
             "support": {
               "chrome": {
                 "version_added": true
@@ -761,6 +775,7 @@
         "atan2": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/atan2",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.atan2",
             "support": {
               "chrome": {
                 "version_added": true
@@ -815,6 +830,7 @@
         "atanh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/atanh",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.atanh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -869,6 +885,7 @@
         "cbrt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/cbrt",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.cbrt",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -923,6 +940,7 @@
         "ceil": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/ceil",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.ceil",
             "support": {
               "chrome": {
                 "version_added": true
@@ -977,6 +995,7 @@
         "clz32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.clz32",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1031,6 +1050,7 @@
         "cos": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/cos",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.cos",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1085,6 +1105,7 @@
         "cosh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/cosh",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.cosh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1139,6 +1160,7 @@
         "exp": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/exp",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.exp",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1193,6 +1215,7 @@
         "expm1": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/expm1",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.expm1",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1247,6 +1270,7 @@
         "floor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/floor",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.floor",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1301,6 +1325,7 @@
         "fround": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/fround",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.fround",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1355,6 +1380,7 @@
         "hypot": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.hypot",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1409,6 +1435,7 @@
         "imul": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/imul",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.imul",
             "support": {
               "chrome": {
                 "version_added": "28"
@@ -1463,6 +1490,7 @@
         "log": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.log",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1517,6 +1545,7 @@
         "log1p": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log1p",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.log1p",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1571,6 +1600,7 @@
         "log2": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log2",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.log2",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1625,6 +1655,7 @@
         "log10": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log10",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.log10",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1679,6 +1710,7 @@
         "max": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/max",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.max",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1733,6 +1765,7 @@
         "min": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/min",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.min",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1787,6 +1820,7 @@
         "pow": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/pow",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.pow",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1841,6 +1875,7 @@
         "random": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/random",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.random",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1895,6 +1930,7 @@
         "round": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/round",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.round",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1949,6 +1985,7 @@
         "sign": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/sign",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.sign",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -2003,6 +2040,7 @@
         "sin": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/sin",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.sin",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2057,6 +2095,7 @@
         "sinh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/sinh",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.sinh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -2111,6 +2150,7 @@
         "sqrt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/sqrt",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.sqrt",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2165,6 +2205,7 @@
         "tan": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/tan",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.tan",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2219,6 +2260,7 @@
         "tanh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/tanh",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.tanh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -2273,6 +2315,7 @@
         "trunc": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-math.trunc",
             "support": {
               "chrome": {
                 "version_added": "38"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -4,6 +4,7 @@
       "Number": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-number-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -57,6 +58,7 @@
         "EPSILON": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/EPSILON",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.epsilon",
             "support": {
               "chrome": {
                 "version_added": true
@@ -111,6 +113,7 @@
         "MAX_SAFE_INTEGER": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.max_safe_integer",
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -165,6 +168,7 @@
         "MAX_VALUE": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_VALUE",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.max_value",
             "support": {
               "chrome": {
                 "version_added": true
@@ -219,6 +223,7 @@
         "MIN_SAFE_INTEGER": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.min_safe_integer",
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -273,6 +278,7 @@
         "MIN_VALUE": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_VALUE",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.min_value",
             "support": {
               "chrome": {
                 "version_added": true
@@ -327,6 +333,7 @@
         "NEGATIVE_INFINITY": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/NEGATIVE_INFINITY",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.negative_infinity",
             "support": {
               "chrome": {
                 "version_added": true
@@ -381,6 +388,7 @@
         "NaN": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.nan",
             "support": {
               "chrome": {
                 "version_added": true
@@ -435,6 +443,7 @@
         "POSITIVE_INFINITY": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/POSITIVE_INFINITY",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.positive_infinity",
             "support": {
               "chrome": {
                 "version_added": true
@@ -489,6 +498,7 @@
         "isFinite": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.isfinite",
             "support": {
               "chrome": {
                 "version_added": "19"
@@ -543,6 +553,7 @@
         "isInteger": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.isinteger",
             "support": {
               "chrome": {
                 "version_added": true
@@ -597,6 +608,7 @@
         "isNaN": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.isnan",
             "support": {
               "chrome": {
                 "version_added": "25"
@@ -651,6 +663,7 @@
         "isSafeInteger": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.issafeinteger",
             "support": {
               "chrome": {
                 "version_added": true
@@ -705,6 +718,7 @@
         "parseFloat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/parseFloat",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.parsefloat",
             "support": {
               "chrome": {
                 "version_added": true
@@ -759,6 +773,7 @@
         "parseInt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/parseInt",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.parseint",
             "support": {
               "chrome": {
                 "version_added": true
@@ -813,6 +828,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-properties-of-the-number-prototype-object",
             "support": {
               "chrome": {
                 "version_added": true
@@ -867,6 +883,7 @@
         "toExponential": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.prototype.toexponential",
             "support": {
               "chrome": {
                 "version_added": true
@@ -921,6 +938,7 @@
         "toFixed": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.prototype.tofixed",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1031,6 +1049,10 @@
         "toLocaleString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString",
+            "spec_url": [
+              "https://tc39.github.io/ecma262/#sec-number.prototype.tolocalestring",
+              "https://tc39.github.io/ecma402/#sec-Number.prototype.toLocaleString"
+            ],
             "support": {
               "chrome": {
                 "version_added": true
@@ -1191,6 +1213,7 @@
         "toPrecision": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.prototype.toprecision",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1299,6 +1322,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toString",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1353,6 +1377,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/valueOf",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-number.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -4,6 +4,7 @@
       "Object": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-object-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -57,6 +58,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype",
             "support": {
               "chrome": {
                 "version_added": true
@@ -279,6 +281,7 @@
           "__compat": {
             "description": "<code>__proto__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/proto",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-additional-properties-of-the-object.prototype-object",
             "support": {
               "chrome": {
                 "version_added": true
@@ -333,6 +336,7 @@
         "constructor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.constructor",
             "support": {
               "chrome": {
                 "version_added": true
@@ -387,6 +391,7 @@
         "assign": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/assign",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.assign",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -441,6 +446,7 @@
         "create": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/create",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.create",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -495,6 +501,7 @@
         "defineProperties": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.defineproperties",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -549,6 +556,7 @@
         "defineProperty": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.defineproperty",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -605,6 +613,7 @@
         "entries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/entries",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.entries",
             "support": {
               "chrome": {
                 "version_added": "54"
@@ -670,6 +679,7 @@
         "freeze": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.freeze",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -724,6 +734,7 @@
         "fromEntries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries",
+            "spec_url": "https://tc39.github.io/proposal-object-from-entries/#sec-object.fromentries",
             "support": {
               "chrome": {
                 "version_added": false
@@ -833,6 +844,7 @@
         "getOwnPropertyDescriptor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.getownpropertydescriptor",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -887,6 +899,7 @@
         "getOwnPropertyDescriptors": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.getownpropertydescriptors",
             "support": {
               "chrome": {
                 "version_added": "54"
@@ -952,6 +965,7 @@
         "getOwnPropertyNames": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.getownpropertynames",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -1006,6 +1020,7 @@
         "getOwnPropertySymbols": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.getownpropertysymbols",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1060,6 +1075,7 @@
         "getPrototypeOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.getprototypeof",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -1114,6 +1130,7 @@
         "is": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/is",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.is",
             "support": {
               "chrome": {
                 "version_added": "30"
@@ -1168,6 +1185,7 @@
         "isExtensible": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.isextensible",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1222,6 +1240,7 @@
         "isFrozen": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.isfrozen",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1276,6 +1295,7 @@
         "isSealed": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.issealed",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1330,6 +1350,7 @@
         "keys": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/keys",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.keys",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -1439,6 +1460,7 @@
         "preventExtensions": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.preventextensions",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1548,6 +1570,7 @@
           "__compat": {
             "description": "<code>__defineGetter__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1604,6 +1627,7 @@
           "__compat": {
             "description": "<code>__defineSetter__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.__defineSetter__",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1660,6 +1684,7 @@
           "__compat": {
             "description": "<code>__lookupGetter__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.__lookupGetter__",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1715,6 +1740,7 @@
           "__compat": {
             "description": "<code>__lookupSetter__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter__",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.__lookupSetter__",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1823,6 +1849,7 @@
         "hasOwnProperty": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.hasownproperty",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1877,6 +1904,7 @@
         "isPrototypeOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isPrototypeOf",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.isprototypeof",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1931,6 +1959,7 @@
         "propertyIsEnumerable": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.propertyisenumerable",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1985,6 +2014,7 @@
         "toLocaleString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/toLocaleString",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.tolocalestring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2093,6 +2123,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/toString",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2203,6 +2234,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2313,6 +2345,7 @@
         "seal": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/seal",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.seal",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -2367,6 +2400,7 @@
         "setPrototypeOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.setprototypeof",
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -2476,6 +2510,7 @@
         "values": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/values",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-object.values",
             "support": {
               "chrome": {
                 "version_added": "54"

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -4,6 +4,7 @@
       "Promise": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-promise-objects",
           "support": {
             "chrome": {
               "version_added": "32"
@@ -58,6 +59,7 @@
           "__compat": {
             "description": "<code>Promise()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-promise-objects",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -117,6 +119,7 @@
         "all": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/all",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-promise.all",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -171,6 +174,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-promise.prototype",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -225,6 +229,7 @@
         "catch": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-promise.prototype.catch",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -279,6 +284,7 @@
         "finally": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-promise.prototype.finally",
             "support": {
               "chrome": {
                 "version_added": "63"
@@ -333,6 +339,7 @@
         "then": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/then",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-promise.prototype.then",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -387,6 +394,7 @@
         "race": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/race",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-promise.race",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -441,6 +449,7 @@
         "reject": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-promise.reject",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -495,6 +504,7 @@
         "resolve": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-promise.resolve",
             "support": {
               "chrome": {
                 "version_added": "32"

--- a/javascript/builtins/Proxy.json
+++ b/javascript/builtins/Proxy.json
@@ -4,6 +4,7 @@
       "Proxy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-objects",
           "support": {
             "chrome": {
               "version_added": "49"
@@ -57,6 +58,7 @@
         "revocable": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/revocable",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-proxy.revocable",
             "support": {
               "chrome": {
                 "version_added": "63"
@@ -112,6 +114,7 @@
           "apply": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/apply",
+              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -166,6 +169,7 @@
           "construct": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/construct",
+              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -220,6 +224,7 @@
           "defineProperty": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/defineProperty",
+              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -274,6 +279,7 @@
           "deleteProperty": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/deleteProperty",
+              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-delete-p",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -384,6 +390,7 @@
           "get": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/get",
+              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -438,6 +445,7 @@
           "getOwnPropertyDescriptor": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/getOwnPropertyDescriptor",
+              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -492,6 +500,7 @@
           "getPrototypeOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/getPrototypeOf",
+              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -546,6 +555,7 @@
           "has": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/has",
+              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-hasproperty-p",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -600,6 +610,7 @@
           "isExtensible": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/isExtensible",
+              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-isextensible",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -654,6 +665,7 @@
           "ownKeys": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys",
+              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -710,6 +722,7 @@
           "preventExtensions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/preventExtensions",
+              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-preventextensions",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -764,6 +777,7 @@
           "set": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/set",
+              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -818,6 +832,7 @@
           "setPrototypeOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/setPrototypeOf",
+              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-setprototypeof-v",
               "support": {
                 "chrome": {
                   "version_added": null

--- a/javascript/builtins/RangeError.json
+++ b/javascript/builtins/RangeError.json
@@ -4,6 +4,7 @@
       "RangeError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RangeError",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/builtins/ReferenceError.json
+++ b/javascript/builtins/ReferenceError.json
@@ -4,6 +4,7 @@
       "ReferenceError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-referenceerror",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/builtins/Reflect.json
+++ b/javascript/builtins/Reflect.json
@@ -4,6 +4,7 @@
       "Reflect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-reflect-object",
           "support": {
             "chrome": {
               "version_added": "49"
@@ -57,6 +58,7 @@
         "apply": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/apply",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.apply",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -111,6 +113,7 @@
         "construct": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/construct",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.construct",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -165,6 +168,7 @@
         "defineProperty": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/defineProperty",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.defineproperty",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -219,6 +223,7 @@
         "deleteProperty": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/deleteProperty",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.deleteproperty",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -328,6 +333,7 @@
         "get": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/get",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.get",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -382,6 +388,7 @@
         "getOwnPropertyDescriptor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/getOwnPropertyDescriptor",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.getownpropertydescriptor",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -436,6 +443,7 @@
         "getPrototypeOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/getPrototypeOf",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.getprototypeof",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -490,6 +498,7 @@
         "has": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/has",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.has",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -544,6 +553,7 @@
         "isExtensible": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/isExtensible",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.isextensible",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -598,6 +608,7 @@
         "ownKeys": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.ownkeys",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -652,6 +663,7 @@
         "preventExtensions": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/preventExtensions",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.preventextensions",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -706,6 +718,7 @@
         "set": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/set",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.set",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -760,6 +773,7 @@
         "setPrototypeOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/setPrototypeOf",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.setprototypeof",
             "support": {
               "chrome": {
                 "version_added": "49"

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -4,6 +4,7 @@
       "RegExp": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-regexp-regular-expression-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -57,6 +58,7 @@
         "compile": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/compile",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype.compile",
             "support": {
               "chrome": {
                 "version_added": true
@@ -111,6 +113,7 @@
         "exec": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype.exec",
             "support": {
               "chrome": {
                 "version_added": true
@@ -165,6 +168,7 @@
         "flags": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/flags",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-regexp.prototype.flags",
             "support": {
               "chrome": {
                 "version_added": true
@@ -225,6 +229,7 @@
         "global": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/global",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-regexp.prototype.global",
             "support": {
               "chrome": {
                 "version_added": true
@@ -333,6 +338,7 @@
         "ignoreCase": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/ignoreCase",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-regexp.prototype.ignorecase",
             "support": {
               "chrome": {
                 "version_added": true
@@ -496,6 +502,7 @@
         "lastIndex": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-properties-of-regexp-instances",
             "support": {
               "chrome": {
                 "version_added": true
@@ -769,6 +776,7 @@
         "multiline": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-regexp.prototype.multiline",
             "support": {
               "chrome": {
                 "version_added": true
@@ -932,6 +940,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1041,6 +1050,7 @@
         "source": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/source",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-regexp.prototype.source",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1257,6 +1267,7 @@
         "sticky": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-regexp.prototype.sticky",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -1419,6 +1430,7 @@
         "test": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype.test",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1527,6 +1539,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/toString",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1689,6 +1702,7 @@
         "unicode": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-regexp.prototype.unicode",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -1744,6 +1758,7 @@
         "@@match": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@match",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype-@@match",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1798,6 +1813,7 @@
         "@@replace": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype-@@replace",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1852,6 +1868,7 @@
         "@@search": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@search",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype-@@search",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1906,6 +1923,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@species",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-regexp-@@species",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1971,6 +1989,7 @@
         "@@split": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@split",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype-@@split",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -4,6 +4,7 @@
       "Set": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-set-objects",
           "support": {
             "chrome": {
               "version_added": "38"
@@ -295,6 +296,7 @@
         "add": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/add",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype.add",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -351,6 +353,7 @@
         "clear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/clear",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype.clear",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -405,6 +408,7 @@
         "delete": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/delete",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype.delete",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -470,6 +474,7 @@
         "entries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/entries",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype.entries",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -524,6 +529,7 @@
         "forEach": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/forEach",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype.foreach",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -578,6 +584,7 @@
         "has": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/has",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype.has",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -632,6 +639,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -686,6 +694,7 @@
         "size": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/size",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-set.prototype.size",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -742,6 +751,7 @@
         "values": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/values",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype.values",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -796,6 +806,7 @@
         "@@iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/@@iterator",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype-@@iterator",
             "support": {
               "chrome": {
                 "version_added": true
@@ -878,6 +889,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/@@species",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-set-@@species",
             "support": {
               "chrome": {
                 "version_added": "51"

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -4,6 +4,7 @@
       "SharedArrayBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-sharedarraybuffer-objects",
           "support": {
             "chrome": [
               {
@@ -237,6 +238,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-sharedarraybuffer.prototype",
             "support": {
               "chrome": [
                 {
@@ -354,6 +356,7 @@
         "byteLength": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-sharedarraybuffer.prototype.bytelength",
             "support": {
               "chrome": [
                 {
@@ -471,6 +474,7 @@
         "slice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-sharedarraybuffer.prototype.slice",
             "support": {
               "chrome": [
                 {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -4,6 +4,7 @@
       "String": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-string-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -57,6 +58,7 @@
         "@@iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/@@iterator",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype-@@iterator",
             "support": {
               "chrome": {
                 "version_added": true
@@ -248,6 +250,7 @@
         "big": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/big",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.big",
             "support": {
               "chrome": {
                 "version_added": true
@@ -302,6 +305,7 @@
         "blink": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/blink",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.blink",
             "support": {
               "chrome": {
                 "version_added": true
@@ -356,6 +360,7 @@
         "bold": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/bold",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.bold",
             "support": {
               "chrome": {
                 "version_added": true
@@ -410,6 +415,7 @@
         "charAt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/charAt",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.charat",
             "support": {
               "chrome": {
                 "version_added": true
@@ -464,6 +470,7 @@
         "charCodeAt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.charcodeat",
             "support": {
               "chrome": {
                 "version_added": true
@@ -518,6 +525,7 @@
         "codePointAt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/codePointAt",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.codepointat",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -583,6 +591,7 @@
         "concat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/concat",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.concat",
             "support": {
               "chrome": {
                 "version_added": true
@@ -637,6 +646,7 @@
         "endsWith": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.endswith",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -702,6 +712,7 @@
         "fixed": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fixed",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.fixed",
             "support": {
               "chrome": {
                 "version_added": true
@@ -756,6 +767,7 @@
         "fontcolor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fontcolor",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.fontcolor",
             "support": {
               "chrome": {
                 "version_added": true
@@ -810,6 +822,7 @@
         "fontsize": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fontsize",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.fontsize",
             "support": {
               "chrome": {
                 "version_added": true
@@ -864,6 +877,7 @@
         "fromCharCode": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.fromcharcodes",
             "support": {
               "chrome": {
                 "version_added": true
@@ -918,6 +932,7 @@
         "fromCodePoint": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.fromcodepoint",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -983,6 +998,7 @@
         "includes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/includes",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.includes",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -1051,6 +1067,7 @@
         "indexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.indexof",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1105,6 +1122,7 @@
         "italics": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/italics",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.italics",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1159,6 +1177,7 @@
         "lastIndexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/lastIndexOf",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.lastindexof",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1213,6 +1232,7 @@
         "length": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/length",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-properties-of-string-instances-length",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1267,6 +1287,7 @@
         "link": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/link",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.link",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1321,6 +1342,10 @@
         "localeCompare": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare",
+            "spec_url": [
+              "https://tc39.github.io/ecma262/#sec-string.prototype.localecompare",
+              "https://tc39.github.io/ecma402/#sec-String.prototype.localeCompare"
+            ],
             "support": {
               "chrome": {
                 "version_added": true
@@ -1481,6 +1506,7 @@
         "match": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/match",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.match",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1590,6 +1616,7 @@
         "normalize": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/normalize",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.normalize",
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -1644,6 +1671,7 @@
         "padEnd": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.padend",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -1709,6 +1737,7 @@
         "padStart": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/padStart",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.padstart",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -1774,6 +1803,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1884,6 +1914,7 @@
         "raw": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/raw",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.raw",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -1938,6 +1969,7 @@
         "repeat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/repeat",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.repeat",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -2003,6 +2035,7 @@
         "replace": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/replace",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.replace",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2112,6 +2145,7 @@
         "search": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/search",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.search",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2221,6 +2255,7 @@
         "slice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/slice",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.slice",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2275,6 +2310,7 @@
         "small": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/small",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.small",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2329,6 +2365,7 @@
         "split": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/split",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.split",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2383,6 +2420,7 @@
         "startsWith": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.startswith",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -2448,6 +2486,7 @@
         "strike": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/strike",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.strike",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2502,6 +2541,7 @@
         "sub": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/sub",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.sub",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2556,6 +2596,7 @@
         "substr": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/substr",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.substr",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2610,6 +2651,7 @@
         "substring": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/substring",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.substring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2664,6 +2706,7 @@
         "sup": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/sup",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.sup",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2718,6 +2761,10 @@
         "toLocaleLowerCase": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase",
+            "spec_url": [
+              "https://tc39.github.io/ecma262/#sec-string.prototype.tolocalelowercase",
+              "https://tc39.github.io/ecma402/#sup-string.prototype.tolocalelowercase"
+            ],
             "support": {
               "chrome": {
                 "version_added": true
@@ -2825,6 +2872,10 @@
         "toLocaleUpperCase": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase",
+            "spec_url": [
+              "https://tc39.github.io/ecma262/#sec-string.prototype.tolocaleuppercase",
+              "https://tc39.github.io/ecma402/#sup-string.prototype.tolocaleuppercase"
+            ],
             "support": {
               "chrome": {
                 "version_added": true
@@ -2932,6 +2983,7 @@
         "toLowerCase": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.tolowercase",
             "support": {
               "chrome": {
                 "version_added": true
@@ -3040,6 +3092,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toString",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -3094,6 +3147,7 @@
         "toUpperCase": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toUpperCase",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.touppercase",
             "support": {
               "chrome": {
                 "version_added": true
@@ -3148,6 +3202,7 @@
         "trim": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trim",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.trim",
             "support": {
               "chrome": {
                 "version_added": true
@@ -3202,6 +3257,7 @@
         "trimEnd": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd",
+            "spec_url": "https://github.com/tc39/proposal-string-left-right-trim/#stringprototypetrimstart--stringprototypetrimend",
             "support": {
               "chrome": [
                 {
@@ -3286,6 +3342,7 @@
         "trimStart": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart",
+            "spec_url": "https://github.com/tc39/proposal-string-left-right-trim/#stringprototypetrimstart--stringprototypetrimend",
             "support": {
               "chrome": [
                 {
@@ -3370,6 +3427,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/valueOf",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -4,6 +4,7 @@
       "Symbol": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-symbol-objects",
           "support": {
             "chrome": {
               "version_added": "38"
@@ -112,6 +113,7 @@
         "description": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description",
+            "spec_url": "https://tc39.github.io/proposal-Symbol-description/#sec-symbol.prototype.description",
             "support": {
               "chrome": {
                 "version_added": "70"
@@ -166,6 +168,7 @@
         "for": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.for",
             "support": {
               "chrome": {
                 "version_added": "40"
@@ -220,6 +223,7 @@
         "hasInstance": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.hasinstance",
             "support": {
               "chrome": {
                 "version_added": "51"
@@ -285,6 +289,7 @@
         "isConcatSpreadable": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/isConcatSpreadable",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.isconcatspreadable",
             "support": {
               "chrome": {
                 "version_added": "48"
@@ -339,6 +344,7 @@
         "iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.iterator",
             "support": {
               "chrome": {
                 "version_added": "43"
@@ -393,6 +399,7 @@
         "keyFor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/keyFor",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.keyfor",
             "support": {
               "chrome": {
                 "version_added": "40"
@@ -447,6 +454,7 @@
         "match": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/match",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.match",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -501,6 +509,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.prototype",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -555,6 +564,7 @@
         "replace": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/replace",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.replace",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -609,6 +619,7 @@
         "search": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/search",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.search",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -663,6 +674,7 @@
         "species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/species",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.species",
             "support": {
               "chrome": {
                 "version_added": "51"
@@ -728,6 +740,7 @@
         "split": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/split",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.split",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -782,6 +795,7 @@
         "toPrimitive": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.toprimitive",
             "support": {
               "chrome": {
                 "version_added": "48"
@@ -890,6 +904,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toString",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -944,6 +959,7 @@
         "toStringTag": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.tostringtag",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -1009,6 +1025,7 @@
         "unscopables": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/unscopables",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.unscopables",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1063,6 +1080,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/valueOf",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1117,6 +1135,7 @@
         "@@toPrimitive": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/@@toPrimitive",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.prototype-@@toprimitive",
             "support": {
               "chrome": {
                 "version_added": null

--- a/javascript/builtins/SyntaxError.json
+++ b/javascript/builtins/SyntaxError.json
@@ -4,6 +4,7 @@
       "SyntaxError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-syntaxerror",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/builtins/TypeError.json
+++ b/javascript/builtins/TypeError.json
@@ -4,6 +4,7 @@
       "TypeError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypeError",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -4,6 +4,7 @@
       "TypedArray": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-typedarray-objects",
           "support": {
             "chrome": {
               "version_added": "7"
@@ -332,6 +333,7 @@
         "BYTES_PER_ELEMENT": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/BYTES_PER_ELEMENT",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-typedarray.bytes_per_element",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -386,6 +388,7 @@
         "buffer": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/buffer",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-%typedarray%.prototype.buffer",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -440,6 +443,7 @@
         "byteLength": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/byteLength",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-%typedarray%.prototype.bytelength",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -494,6 +498,7 @@
         "byteOffset": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/byteOffset",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-%typedarray%.prototype.byteoffset",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -548,6 +553,7 @@
         "copyWithin": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.copywithin",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -602,6 +608,7 @@
         "entries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/entries",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.entries",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -656,6 +663,7 @@
         "every": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/every",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.every",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -710,6 +718,7 @@
         "fill": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.fill",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -764,6 +773,7 @@
         "filter": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/filter",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.filter",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -818,6 +828,7 @@
         "find": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/find",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.find",
             "support": {
               "chrome": {
                 "version_added": true
@@ -872,6 +883,7 @@
         "findIndex": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/findIndex",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.findindex",
             "support": {
               "chrome": {
                 "version_added": true
@@ -926,6 +938,7 @@
         "forEach": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/forEach",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.foreach",
             "support": {
               "chrome": {
                 "version_added": true
@@ -980,6 +993,7 @@
         "from": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.from",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1034,6 +1048,7 @@
         "includes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/includes",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.includes",
             "support": {
               "chrome": {
                 "version_added": "47"
@@ -1099,6 +1114,7 @@
         "indexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/indexOf",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.indexof",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1155,6 +1171,7 @@
         "join": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/join",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.join",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1209,6 +1226,7 @@
         "keys": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/keys",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.keys",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1263,6 +1281,7 @@
         "lastIndexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/lastIndexOf",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.lastindexof",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1319,6 +1338,7 @@
         "length": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/length",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-%typedarray%.prototype.length",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1373,6 +1393,7 @@
         "map": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/map",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.map",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1485,6 +1506,7 @@
         "name": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/name",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-properties-of-the-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1539,6 +1561,7 @@
         "of": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/of",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.of",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1593,6 +1616,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-properties-of-the-%typedarrayprototype%-object",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1647,6 +1671,7 @@
         "reduce": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reduce",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.reduce",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1701,6 +1726,7 @@
         "reduceRight": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reduceRight",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.reduceRight",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1755,6 +1781,7 @@
         "reverse": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reverse",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.reverse",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1809,6 +1836,7 @@
         "set": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/set",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.set-array-offset",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1863,6 +1891,7 @@
         "slice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.slice",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1917,6 +1946,7 @@
         "some": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/some",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.some",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1971,6 +2001,7 @@
         "sort": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/sort",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.sort",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2025,6 +2056,7 @@
         "subarray": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/subarray",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.subarray",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -2079,6 +2111,7 @@
         "toLocaleString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toLocaleString",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.tolocalestring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2133,6 +2166,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toString",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2187,6 +2221,7 @@
         "values": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/values",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.values",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2241,6 +2276,7 @@
         "@@iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype-@@iterator",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2323,6 +2359,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@species",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-get-%typedarray%-@@species",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/URIError.json
+++ b/javascript/builtins/URIError.json
@@ -4,6 +4,7 @@
       "URIError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/URIError",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-urierror",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -4,6 +4,7 @@
       "Uint16Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array",
+          "spec_url": "https://tc39.github.io/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -4,6 +4,7 @@
       "Uint32Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array",
+          "spec_url": "https://tc39.github.io/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -4,6 +4,7 @@
       "Uint8Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array",
+          "spec_url": "https://tc39.github.io/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -4,6 +4,7 @@
       "Uint8ClampedArray": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray",
+          "spec_url": "https://tc39.github.io/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -4,6 +4,7 @@
       "WeakMap": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-weakmap-objects",
           "support": {
             "chrome": {
               "version_added": "36"
@@ -304,6 +305,7 @@
         "delete": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/delete",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-weakmap.prototype.delete",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -371,6 +373,7 @@
         "get": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/get",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-weakmap.prototype.get",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -438,6 +441,7 @@
         "has": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/has",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-weakmap.prototype.has",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -505,6 +509,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-weakmap.prototype",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -570,6 +575,7 @@
         "set": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/set",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-weakmap.prototype.set",
             "support": {
               "chrome": {
                 "version_added": "36"

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -4,6 +4,7 @@
       "WeakSet": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-weakset-objects",
           "support": {
             "chrome": {
               "version_added": "36"
@@ -165,6 +166,7 @@
         "add": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/add",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-weakset.prototype.add",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -280,6 +282,7 @@
         "delete": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/delete",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-weakset.prototype.delete",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -334,6 +337,7 @@
         "has": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/has",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-weakset.prototype.has",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -388,6 +392,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/prototype",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-weakset.prototype",
             "support": {
               "chrome": {
                 "version_added": "36"

--- a/javascript/builtins/WebAssembly.json
+++ b/javascript/builtins/WebAssembly.json
@@ -4,6 +4,7 @@
       "WebAssembly": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly",
+          "spec_url": "https://webassembly.github.io/spec/js-api/#the-webassembly-object",
           "support": {
             "chrome": {
               "version_added": "57"
@@ -65,6 +66,10 @@
         "CompileError": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError",
+            "spec_url": [
+              "https://webassembly.github.io/spec/js-api/#constructor-properties-of-the-webassembly-object",
+              "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard"
+            ],
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -127,6 +132,7 @@
         "Global": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Global",
+            "spec_url": "https://webassembly.github.io/spec/js-api/#globals",
             "support": {
               "chrome": {
                 "version_added": "69"
@@ -289,6 +295,7 @@
         "Instance": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance",
+            "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblyinstance-objects",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -350,6 +357,7 @@
           "exports": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/exports",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblyinstance-objects",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -412,6 +420,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/prototype",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymodule-objects",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -475,6 +484,10 @@
         "LinkError": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError",
+            "spec_url": [
+              "https://webassembly.github.io/spec/js-api/#constructor-properties-of-the-webassembly-object",
+              "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard"
+            ],
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -537,6 +550,7 @@
         "Memory": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory",
+            "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymemory-objects",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -598,6 +612,7 @@
           "buffer": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffer",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymemoryprototypebuffer",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -660,6 +675,7 @@
           "grow": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/grow",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymemoryprototypegrow",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -722,6 +738,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/prototype",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymemory-objects",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -785,6 +802,7 @@
         "Module": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module",
+            "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymodule-objects",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -846,6 +864,7 @@
           "customSections": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/customSections",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymodulecustomsections",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -908,6 +927,7 @@
           "exports": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/exports",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymoduleexports",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -970,6 +990,7 @@
           "imports": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/imports",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymoduleimports",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -1032,6 +1053,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/prototype",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymodule-objects",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -1095,6 +1117,10 @@
         "RuntimeError": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError",
+            "spec_url": [
+              "https://webassembly.github.io/spec/js-api/#constructor-properties-of-the-webassembly-object",
+              "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard"
+            ],
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -1157,6 +1183,7 @@
         "Table": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table",
+            "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblytable-objects",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -1218,6 +1245,7 @@
           "get": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/get",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblytableprototypeget",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -1280,6 +1308,7 @@
           "grow": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/grow",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblytableprototypegrow",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -1342,6 +1371,7 @@
           "length": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/length",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblytableprototypelength",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -1404,6 +1434,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/prototype",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblytable-objects",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -1466,6 +1497,7 @@
           "set": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/set",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblytableprototypeset",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -1529,6 +1561,7 @@
         "compile": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/compile",
+            "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblycompile",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -1591,6 +1624,7 @@
         "compileStreaming": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/compileStreaming",
+            "spec_url": "https://github.com/WebAssembly/design/blob/master/Web.md#webassemblycompilestreaming",
             "support": {
               "chrome": {
                 "version_added": "61"
@@ -1645,6 +1679,7 @@
         "instantiate": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiate",
+            "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblyinstantiate",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -1707,6 +1742,7 @@
         "instantiateStreaming": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming",
+            "spec_url": "https://github.com/WebAssembly/design/blob/master/Web.md#webassemblyinstantiatestreaming",
             "support": {
               "chrome": {
                 "version_added": "61"
@@ -1761,6 +1797,7 @@
         "validate": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/validate",
+            "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblyvalidate",
             "support": {
               "chrome": {
                 "version_added": "57"

--- a/javascript/builtins/globals.json
+++ b/javascript/builtins/globals.json
@@ -4,6 +4,7 @@
       "Infinity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Infinity",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-value-properties-of-the-global-object-infinity",
           "support": {
             "chrome": {
               "version_added": true
@@ -58,6 +59,7 @@
       "NaN": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NaN",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-value-properties-of-the-global-object-nan",
           "support": {
             "chrome": {
               "version_added": true
@@ -112,6 +114,7 @@
       "decodeURI": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/decodeURI",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-decodeuri-encodeduri",
           "support": {
             "chrome": {
               "version_added": true
@@ -166,6 +169,7 @@
       "decodeURIComponent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-decodeuricomponent-encodeduricomponent",
           "support": {
             "chrome": {
               "version_added": true
@@ -220,6 +224,7 @@
       "encodeURI": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/encodeURI",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-encodeuri-uri",
           "support": {
             "chrome": {
               "version_added": true
@@ -274,6 +279,7 @@
       "encodeURIComponent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-encodeuricomponent-uricomponent",
           "support": {
             "chrome": {
               "version_added": true
@@ -328,6 +334,7 @@
       "escape": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/escape",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-escape-string",
           "support": {
             "chrome": {
               "version_added": true
@@ -382,6 +389,7 @@
       "eval": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/eval",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-eval-x",
           "support": {
             "chrome": {
               "version_added": true
@@ -436,6 +444,7 @@
       "isFinite": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/isFinite",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-isfinite-number",
           "support": {
             "chrome": {
               "version_added": true
@@ -490,6 +499,7 @@
       "isNaN": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/isNaN",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-isnan-number",
           "support": {
             "chrome": {
               "version_added": true
@@ -544,6 +554,7 @@
       "null": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/null",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-null-value",
           "support": {
             "chrome": {
               "version_added": true
@@ -598,6 +609,7 @@
       "parseFloat": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/parseFloat",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-parsefloat-string",
           "support": {
             "chrome": {
               "version_added": true
@@ -652,6 +664,7 @@
       "parseInt": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/parseInt",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-parseint-string-radix",
           "support": {
             "chrome": {
               "version_added": true
@@ -760,6 +773,7 @@
       "undefined": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-undefined",
           "support": {
             "chrome": {
               "version_added": true
@@ -814,6 +828,7 @@
       "unescape": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/unescape",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-unescape-string",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -3,6 +3,7 @@
     "classes": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes",
+        "spec_url": "https://tc39.github.io/ecma262/#sec-class-definitions",
         "support": {
           "chrome": {
             "version_added": "49",
@@ -77,6 +78,7 @@
       "constructor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/constructor",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-static-semantics-constructormethod",
           "support": {
             "chrome": {
               "version_added": "49",
@@ -152,6 +154,7 @@
       "extends": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/extends",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-class-definitions",
           "support": {
             "chrome": {
               "version_added": "49",
@@ -227,6 +230,7 @@
       "static": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/static",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-class-definitions",
           "support": {
             "chrome": {
               "version_added": "49",

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -3,6 +3,7 @@
     "functions": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions",
+        "spec_url": "https://tc39.github.io/ecma262/#sec-function-definitions",
         "support": {
           "chrome": {
             "version_added": true
@@ -56,6 +57,7 @@
       "arguments": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/arguments",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-arguments-exotic-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -109,6 +111,7 @@
         "callee": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/arguments/callee",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-arguments-exotic-objects",
             "support": {
               "chrome": {
                 "version_added": true
@@ -218,6 +221,7 @@
         "length": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/arguments/length",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-arguments-exotic-objects",
             "support": {
               "chrome": {
                 "version_added": true
@@ -272,6 +276,10 @@
         "@@iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/arguments/@@iterator",
+            "spec_url": [
+              "https://tc39.github.io/ecma262/#sec-createunmappedargumentsobject",
+              "https://tc39.github.io/ecma262/#sec-createmappedargumentsobject"
+            ],
             "support": {
               "chrome": {
                 "version_added": "52"
@@ -328,6 +336,7 @@
         "__compat": {
           "description": "Arrow functions",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/Arrow_functions",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-arrow-function-definitions",
           "support": {
             "chrome": {
               "version_added": "45"
@@ -499,6 +508,7 @@
         "__compat": {
           "description": "Default parameters",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/Default_parameters",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-function-definitions",
           "support": {
             "chrome": {
               "version_added": "49"
@@ -662,6 +672,7 @@
         "__compat": {
           "description": "Method definitions",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/Method_definitions",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-method-definitions",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -901,6 +912,7 @@
         "__compat": {
           "description": "Rest parameters",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/rest_parameters",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-function-definitions",
           "support": {
             "chrome": {
               "version_added": "47"
@@ -1020,6 +1032,7 @@
       "get": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/get",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-method-definitions",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1128,6 +1141,7 @@
       "set": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/set",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-method-definitions",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -730,6 +730,7 @@
         "__compat": {
           "description": "Template literals",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Template_literals",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-template-literals",
           "support": {
             "chrome": {
               "version_added": "41"

--- a/javascript/operators/async_function_expression.json
+++ b/javascript/operators/async_function_expression.json
@@ -5,6 +5,7 @@
         "__compat": {
           "description": "<code>async function</code> expression",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/async_function",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-async-function-definitions",
           "support": {
             "chrome": {
               "version_added": "55"

--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -4,6 +4,7 @@
       "await": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/await",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-async-function-definitions",
           "support": {
             "chrome": {
               "version_added": "55"

--- a/javascript/operators/class.json
+++ b/javascript/operators/class.json
@@ -4,6 +4,7 @@
       "class": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/class",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-class-definitions",
           "support": {
             "chrome": {
               "version_added": "42"

--- a/javascript/operators/comma.json
+++ b/javascript/operators/comma.json
@@ -5,6 +5,7 @@
         "__compat": {
           "description": "Comma operator",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Comma_operator",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-comma-operator",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/conditional.json
+++ b/javascript/operators/conditional.json
@@ -5,6 +5,7 @@
         "__compat": {
           "description": "Conditional operator (<code>c ? t : f</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Conditional_Operator",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-conditional-operator",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/delete.json
+++ b/javascript/operators/delete.json
@@ -4,6 +4,7 @@
       "delete": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/delete",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-delete-operator",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/destructuring.json
+++ b/javascript/operators/destructuring.json
@@ -5,6 +5,7 @@
         "__compat": {
           "description": "Destructuring assignment",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-destructuring-assignment",
           "support": {
             "chrome": {
               "version_added": "49"

--- a/javascript/operators/function.json
+++ b/javascript/operators/function.json
@@ -4,6 +4,7 @@
       "function": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/function",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-function-definitions",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/function_star.json
+++ b/javascript/operators/function_star.json
@@ -5,6 +5,7 @@
         "__compat": {
           "description": "<code>function*</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/function*",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-generator-function-definitions",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/grouping.json
+++ b/javascript/operators/grouping.json
@@ -5,6 +5,7 @@
         "__compat": {
           "description": "Grouping operator <code>()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Grouping",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-grouping-operator",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/in.json
+++ b/javascript/operators/in.json
@@ -4,6 +4,7 @@
       "in": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/in",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-relational-operators",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/instanceof.json
+++ b/javascript/operators/instanceof.json
@@ -4,6 +4,7 @@
       "instanceof": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/instanceof",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-relational-operators",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/new.json
+++ b/javascript/operators/new.json
@@ -4,6 +4,7 @@
       "new": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/new",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-new-operator",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/new_target.json
+++ b/javascript/operators/new_target.json
@@ -5,6 +5,7 @@
         "__compat": {
           "description": "<code>new.target</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/new.target",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-built-in-function-objects",
           "support": {
             "chrome": {
               "version_added": "46"

--- a/javascript/operators/object_initializer.json
+++ b/javascript/operators/object_initializer.json
@@ -5,6 +5,7 @@
         "__compat": {
           "description": "Object initializer",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Object_initializer",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-object-initializer",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/pipeline.json
+++ b/javascript/operators/pipeline.json
@@ -5,6 +5,7 @@
         "__compat": {
           "description": "Pipeline operator (<code>|></code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Pipeline_operator",
+          "spec_url": "https://tc39.github.io/proposal-pipeline-operator/#sec-intro",
           "support": {
             "chrome": {
               "version_added": false

--- a/javascript/operators/property_accessors.json
+++ b/javascript/operators/property_accessors.json
@@ -5,6 +5,7 @@
         "__compat": {
           "description": "Property accessors",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Property_Accessors",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-property-accessors",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/super.json
+++ b/javascript/operators/super.json
@@ -4,6 +4,7 @@
       "super": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/super",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-super-keyword",
           "support": {
             "chrome": {
               "version_added": "42"

--- a/javascript/operators/this.json
+++ b/javascript/operators/this.json
@@ -4,6 +4,7 @@
       "this": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/this",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-this-keyword",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/typeof.json
+++ b/javascript/operators/typeof.json
@@ -4,6 +4,7 @@
       "typeof": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/typeof",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-typeof-operator",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/void.json
+++ b/javascript/operators/void.json
@@ -4,6 +4,7 @@
       "void": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/void",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-void-operator",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/yield.json
+++ b/javascript/operators/yield.json
@@ -4,6 +4,7 @@
       "yield": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/yield",
+          "spec_url": "https://tc39.github.io/ecma262/#prod-YieldExpression",
           "support": {
             "chrome": {
               "version_added": "39"

--- a/javascript/operators/yield_star.json
+++ b/javascript/operators/yield_star.json
@@ -5,6 +5,7 @@
         "__compat": {
           "description": "<code>yield*</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/yield*",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-generator-function-definitions-runtime-semantics-evaluation",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -62,6 +62,7 @@
         "__compat": {
           "description": "<code>async function</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/async_function",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-async-function-definitions",
           "support": {
             "chrome": {
               "version_added": "55"
@@ -127,6 +128,7 @@
       "block": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/block",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-block",
           "support": {
             "chrome": {
               "version_added": true
@@ -181,6 +183,7 @@
       "break": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/break",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-break-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -235,6 +238,7 @@
       "class": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/class",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-class-definitions",
           "support": {
             "chrome": {
               "version_added": "42"
@@ -397,6 +401,7 @@
       "const": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/const",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-let-and-const-declarations",
           "support": {
             "chrome": {
               "version_added": "21"
@@ -459,6 +464,7 @@
       "continue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/continue",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-continue-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -513,6 +519,7 @@
       "debugger": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/debugger",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-debugger-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -569,6 +576,10 @@
           "__compat": {
             "description": "<code>default</code> keyword in <code>switch</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/default",
+            "spec_url": [
+              "https://tc39.github.io/ecma262/#sec-switch-statement",
+              "https://tc39.github.io/ecma262/#sec-exports"
+            ],
             "support": {
               "chrome": {
                 "version_added": true
@@ -624,6 +635,10 @@
           "__compat": {
             "description": "<code>default</code> keyword with <code>export</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/default",
+            "spec_url": [
+              "https://tc39.github.io/ecma262/#sec-switch-statement",
+              "https://tc39.github.io/ecma262/#sec-exports"
+            ],
             "support": {
               "chrome": {
                 "version_added": "61"
@@ -715,6 +730,7 @@
         "__compat": {
           "description": "<code>do...while</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/do...while",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-do-while-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -770,6 +786,7 @@
         "__compat": {
           "description": "Empty statement (<code>;</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/Empty",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-empty-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -824,6 +841,7 @@
       "export": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/export",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-exports",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -913,6 +931,7 @@
       "for": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-for-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -968,6 +987,7 @@
         "__compat": {
           "description": "<code>for await...of</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for-await...of",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-for-in-and-for-of-statements",
           "support": {
             "chrome": {
               "version_added": "63"
@@ -1080,6 +1100,7 @@
         "__compat": {
           "description": "<code>for...in</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for...in",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-for-in-and-for-of-statements",
           "support": {
             "chrome": {
               "version_added": true
@@ -1135,6 +1156,7 @@
         "__compat": {
           "description": "<code>for...of</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for...of",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-for-in-and-for-of-statements",
           "support": {
             "chrome": {
               "version_added": "38"
@@ -1299,6 +1321,7 @@
       "function": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-function-definitions",
           "support": {
             "chrome": {
               "version_added": true
@@ -1462,6 +1485,7 @@
         "__compat": {
           "description": "<code>function*</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function*",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-generator-function-definitions",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -1690,6 +1714,7 @@
         "__compat": {
           "description": "<code>if...else</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/if...else",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-if-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -1744,6 +1769,10 @@
       "import": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/import",
+          "spec_url": [
+            "https://github.com/tc39/proposal-dynamic-import/#import",
+            "https://tc39.github.io/ecma262/#sec-imports"
+          ],
           "support": {
             "chrome": {
               "version_added": "61"
@@ -1898,6 +1927,10 @@
         "__compat": {
           "description": "<code>import.meta</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/import.meta",
+          "spec_url": [
+            "https://github.com/tc39/proposal-import-meta/#importmeta",
+            "https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties"
+          ],
           "support": {
             "chrome": {
               "version_added": "64"
@@ -1937,6 +1970,7 @@
       "label": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/label",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-labelled-statements",
           "support": {
             "chrome": {
               "version_added": true
@@ -1991,6 +2025,7 @@
       "let": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/let",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-let-and-const-declarations",
           "support": {
             "chrome": [
               {
@@ -2101,6 +2136,7 @@
       "return": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/return",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-return-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -2155,6 +2191,7 @@
       "switch": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/switch",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-switch-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -2209,6 +2246,7 @@
       "throw": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/throw",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-throw-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -2264,6 +2302,7 @@
         "__compat": {
           "description": "<code>try...catch</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/try...catch",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-try-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -2428,6 +2467,7 @@
       "var": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/var",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-variable-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -2482,6 +2522,7 @@
       "while": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/while",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-while-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -2536,6 +2577,7 @@
       "with": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/with",
+          "spec_url": "https://tc39.github.io/ecma262/#sec-with-statement",
           "support": {
             "chrome": {
               "version_added": true

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -147,6 +147,25 @@
           "pattern": "^https:\/\/developer\\.mozilla\\.org\/docs\/",
           "description": "A URL that points to an MDN reference page documenting the feature. The URL should be language-agnostic."
         },
+        "spec_url": {
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "uri",
+              "pattern": "^http(s)?:\/\/[^#]+#.+"
+            },
+            {
+              "type": "array",
+              "minItems": 2,
+              "items": {
+                "type": "string",
+                "format": "uri",
+                "pattern": "^http(s)?:\/\/[^#]+#.+"
+              }
+            }
+          ],
+          "description": "An optional URL or array of URLs, each of which is for a specific part of a specification in which this feature is defined. Each URL must contain a fragment identifier."
+        },
         "support": { "$ref": "#/definitions/support_block" },
         "status": { "$ref": "#/definitions/status_block" }
       },


### PR DESCRIPTION
This change adds spec URLs in the `*.json` sources for all JavaScript features that have an `mdn_url` for an MDN article with a **Specification(s)** table — modulo the following exception:

* no spec data is added for any cases where a URL found in an MDN **Specification(s)** table has no fragment-ID part

The new field that holds the spec-URL data is named `spec_url`, and its value is either a single URL (in the case where the feature is only associated with a single specification references), or any array of URLs (in the case where the feature is associated with multiple specification references).

The change also:

* Includes an `add-specs.py` script that can be used to (re)generate all the spec data and update all the `*.json` sources. (The script works by scraping MDN **Specification(s)** tables.)

* Updates `schemas/compat-data.schema.json` to allow the additional spec data and to specify the structure it must conform to.
