### PR TITLE
Added supported safari version

### DIFF
--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -49,7 +49,7 @@
             "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "10.1"
           },
           "samsunginternet_android": {
             "version_added": null
@@ -96,10 +96,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -165,7 +165,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -227,10 +227,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -292,10 +292,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -343,10 +343,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -394,10 +394,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -47,10 +47,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": "10"
+            "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "10"
+            "version_added": "10.1"
           },
           "samsunginternet_android": {
             "version_added": null
@@ -97,10 +97,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -191,10 +191,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10-1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -254,10 +254,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -317,10 +317,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -47,10 +47,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": false
+            "version_added": "10"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "10"
           },
           "samsunginternet_android": {
             "version_added": null
@@ -97,10 +97,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -191,10 +191,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -254,10 +254,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -317,10 +317,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -191,7 +191,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "10-1"
+              "version_added": "10.1"
             },
             "safari_ios": {
               "version_added": "10.1"


### PR DESCRIPTION
Tested in browserstack with safari 9 on mac and ios (had nothing)
Tested in browserstack with safari 10 on mac and ios (had everything)

Test page i made https://plnkr.co/edit/65eFEo0D1vjdRsnCstxj?p=preview

also says here https://developer.apple.com/documentation/webkitjs/textencoder that it was added in v10.1