### PR TITLE
Compat data for WebExt tabs.highlight

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1531,13 +1531,36 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "63"
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": {
                 "version_added": false
+              }
+            }
+          },
+          "highlightInfo": {
+            "populate": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "63"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
tabs.highlight was implemented in [bug 1464862](https://bugzilla.mozilla.org/show_bug.cgi?id=1464862), and its highlightInfo.populate parameter in [bug 1489814](https://bugzilla.mozilla.org/show_bug.cgi?id=1489814)