### PR TITLE
Add more detailed support info for FormData methods in Safari

### DIFF
--- a/api/FormData.json
+++ b/api/FormData.json
@@ -191,7 +191,7 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": true
+                "version_added": "9"
               },
               "safari_ios": {
                 "version_added": null
@@ -243,7 +243,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -294,7 +294,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -345,7 +345,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -396,7 +396,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -447,7 +447,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -498,7 +498,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -549,7 +549,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -600,7 +600,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -652,7 +652,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null


### PR DESCRIPTION
As I needed the data in a project, I've tested the support of the FormData methods in several Safari versions via Browserstack. It's based on inspecting the `FormData` prototype in the developer console.
Unfortunately, I haven't found any hard evidence backing my claims.