### PR TITLE
Update CSP policy compatibility table

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -309,7 +309,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },
@@ -668,7 +668,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -1564,11 +1564,11 @@
             "support": {
               "chrome": {
                 "version_added": "59",
-                "notes": "Chrome 59 and higher skips the deprecated <code>child-src</code> directive."
+                "notes": "Chrome 59 and higher skips the <code>child-src</code> directive."
               },
               "chrome_android": {
                 "version_added": "59",
-                "notes": "Chrome 59 and higher skips the deprecated <code>child-src</code> directive."
+                "notes": "Chrome 59 and higher skips the <code>child-src</code> directive."
               },
               "edge": {
                 "version_added": false
@@ -1602,7 +1602,7 @@
               },
               "webview_android": {
                 "version_added": "59",
-                "notes": "Chrome 59 and higher skips the deprecated <code>child-src</code> directive."
+                "notes": "Chrome 59 and higher skips the <code>child-src</code> directive."
               }
             },
             "status": {


### PR DESCRIPTION
`frame-src` is deprecated, not `child-src`.

See reference: https://content-security-policy.com/
And from the spec: https://www.w3.org/TR/CSP2/#directive-frame-src

> The frame-src directive is deprecated. Authors who wish to govern nested browsing contexts SHOULD use the child-src directive instead.