### PR TITLE
Min(), max(), and clamp() CSS values

### DIFF
--- a/css/types/clamp.json
+++ b/css/types/clamp.json
@@ -1,7 +1,7 @@
 {
   "css": {
     "types": {
-      "calc": {
+      "clamp": {
         "__compat": {
           "description": "<code>&lt;clamp()&gt;</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clamp",

--- a/css/types/max.json
+++ b/css/types/max.json
@@ -1,7 +1,7 @@
 {
   "css": {
     "types": {
-      "calc": {
+      "max": {
         "__compat": {
           "description": "<code>&lt;max()&gt;</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max",

--- a/css/types/min.json
+++ b/css/types/min.json
@@ -1,7 +1,7 @@
 {
   "css": {
     "types": {
-      "calc": {
+      "min": {
         "__compat": {
           "description": "<code>&lt;min()&gt;</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min",


### PR DESCRIPTION
Added clamp(), min(), and max(), new values supported only in Safari Technology Preview  - release 67.

These are functions, like calc().

Writing the pages now.
