### PR TITLE
updating sandbox sub-items to hopefully make them easier to read

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -735,9 +735,9 @@
               "deprecated": false
             }
           },
-          "sandbox-allow-popups": {
+          "allow-popups": {
             "__compat": {
-              "description": "<code>sandbox='allow-popups'</code>",
+              "description": "<code>allow-popups</code>",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -786,9 +786,9 @@
               }
             }
           },
-          "sandbox-allow-popups-to-escape-sandbox": {
+          "allow-popups-to-escape-sandbox": {
             "__compat": {
-              "description": "<code>sandbox='allow-popups-to-escape-sandbox'</code>",
+              "description": "<code>allow-popups-to-escape-sandbox</code>",
               "support": {
                 "chrome": {
                   "version_added": "46"
@@ -837,9 +837,9 @@
               }
             }
           },
-          "sandbox-allow-modals": {
+          "allow-modals": {
             "__compat": {
-              "description": "<code>sandbox='allow-modals'</code>",
+              "description": "<code>allow-modals</code>",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -888,9 +888,9 @@
               }
             }
           },
-          "sandbox-allow-presentation": {
+          "allow-presentation": {
             "__compat": {
-              "description": "<code>sandbox='allow-presentation'</code>",
+              "description": "<code>allow-presentation</code>",
               "support": {
                 "chrome": {
                   "version_added": "53"
@@ -939,9 +939,9 @@
               }
             }
           },
-          "sandbox-allow-top-navigation-by-user-activation": {
+          "allow-top-navigation-by-user-activation": {
             "__compat": {
-              "description": "<code>sandbox='allow-top-navigation-by-user-activation'</code>",
+              "description": "<code>allow-top-navigation-by-user-activation</code>",
               "support": {
                 "chrome": {
                   "version_added": "58"

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -734,260 +734,260 @@
               "standard_track": true,
               "deprecated": false
             }
-          },
-          "allow-popups": {
-            "__compat": {
-              "description": "<code>allow-popups</code>",
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "28"
-                },
-                "firefox_android": {
-                  "version_added": "27"
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
-                "webview_android": {
-                  "version_added": null
-                }
+          }
+        },
+        "sandbox-allow-popups": {
+          "__compat": {
+            "description": "<code>sandbox=\"allow-popups\"</code>",
+            "support": {
+              "chrome": {
+                "version_added": true
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "28"
+              },
+              "firefox_android": {
+                "version_added": "27"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "allow-popups-to-escape-sandbox": {
-            "__compat": {
-              "description": "<code>allow-popups-to-escape-sandbox</code>",
-              "support": {
-                "chrome": {
-                  "version_added": "46"
-                },
-                "chrome_android": {
-                  "version_added": "46"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "49"
-                },
-                "firefox_android": {
-                  "version_added": "49"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "32"
-                },
-                "opera_android": {
-                  "version_added": "32"
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                },
-                "samsunginternet_android": {
-                  "version_added": "5.0"
-                },
-                "webview_android": {
-                  "version_added": "46"
-                }
+          }
+        },
+        "sandbox-allow-popups-to-escape-sandbox": {
+          "__compat": {
+            "description": "<code>sandbox=\"allow-popups-to-escape-sandbox\"</code>",
+            "support": {
+              "chrome": {
+                "version_added": "46"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome_android": {
+                "version_added": "46"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": {
+                "version_added": "49"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "32"
+              },
+              "opera_android": {
+                "version_added": "32"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "allow-modals": {
-            "__compat": {
-              "description": "<code>allow-modals</code>",
-              "support": {
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "49"
-                },
-                "firefox_android": {
-                  "version_added": "49"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
-                "webview_android": {
-                  "version_added": null
-                }
+          }
+        },
+        "sandbox-allow-modals": {
+          "__compat": {
+            "description": "<code>sandbox=\"allow-modals\"</code>",
+            "support": {
+              "chrome": {
+                "version_added": null
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": {
+                "version_added": "49"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "allow-presentation": {
-            "__compat": {
-              "description": "<code>allow-presentation</code>",
-              "support": {
-                "chrome": {
-                  "version_added": "53"
-                },
-                "chrome_android": {
-                  "version_added": "53"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "50"
-                },
-                "firefox_android": {
-                  "version_added": "50"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "40"
-                },
-                "opera_android": {
-                  "version_added": "40"
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                },
-                "samsunginternet_android": {
-                  "version_added": "6.0"
-                },
-                "webview_android": {
-                  "version_added": false
-                }
+          }
+        },
+        "sandbox-allow-presentation": {
+          "__compat": {
+            "description": "<code>sandbox=\"allow-presentation\"</code>",
+            "support": {
+              "chrome": {
+                "version_added": "53"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome_android": {
+                "version_added": "53"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "50"
+              },
+              "firefox_android": {
+                "version_added": "50"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "40"
+              },
+              "opera_android": {
+                "version_added": "40"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": false
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "allow-top-navigation-by-user-activation": {
-            "__compat": {
-              "description": "<code>allow-top-navigation-by-user-activation</code>",
-              "support": {
-                "chrome": {
-                  "version_added": "58"
-                },
-                "chrome_android": {
-                  "version_added": "58"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "45"
-                },
-                "opera_android": {
-                  "version_added": "45"
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                },
-                "samsunginternet_android": {
-                  "version_added": "7.0"
-                },
-                "webview_android": {
-                  "version_added": "58"
-                }
+          }
+        },
+        "sandbox-allow-top-navigation-by-user-activation": {
+          "__compat": {
+            "description": "<code>sandbox=\"allow-top-navigation-by-user-activation\"</code>",
+            "support": {
+              "chrome": {
+                "version_added": "58"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome_android": {
+                "version_added": "58"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "45"
+              },
+              "opera_android": {
+                "version_added": "45"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "7.0"
+              },
+              "webview_android": {
+                "version_added": "58"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },


### PR DESCRIPTION
If you look at the [`<iframe>` compat table](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#Browser_compatibility), you'll see that the sandbox token support info is duplicative and hard to read. I am hoping that this PR will improve things a little.