### PR TITLE
Update Firefox data

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -10,27 +10,27 @@
         },
         "1.5": {
           "release_date": "2005-11-29",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/1.5",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/1.5",
           "status": "retired"
         },
         "2": {
           "release_date": "2006-10-24",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/2",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/2",
           "status": "retired"
         },
         "3": {
           "release_date": "2008-06-17",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/3",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/3",
           "status": "retired"
         },
         "3.5": {
           "release_date": "2009-06-30",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/3.5",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/3.5",
           "status": "retired"
         },
         "3.6": {
           "release_date": "2010-01-21",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/3.6",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/3.6",
           "status": "retired"
         },
         "3.6.9": {
@@ -40,237 +40,237 @@
         },
         "4": {
           "release_date": "2011-03-22",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/4",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/4",
           "status": "retired"
         },
         "5": {
           "release_date": "2011-06-21",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/5",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/5",
           "status": "retired"
         },
         "6": {
           "release_date": "2011-08-16",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/6",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/6",
           "status": "retired"
         },
         "7": {
           "release_date": "2011-09-27",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/7",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/7",
           "status": "retired"
         },
         "8": {
           "release_date": "2011-11-08",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/8",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/8",
           "status": "retired"
         },
         "9": {
           "release_date": "2011-12-20",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/9",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/9",
           "status": "retired"
         },
         "10": {
           "release_date": "2012-01-31",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/10",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/10",
           "status": "retired"
         },
         "11": {
           "release_date": "2012-03-13",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/11",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/11",
           "status": "retired"
         },
         "12": {
           "release_date": "2012-04-24",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/12",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/12",
           "status": "retired"
         },
         "13": {
           "release_date": "2012-06-05",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/13",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/13",
           "status": "retired"
         },
         "14": {
           "release_date": "2012-07-17",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/14",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/14",
           "status": "retired"
         },
         "15": {
           "release_date": "2012-08-28",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/15",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/15",
           "status": "retired"
         },
         "16": {
           "release_date": "2012-10-09",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/16",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/16",
           "status": "retired"
         },
         "17": {
           "release_date": "2012-11-20",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/17",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/17",
           "status": "retired"
         },
         "18": {
           "release_date": "2013-01-08",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/18",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/18",
           "status": "retired"
         },
         "19": {
           "release_date": "2013-02-19",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/19",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/19",
           "status": "retired"
         },
         "20": {
           "release_date": "2013-04-02",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/20",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/20",
           "status": "retired"
         },
         "21": {
           "release_date": "2013-05-14",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/21",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/21",
           "status": "retired"
         },
         "22": {
           "release_date": "2013-06-25",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/22",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/22",
           "status": "retired"
         },
         "23": {
           "release_date": "2013-08-06",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/23",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/23",
           "status": "retired"
         },
         "24": {
           "release_date": "2013-09-17",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/24",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/24",
           "status": "retired"
         },
         "25": {
           "release_date": "2013-10-29",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/25",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/25",
           "status": "retired"
         },
         "26": {
           "release_date": "2013-12-10",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/26",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/26",
           "status": "retired"
         },
         "27": {
           "release_date": "2014-02-04",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/27",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/27",
           "status": "retired"
         },
         "28": {
           "release_date": "2014-03-18",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/28",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/28",
           "status": "retired"
         },
         "29": {
           "release_date": "2014-04-29",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/29",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/29",
           "status": "retired"
         },
         "30": {
           "release_date": "2014-06-10",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/30",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/30",
           "status": "retired"
         },
         "31": {
           "release_date": "2014-07-22",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/31",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/31",
           "status": "retired"
         },
         "32": {
           "release_date": "2014-09-02",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/32",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/32",
           "status": "retired"
         },
         "33": {
           "release_date": "2014-10-14",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/33",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/33",
           "status": "retired"
         },
         "34": {
           "release_date": "2014-12-01",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/34",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/34",
           "status": "retired"
         },
         "35": {
           "release_date": "2015-01-13",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/35",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/35",
           "status": "retired"
         },
         "36": {
           "release_date": "2015-02-24",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/36",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/36",
           "status": "retired"
         },
         "37": {
           "release_date": "2015-03-31",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/37",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/37",
           "status": "retired"
         },
         "38": {
           "release_date": "2015-05-12",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/38",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/38",
           "status": "retired"
         },
         "39": {
           "release_date": "2015-07-02",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/39",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/39",
           "status": "retired"
         },
         "40": {
           "release_date": "2015-08-11",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/40",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/40",
           "status": "retired"
         },
         "41": {
           "release_date": "2015-09-22",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/41",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/41",
           "status": "retired"
         },
         "42": {
           "release_date": "2015-11-03",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/42",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/42",
           "status": "retired"
         },
         "43": {
           "release_date": "2015-12-15",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/43",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/43",
           "status": "retired"
         },
         "44": {
           "release_date": "2016-01-26",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/44",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/44",
           "status": "retired"
         },
         "45": {
           "release_date": "2016-03-08",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/45",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/45",
           "status": "retired"
         },
         "46": {
           "release_date": "2016-04-26",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/46",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/46",
           "status": "retired"
         },
         "47": {
           "release_date": "2016-06-07",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/47",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/47",
           "status": "retired"
         },
         "48": {
           "release_date": "2016-08-02",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/48",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/48",
           "status": "retired"
         },
         "49": {
           "release_date": "2016-09-20",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/49",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/49",
           "status": "retired"
         },
         "50": {
           "release_date": "2016-11-15",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/50",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/50",
           "status": "retired"
         },
         "50.0.1": {
@@ -279,73 +279,108 @@
         },
         "51": {
           "release_date": "2017-01-24",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/51",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/51",
           "status": "retired"
         },
         "52": {
           "release_date": "2017-03-07",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/52",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/52",
           "status": "retired"
         },
         "53": {
           "release_date": "2017-04-19",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/53",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/53",
           "status": "retired"
         },
         "54": {
           "release_date": "2017-06-13",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/54",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/54",
           "status": "retired"
         },
         "55": {
           "release_date": "2017-08-08",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/55",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/55",
           "status": "retired"
         },
         "56": {
           "release_date": "2017-09-28",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/56",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/56",
           "status": "retired"
         },
         "57": {
           "release_date": "2017-11-14",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/57",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/57",
           "status": "retired"
         },
         "58": {
           "release_date": "2018-01-23",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/58",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/58",
           "status": "retired"
         },
         "59": {
           "release_date": "2018-03-13",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/59",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/59",
           "status": "retired"
         },
         "60": {
           "release_date": "2018-05-09",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/60",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/60",
           "status": "esr"
         },
         "61": {
           "release_date": "2018-06-26",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/61",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/61",
           "status": "retired"
         },
         "62": {
           "release_date": "2018-09-05",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/62",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/62",
           "status": "current"
         },
         "63": {
           "release_date": "2018-10-23",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/63",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/63",
           "status": "beta"
         },
         "64": {
-          "release_date": "2018-11-27",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/64",
+          "release_date": "2018-12-11",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/64",
           "status": "nightly"
+        },
+        "65": {
+          "release_date": "2019-01-29",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/65",
+          "status": "planned"
+        },
+        "66": {
+          "release_date": "2019-03-19",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/66",
+          "status": "planned"
+        },
+        "67": {
+          "release_date": "2019-05-14",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/67",
+          "status": "planned"
+        },
+        "68": {
+          "release_date": "2019-07-09",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/68",
+          "status": "planned"
+        },
+        "69": {
+          "release_date": "2019-09-03",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/69",
+          "status": "planned"
+        },
+        "70": {
+          "release_date": "2019-10-22",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/70",
+          "status": "planned"
+        },
+        "71": {
+          "release_date": "2019-12-10",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/70",
+          "status": "planned"
         }
       }
     }

--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -379,7 +379,7 @@
         },
         "71": {
           "release_date": "2019-12-10",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/70",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/71",
           "status": "planned"
         }
       }

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -325,7 +325,7 @@
         },
         "71": {
           "release_date": "2019-12-10",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/70",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/71",
           "status": "planned"
         }
       }

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -5,293 +5,328 @@
       "releases": {
         "4": {
           "release_date": "2011-03-29",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/4",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/4",
           "status": "retired"
         },
         "5": {
           "release_date": "2011-06-21",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/5",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/5",
           "status": "retired"
         },
         "6": {
           "release_date": "2011-08-16",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/6",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/6",
           "status": "retired"
         },
         "7": {
           "release_date": "2011-09-27",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/7",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/7",
           "status": "retired"
         },
         "8": {
           "release_date": "2011-11-08",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/8",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/8",
           "status": "retired"
         },
         "9": {
           "release_date": "2011-12-21",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/9",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/9",
           "status": "retired"
         },
         "10": {
           "release_date": "2012-01-31",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/10",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/10",
           "status": "retired"
         },
         "14": {
           "release_date": "2012-06-26",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/14",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/14",
           "status": "retired"
         },
         "15": {
           "release_date": "2012-08-28",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/15",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/15",
           "status": "retired"
         },
         "16": {
           "release_date": "2012-10-09",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/16",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/16",
           "status": "retired"
         },
         "17": {
           "release_date": "2012-11-20",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/17",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/17",
           "status": "retired"
         },
         "18": {
           "release_date": "2013-01-08",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/18",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/18",
           "status": "retired"
         },
         "19": {
           "release_date": "2013-02-19",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/19",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/19",
           "status": "retired"
         },
         "20": {
           "release_date": "2013-04-02",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/20",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/20",
           "status": "retired"
         },
         "21": {
           "release_date": "2013-05-14",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/21",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/21",
           "status": "retired"
         },
         "22": {
           "release_date": "2013-06-25",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/22",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/22",
           "status": "retired"
         },
         "23": {
           "release_date": "2013-08-06",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/23",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/23",
           "status": "retired"
         },
         "24": {
           "release_date": "2013-09-17",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/24",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/24",
           "status": "retired"
         },
         "25": {
           "release_date": "2013-10-29",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/25",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/25",
           "status": "retired"
         },
         "26": {
           "release_date": "2013-12-10",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/26",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/26",
           "status": "retired"
         },
         "27": {
           "release_date": "2014-02-04",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/27",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/27",
           "status": "retired"
         },
         "28": {
           "release_date": "2014-03-18",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/28",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/28",
           "status": "retired"
         },
         "29": {
           "release_date": "2014-04-29",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/29",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/29",
           "status": "retired"
         },
         "30": {
           "release_date": "2014-06-10",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/30",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/30",
           "status": "retired"
         },
         "31": {
           "release_date": "2014-07-22",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/31",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/31",
           "status": "retired"
         },
         "32": {
           "release_date": "2014-09-02",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/32",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/32",
           "status": "retired"
         },
         "33": {
           "release_date": "2014-10-14",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/33",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/33",
           "status": "retired"
         },
         "34": {
           "release_date": "2014-12-01",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/34",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/34",
           "status": "retired"
         },
         "35": {
           "release_date": "2015-01-13",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/35",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/35",
           "status": "retired"
         },
         "36": {
           "release_date": "2015-02-27",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/36",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/36",
           "status": "retired"
         },
         "37": {
           "release_date": "2015-03-31",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/37",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/37",
           "status": "retired"
         },
         "38": {
           "release_date": "2015-05-12",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/38",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/38",
           "status": "retired"
         },
         "39": {
           "release_date": "2015-07-02",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/39",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/39",
           "status": "retired"
         },
         "40": {
           "release_date": "2015-08-11",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/40",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/40",
           "status": "retired"
         },
         "41": {
           "release_date": "2015-09-22",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/41",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/41",
           "status": "retired"
         },
         "42": {
           "release_date": "2015-11-03",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/42",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/42",
           "status": "retired"
         },
         "43": {
           "release_date": "2015-12-15",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/43",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/43",
           "status": "retired"
         },
         "44": {
           "release_date": "2016-01-26",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/44",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/44",
           "status": "retired"
         },
         "45": {
           "release_date": "2016-03-08",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/45",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/45",
           "status": "retired"
         },
         "46": {
           "release_date": "2016-04-26",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/46",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/46",
           "status": "retired"
         },
         "47": {
           "release_date": "2016-06-07",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/47",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/47",
           "status": "retired"
         },
         "48": {
           "release_date": "2016-08-02",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/48",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/48",
           "status": "retired"
         },
         "49": {
           "release_date": "2016-09-20",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/49",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/49",
           "status": "retired"
         },
         "50": {
           "release_date": "2016-11-15",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/50",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/50",
           "status": "retired"
         },
         "51": {
           "release_date": "2017-01-24",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/51",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/51",
           "status": "retired"
         },
         "52": {
           "release_date": "2017-03-07",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/52",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/52",
           "status": "retired"
         },
         "53": {
           "release_date": "2017-04-19",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/53",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/53",
           "status": "retired"
         },
         "54": {
           "release_date": "2017-06-13",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/54",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/54",
           "status": "retired"
         },
         "55": {
           "release_date": "2017-08-08",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/55",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/55",
           "status": "retired"
         },
         "56": {
           "release_date": "2017-09-28",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/56",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/56",
           "status": "retired"
         },
         "57": {
           "release_date": "2017-11-28",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/57",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/57",
           "status": "retired"
         },
         "58": {
           "release_date": "2018-01-22",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/58",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/58",
           "status": "retired"
         },
         "59": {
           "release_date": "2018-03-13",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/59",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/59",
           "status": "retired"
         },
         "60": {
           "release_date": "2018-05-09",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/60",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/60",
           "status": "esr"
         },
         "61": {
           "release_date": "2018-06-26",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/61",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/61",
           "status": "retired"
         },
         "62": {
           "release_date": "2018-09-05",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/62",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/62",
           "status": "current"
         },
         "63": {
           "release_date": "2018-10-23",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/63",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/63",
           "status": "beta"
         },
         "64": {
-          "release_date": "2018-11-27",
-          "release_notes": "https://developer.mozilla.org/Firefox/Releases/64",
+          "release_date": "2018-12-11",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/64",
           "status": "nightly"
+        },
+        "65": {
+          "release_date": "2019-01-29",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/65",
+          "status": "planned"
+        },
+        "66": {
+          "release_date": "2019-03-19",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/66",
+          "status": "planned"
+        },
+        "67": {
+          "release_date": "2019-05-14",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/67",
+          "status": "planned"
+        },
+        "68": {
+          "release_date": "2019-07-09",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/68",
+          "status": "planned"
+        },
+        "69": {
+          "release_date": "2019-09-03",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/69",
+          "status": "planned"
+        },
+        "70": {
+          "release_date": "2019-10-22",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/70",
+          "status": "planned"
+        },
+        "71": {
+          "release_date": "2019-12-10",
+          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/70",
+          "status": "planned"
         }
       }
     }


### PR DESCRIPTION
This does 3 things:

- Add Firefox up to 71 according to https://wiki.mozilla.org/Release_Management/Calendar
- Correct the date for Firefox 64.
- Change all URLs to the non-zone URLs as zones are gone :)