### PR TITLE
IE11: inset must be last in box-shadow

### DIFF
--- a/css/properties/box-shadow.json
+++ b/css/properties/box-shadow.json
@@ -218,7 +218,7 @@
               },
               "ie": {
                 "version_added": "9",
-                "partial_implementation": true
+                "partial_implementation": true,
                 "notes": [
                   "To use <code>box-shadow</code> in Internet Explorer 9 or later, you must set <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> to <code>separate</code>.",
                   "<code>inset</code> must be the last keyword in the declaration."

--- a/css/properties/box-shadow.json
+++ b/css/properties/box-shadow.json
@@ -218,7 +218,11 @@
               },
               "ie": {
                 "version_added": "9",
-                "notes": "To use <code>box-shadow</code> in Internet Explorer 9 or later, you must set <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> to <code>separate</code>. Also, <code>inset</code must be at the end of the specification. Otherwise the full property will be ignored."
+                "partial_implementation": true
+                "notes": [
+                  "To use <code>box-shadow</code> in Internet Explorer 9 or later, you must set <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> to <code>separate</code>.",
+                  "<code>inset</code> must be the last keyword in the declaration."
+                ]
               },
               "opera": {
                 "version_added": "10.5"

--- a/css/properties/box-shadow.json
+++ b/css/properties/box-shadow.json
@@ -218,7 +218,7 @@
               },
               "ie": {
                 "version_added": "9",
-                "notes": "To use <code>box-shadow</code> in Internet Explorer 9 or later, you must set <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> to <code>separate</code>."
+                "notes": "To use <code>box-shadow</code> in Internet Explorer 9 or later, you must set <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> to <code>separate</code>. Also, <code>inset</code must be at the end of the specification. Otherwise the full property will be ignored."
               },
               "opera": {
                 "version_added": "10.5"


### PR DESCRIPTION
When specifying the box-shadow property, the optional `inset` specification must be at the end. Otherwise, Internet Explorer will ignore the full property. I have only tested this on IE11, but I suspect earlier versions have the same problem. I have not found any documentation or questions about this quirk online. 

Aside: I have put the note in the same string as the original note. Is this the right thing to do? Or should it be converted to an array of two strings?