### PR TITLE
Update chrome desktop browser data

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -346,12 +346,17 @@
         "69": {
           "release_date": "2018-09-04",
           "release_notes": "https://chromereleases.googleblog.com/2018/09/stable-channel-update-for-desktop.html",
-          "status": "current"
+          "status": "retired"
         },
         "70": {
-          "status": "beta"
+          "release_date": "2018-10-16",
+          "release_notes": "https://chromereleases.googleblog.com/2018/10/stable-channel-update-for-desktop.html",
+          "status": "current"
         },
         "71": {
+          "status": "beta"
+        },
+        "72": {
           "status": "nightly"
         }
       }


### PR DESCRIPTION
Chrome v70 is now available
https://chromereleases.googleblog.com/2018/10/stable-channel-update-for-desktop.html