### PR TITLE
Basic JS import support in Android WebView

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1772,7 +1772,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {


### PR DESCRIPTION
JS imports are supported since version 61 according to this page:

https://www.chromestatus.com/feature/5365692190687232