### PR TITLE
Update compat data for PromiseRejectionEvent

### DIFF
--- a/api/PromiseRejectionEvent.json
+++ b/api/PromiseRejectionEvent.json
@@ -8,7 +8,7 @@
             "version_added": "49"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "49"
           },
           "edge": {
             "version_added": null
@@ -42,22 +42,22 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "36"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "36"
           },
           "safari": {
-            "version_added": false
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": true
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "49"
           }
         },
         "status": {
@@ -75,7 +75,7 @@
               "version_added": "49"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -107,22 +107,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "49"
             }
           },
           "status": {
@@ -140,7 +140,7 @@
               "version_added": "49"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -172,22 +172,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "49"
             }
           },
           "status": {
@@ -205,7 +205,7 @@
               "version_added": "49"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -237,22 +237,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "49"
             }
           },
           "status": {

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -543,7 +543,7 @@
               "version_added": "49"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -552,30 +552,49 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to about:config and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              "version_added": "55",
+              "partial_implementation": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.promise_rejection_events.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "Firefox doesn't yet send the <a href='https://developer.mozilla.org/docs/Web/Events/unhandledrejection'>unhandledrejection</a> or understand <a href='https://developer.mozilla.org/docs/Web/Events/rejectionhandled'>rejectionhandled<a> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to about:config and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              "version_added": "55",
+              "partial_implementation": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.promise_rejection_events.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "Firefox doesn't yet send the <a href='https://developer.mozilla.org/docs/Web/Events/unhandledrejection'>unhandledrejection</a> or understand <a href='https://developer.mozilla.org/docs/Web/Events/rejectionhandled'>rejectionhandled<a> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "36"
             },
             "opera_android": {
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
+            },
+            "samsunginternet_android": {
+              "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "49"
             }
           },
           "status": {
@@ -641,39 +660,58 @@
               "version_added": "49"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "edge": {
-              "version_added": true
+              "version_added": null
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": null
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to about:config and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              "version_added": "55",
+              "partial_implementation": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.promise_rejection_events.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "Firefox doesn't yet send the <a href='https://developer.mozilla.org/docs/Web/Events/unhandledrejection'>unhandledrejection</a> or understand <a href='https://developer.mozilla.org/docs/Web/Events/rejectionhandled'>rejectionhandled<a> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to about:config and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              "version_added": "55",
+              "partial_implementation": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.promise_rejection_events.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "Firefox doesn't yet send the <a href='https://developer.mozilla.org/docs/Web/Events/unhandledrejection'>unhandledrejection</a> or understand <a href='https://developer.mozilla.org/docs/Web/Events/rejectionhandled'>rejectionhandled<a> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "36"
             },
             "opera_android": {
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
+            },
+            "samsunginternet_android": {
+              "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "49"
             }
           },
           "status": {


### PR DESCRIPTION
Follow-up for #2100

Currently, the MDN docs indicate that `PromiseRejectionEvent` and the associated `window.onunhandledrejection` and `window.onrejectionhandled` properties are Chrome-only. I believe the CanIUse data for these events are correct: https://caniuse.com/#feat=unhandledrejection

Also, I believe this same data should appear on https://developer.mozilla.org/en-US/docs/Web/Events/unhandledrejection#Browser_compatibility.