### PR TITLE
Update KeyboardEvent.getModifierState support

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1007,19 +1007,19 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": false
+              "version_added": "17"
             },
             "opera_android": {
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
I saw that KeyboardEvent.getModifierState wasn't supported in Safari, 
which didn't seem right. I've updated the version_added field for a few 
browsers to be in line with the CanIUse database:

https://caniuse.com/#feat=keyboardevent-getmodifierstate