### PR TITLE
Edge v44 supports 'finally'

### DIFF
--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -287,7 +287,7 @@
                 "version_added": "63"
               },
               "edge": {
-                "version_added": "44"
+                "version_added": "18"
               },
               "edge_mobile": {
                 "version_added": false

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -287,7 +287,7 @@
                 "version_added": "63"
               },
               "edge": {
-                "version_added": false
+                "version_added": "44"
               },
               "edge_mobile": {
                 "version_added": false


### PR DESCRIPTION
I just tried it out on Edge v44.17763:

```
<< new Promise((res, rej) => res(2)).then(console.debug).finally(() => console.debug('finalized'))
>> [object Promise]: {}
>> 2
>> finalized
```

I haven't tested it on edge mobile. Also, if anyone could test it on earlier versions of Edge to figure out *when* support was added, it'd be appreciated.