### PR TITLE
transferControlToOffscreen is available in chrome 69 without flag

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -908,10 +908,10 @@
               "version_added": false
             },
             "chrome": {
-              "version_added": false
+              "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false


### PR DESCRIPTION
transferControlToOffscreen is available in chrome 69 without flag