### PR TITLE
Update firefox compat data 

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -335,22 +335,22 @@
         "62": {
           "release_date": "2018-09-05",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/62",
-          "status": "current"
+          "status": "retired"
         },
         "63": {
           "release_date": "2018-10-23",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/63",
-          "status": "beta"
+          "status": "current"
         },
         "64": {
           "release_date": "2018-12-11",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/64",
-          "status": "nightly"
+          "status": "beta"
         },
         "65": {
           "release_date": "2019-01-29",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/65",
-          "status": "planned"
+          "status": "nightly"
         },
         "66": {
           "release_date": "2019-03-19",

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -281,22 +281,22 @@
         "62": {
           "release_date": "2018-09-05",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/62",
-          "status": "current"
+          "status": "retired"
         },
         "63": {
           "release_date": "2018-10-23",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/63",
-          "status": "beta"
+          "status": "current"
         },
         "64": {
           "release_date": "2018-12-11",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/64",
-          "status": "nightly"
+          "status": "beta"
         },
         "65": {
           "release_date": "2019-01-29",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/65",
-          "status": "planned"
+          "status": "nightly"
         },
         "66": {
           "release_date": "2019-03-19",


### PR DESCRIPTION
Firefox 63 was released yesterday

https://hacks.mozilla.org/2018/10/firefox-63-tricks-and-treats/

This updates the compatibility data for both android and desktop.