### PR TITLE
Add options parameter to Element.requestFullscreen()

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3518,9 +3518,9 @@
             }
           }
         },
-        "supports_options": {
+        "options_parameter": {
           "__compat": {
-            "description": "Supports the <code>options</code> parameter",
+            "description": "<code>options</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "71"


### PR DESCRIPTION
This adds information about the options parameter to
requestFullscreen's entry. Supported on Chrome 71;
Firefox doesn't support it yet.. Other browsers are
unknown.