### PR TITLE
Corrected compat data for api.Element.animate based on tests 

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -141,7 +141,7 @@
               "version_added": "23"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": null


### PR DESCRIPTION
Tested on Safari 12.0 (13606.2.11) -> Not a function