### PR TITLE
Fix alternative names for WebGL in Firefox

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -334,11 +334,11 @@
               },
               "firefox": [
                 {
-                  "version_added": "24",
-                  "alternative_name": "experimental-webgl"
+                  "version_added": "24"
                 },
                 {
-                  "version_added": "3.6"
+                  "version_added": "3.6",
+                  "alternative_name": "experimental-webgl"
                 }
               ],
               "firefox_android": {
@@ -405,7 +405,7 @@
                 },
                 {
                   "version_added": "25",
-                  "alternative_name": "experimental-webgl"
+                  "alternative_name": "experimental-webgl2"
                 }
               ],
               "firefox_android": {


### PR DESCRIPTION
The actual data is obviously wrong, but you can still check out here: https://caniuse.com/#search=web%20gl

I just did it for HTMLCanvasElement.getContext(), but there may be more fixes to do.