### PR TITLE
Update Selection API compat data for Chrome and Opera

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -54,7 +54,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Selection/addRange",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -102,7 +102,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Selection/anchorNode",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -150,7 +150,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Selection/anchorOffset",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -777,7 +777,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Selection/isCollapsed",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -1258,7 +1258,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Selection/toString",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -54,10 +54,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Selection/addRange",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -75,10 +75,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -87,7 +87,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -102,10 +102,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Selection/anchorNode",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -123,10 +123,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -135,7 +135,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -150,10 +150,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Selection/anchorOffset",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -171,10 +171,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -183,7 +183,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -231,7 +231,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -267,10 +267,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -279,7 +279,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -315,10 +315,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -327,7 +327,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -377,7 +377,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -424,7 +424,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": null
+                "version_added": true
               }
             },
             "status": {
@@ -657,7 +657,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "5.1"
@@ -666,7 +666,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -702,10 +702,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -714,7 +714,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -750,10 +750,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -762,7 +762,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -777,10 +777,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Selection/isCollapsed",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -798,10 +798,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -810,7 +810,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -905,7 +905,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": null
+                "version_added": true
               }
             },
             "status": {
@@ -953,7 +953,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": null
+                "version_added": true
               }
             },
             "status": {
@@ -993,7 +993,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -1002,7 +1002,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -1098,7 +1098,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -1146,7 +1146,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -1258,10 +1258,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Selection/toString",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -1279,10 +1279,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -1291,7 +1291,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
Selection API should be fully supported at least since Chrome 58/Opera 45.