### PR TITLE
Updates for Fullscreen API changes

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3310,7 +3310,7 @@
             ]
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -3319,15 +3319,48 @@
           "__compat": {
             "description": "Returns a <code>Promise</code>",
             "support": {
+              "chrome": {
+                "version_added": "71"
+              },
+              "chrome_android": {
+                "version_added": "71"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
               "firefox": {
                 "version_added": "64"
               },
               "firefox_android": {
                 "version_added": "64"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": "71"
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/Element.json
+++ b/api/Element.json
@@ -2741,6 +2741,102 @@
           }
         }
       },
+      "onfullscreenchange": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/onfullscreenchange",
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "64"
+            },
+            "firefox_android": {
+              "version_added": "64"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "57"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onfullscreenerror": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/onfullscreenerror",
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "64"
+            },
+            "firefox_android": {
+              "version_added": "64"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "57"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "ongotpointercapture": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ongotpointercapture",

--- a/api/FullscreenOptions.json
+++ b/api/FullscreenOptions.json
@@ -1,0 +1,106 @@
+{
+  "api": {
+    "FullscreenOptions": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/FullscreenOptions",
+        "support": {
+          "chrome": {
+            "version_added": "71"
+          },
+          "chrome_android": {
+            "version_added": "71"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "64"
+          },
+          "firefox_android": {
+            "version_added": "64"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          },
+          "samsunginternet_android": {
+            "version_added": null
+          },
+          "webview_android": {
+            "version_added": "71"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "navigationUI": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FullscreenOptions/navigationUI",
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "71"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "64"
+            },
+            "firefox_android": {
+              "version_added": "64"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "71"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This includes updates for the Fullscreen API, including:

* Adding missing data for "returns_a_promise" on `Document.exitFullScreen()`
* Changing some incorrect "experimental" values to false
* Adding missing `onfullscreenchange` and `onfullscreenerror` to `Element.json`
* Adding new `FullscreenOptions` dictionary

The version number updates were all done previously by
@ExE-Boss. I've submitted a previous PR to add the
options parameter to `Document.requestFullScreen()`.
Together all of this work completes updates for the
Fullscreen API at this time.