### PR TITLE
Add the inputmode global HTML attribute

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -836,6 +836,54 @@
           }
         }
       },
+      "inputmode": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/inputmode",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "is": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/is",


### PR DESCRIPTION
Adds inputmode to the global attributes list. Currently
supported only by Chrome that I can find. This comes from
looking at Chrome source, caniuse data, and this Chrome
bug:

https://bugs.chromium.org/p/chromium/issues/detail?id=244688