### PR TITLE
Note Safari 10.1.2 support for document.createComment

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -1272,7 +1272,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "10.1.2",
+              "version_added": "7",
               "notes": "Possibly supported earlier; 10.1.2 was the earliest version available for testing at this time."
             },
             "safari_ios": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -1272,8 +1272,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "7",
-              "notes": "Possibly supported earlier; 10.1.2 was the earliest version available for testing at this time."
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": null

--- a/api/Document.json
+++ b/api/Document.json
@@ -1272,7 +1272,8 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1.2",
+              "notes": "Possibly supported earlier; 10.1.2 was the earliest version available for testing at this time."
             },
             "safari_ios": {
               "version_added": null


### PR DESCRIPTION
This changes Safari's support for `document.createComment` from "unknown" to a value that indicates it is presently supported.

I don't know how far back this method is supported; 10.1.2 is the earliest version of the browser I have access to for testing purposes. This has been added as a "note" in the compatibility table.