### PR TITLE
Update browser compatibility for rest_in_objects

### DIFF
--- a/javascript/operators/destructuring.json
+++ b/javascript/operators/destructuring.json
@@ -203,7 +203,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "8.3"
+                "version_added": "8.3.0"
               },
               "opera": {
                 "version_added": true
@@ -215,7 +215,7 @@
                 "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": "11.3"
+                "version_added": "11.1"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/javascript/operators/destructuring.json
+++ b/javascript/operators/destructuring.json
@@ -203,7 +203,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "8.3"
               },
               "opera": {
                 "version_added": true
@@ -212,10 +212,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": false
+                "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/javascript/operators/object_initializer.json
+++ b/javascript/operators/object_initializer.json
@@ -243,7 +243,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.3.0"
               },
               "opera": {
                 "version_added": null
@@ -252,10 +252,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": false
+                "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11.1"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
Compare https://kangax.github.io/compat-table/es2016plus/#test-object_rest/spread_properties

The rest/spread proposal has also achieved Stage 4, which is mentioned in the Specifications table on mdn but not in the section that introduces it: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Rest_in_Object_Destructuring