### PR TITLE
Updates CSSStyleSheet.insertRule compatability for IE and FF

### DIFF
--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -258,13 +258,13 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": "55"
               },
               "firefox_android": {
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "47"


### PR DESCRIPTION
Updates the compatibility of optional index parameter for the insertRule method. On FF, this was optional starting in FF 55 and IE never added it.