### PR TITLE
FileSystem: Edge Note: Fix tag escaping

### DIFF
--- a/api/FileSystem.json
+++ b/api/FileSystem.json
@@ -14,7 +14,7 @@
           "edge": {
             "version_added": true,
             "prefix": "WebKit",
-            "notes": "Edge only supports this API in drag-and-drop scenarios using the the <code><a href='https://developer.mozilla.org/docs/Web/API/DataTransferItem/webkitGetAsEntry'>DataTransferItem.webkitGetAsEntry()</a></code> method. It's not available for use in file or folder picker panels (such as when you use an <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/input'><input></a></code> element with the <code><a href='https://developer.mozilla.org/docs/Web/API/HTMLInputElement/webkitdirectory'>HTMLInputElement.webkitdirectory</a></code> attribute."
+            "notes": "Edge only supports this API in drag-and-drop scenarios using the the <code><a href='https://developer.mozilla.org/docs/Web/API/DataTransferItem/webkitGetAsEntry'>DataTransferItem.webkitGetAsEntry()</a></code> method. It's not available for use in file or folder picker panels (such as when you use an <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/input'>&lt;input&gt;</a></code> element with the <code><a href='https://developer.mozilla.org/docs/Web/API/HTMLInputElement/webkitdirectory'>HTMLInputElement.webkitdirectory</a></code> attribute."
           },
           "edge_mobile": {
             "version_added": null


### PR DESCRIPTION
Fix the `<input>` tag not to be rendered as actual input box in the compatibility table:
![image](https://user-images.githubusercontent.com/1079715/47855735-b4500000-de28-11e8-9f48-17648b0f90c3.png)
<https://developer.mozilla.org/en-US/docs/Web/API/FileSystem#Browser_compatibility>