### PR TITLE
Bug 1496617: Unprefix `image-rendering: crisp-edges`

### DIFF
--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -53,7 +53,6 @@
         },
         "crisp-edges": {
           "__compat": {
-            "description": "<code>crisp-edges</code>",
             "support": {
               "chrome": {
                 "alternative_name": "-webkit-optimize-contrast",
@@ -68,10 +67,15 @@
               "edge_mobile": {
                 "version_added": null
               },
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "3.6"
-              },
+              "firefox": [
+                {
+                  "version_added": "65"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "3.6"
+                }
+              ],
               "firefox_android": {
                 "version_added": null
               },
@@ -108,7 +112,6 @@
         },
         "pixelated": {
           "__compat": {
-            "description": "<code>pixelated</code>",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -120,13 +123,13 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -159,7 +162,6 @@
         },
         "optimizeQuality": {
           "__compat": {
-            "description": "<code>optimizeQuality</code>",
             "support": {
               "chrome": {
                 "version_added": false
@@ -210,7 +212,6 @@
         },
         "optimizeSpeed": {
           "__compat": {
-            "description": "<code>optimizeSpeed</code>",
             "support": {
               "chrome": {
                 "version_added": false

--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -21,7 +21,7 @@
               "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -76,9 +76,15 @@
                   "version_added": "3.6"
                 }
               ],
-              "firefox_android": {
-                "version_added": null
-              },
+              "firefox_android": [
+                {
+                  "version_added": "65"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -179,7 +185,7 @@
                 "version_added": "3.6"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -229,7 +235,7 @@
                 "version_added": "3.6"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
See [bug&nbsp;1496617](https://bugzilla.mozilla.org/show_bug.cgi?id=1496617 "FIXED: Unprefix `image-rendering: crisp-edges`") for details.

---

review?(@Elchi3, @ddbeck)