### PR TITLE
Add `object-fit` and `object-position` Safari Support Details

### DIFF
--- a/css/properties/object-fit.json
+++ b/css/properties/object-fit.json
@@ -46,10 +46,10 @@
               }
             ],
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/css/properties/object-position.json
+++ b/css/properties/object-position.json
@@ -48,7 +48,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": null


### PR DESCRIPTION
Both `object-fit` and `object-position` were added to Safari in version 10. Below are the bug reports for the feature.

object-position: https://bugs.webkit.org/show_bug.cgi?id=122811
object-fit: https://bugs.webkit.org/show_bug.cgi?id=52040