### PR TITLE
Add targetElementId to browser.menus.onClickData

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -366,6 +366,27 @@
                 }
               }
             }
+          },
+          "targetElementId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "63"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "create": {


### PR DESCRIPTION
The property targetElementId is added to browser.menus.onClickData in Firefox 63, like browser.menus.getTargetElement.
https://blog.mozilla.org/addons/2018/08/31/extensions-in-firefox-63/