### PR TITLE
updating support info for FF64

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -172,12 +172,10 @@
                 "version_added": "16"
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+                "version_added": "64"
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+                "version_added": "64"
               },
               "ie": {
                 "version_added": false
@@ -226,12 +224,10 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+                "version_added": "64"
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1035774'>bug 1035774</a>."
+                "version_added": "64"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
64 supports the `pointer`, `any-pointer`, `hover` media features https://bugzilla.mozilla.org/show_bug.cgi?id=1035774