### PR TITLE
Update Firefox compatibility for Window.event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1794,10 +1794,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "63"
+              "version_added": "64"
             },
             "firefox_android": {
-              "version_added": "63"
+              "version_added": "64"
             },
             "ie": {
               "version_added": true


### PR DESCRIPTION
Window.event is fixed in Firefox 64 : https://bugzilla.mozilla.org/show_bug.cgi?id=218415