### PR TITLE
Bug 1487982: Rename `applications` to `browser_specific_settings`

### DIFF
--- a/webextensions/manifest/browser_specific_settings.json
+++ b/webextensions/manifest/browser_specific_settings.json
@@ -1,16 +1,15 @@
 {
   "webextensions": {
     "manifest": {
-      "applications": {
+      "browser_specific_settings": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/applications",
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings",
           "support": {
             "chrome": {
               "version_added": false
             },
             "edge": {
-              "version_added": "15",
-              "alternative_name": "browser_specific_settings"
+              "version_added": "15"
             },
             "firefox": [
               {
@@ -18,7 +17,7 @@
               },
               {
                 "version_added": "48",
-                "alternative_name": "browser_specific_settings"
+                "alternative_name": "applications"
               }
             ],
             "firefox_android": [
@@ -27,7 +26,7 @@
               },
               {
                 "version_added": "48",
-                "alternative_name": "browser_specific_settings"
+                "alternative_name": "applications"
               }
             ],
             "opera": {


### PR DESCRIPTION
Resolves #2540 and [bug&nbsp;1487982](https://bugzilla.mozilla.org/show_bug.cgi?id=1487982)

I already moved [the page to the new location](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings).

review?(@Elchi3)