### PR TITLE
Update aspect-ratio for safari_ios

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -291,7 +291,7 @@
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
Tested aspect-ratio media query on iOS 12 Safari and it works.