### PR TITLE
Update HTMLElement.nonce

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1167,25 +1167,25 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/nonce",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "61"
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -1200,7 +1200,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "61"
             }
           },
           "status": {


### PR DESCRIPTION
Edge and other browsers does not support `HTMLElement.prototype.nonce` while Chrome supports it since version 61.