### PR TITLE
Safari 10.0 does not support fetch()

### DIFF
--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -626,10 +626,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "webview_android": {
               "version_added": "42"


### PR DESCRIPTION
Fixes #3059 