### PR TITLE
Added compatibility data from svg/attribute/paint-property

### DIFF
--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -1927,7 +1927,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/paint-order",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
                 "version_added": null
@@ -1939,32 +1939,32 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": true
               },
               "firefox_android": {
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This was a trial run of my scraper project (https://github.com/SKalt/mdn-compat-table-scraper).  If anyone cares to cast a critical eye over the original table, see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/paint-order#Browser_compatibility. 