### PR TITLE
Add version information for updateViaCache for Firefox and Chrome

### DIFF
--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -1245,10 +1245,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/updateViaCache",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "68"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "68"
             },
             "edge": {
               "version_added": "18"
@@ -1257,10 +1257,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "57"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "57"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
Firefox:
https://bugzilla.mozilla.org/show_bug.cgi?id=1353636

Chrome:
https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/RwjXGTAbuuA
https://developers.google.com/web/updates/2018/06/fresher-sw