### PR TITLE
updating WebVR support data for macOS and Android

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -456,9 +456,18 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "56",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
+              }
+            ],
+            "firefox_android": {
+              "version_added": "55"
             },
             "ie": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -68,10 +68,16 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is available in Firefox Nightly."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
+              }
+            ],
             "firefox_android": {
               "version_added": "55"
             },
@@ -956,10 +962,16 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "55",
-              "notes": "Currently only Windows support is enabled by default. Mac support is <a href='https://hacks.mozilla.org/2017/06/announcing-webvr-on-mac/'>available in Firefox Nightly</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
+              }
+            ],
             "firefox_android": {
               "version_added": "55"
             },

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -33,10 +33,13 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "63",
-              "notes": "macOS support was enabled in Firefox 63."
+              "version_added": "64",
+              "notes": "macOS support was enabled in Firefox 64."
             }
           ],
+          "firefox_android": {
+            "version_added": "55"
+          },
           "ie": {
             "version_added": false
           },
@@ -86,10 +89,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -140,10 +146,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -194,10 +203,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -248,10 +260,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -302,10 +317,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -356,10 +374,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -410,10 +431,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -464,10 +488,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -518,10 +545,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -572,10 +602,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -615,10 +648,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -669,10 +705,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -759,10 +798,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -813,10 +855,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -867,10 +912,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -921,10 +969,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -975,10 +1026,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -1029,10 +1083,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -1083,10 +1140,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -33,10 +33,13 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "63",
-              "notes": "macOS support was enabled in Firefox 63."
+              "version_added": "64",
+              "notes": "macOS support was enabled in Firefox 64."
             }
           ],
+          "firefox_android": {
+            "version_added": "55"
+          },
           "ie": {
             "version_added": false
           },
@@ -86,10 +89,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -140,10 +146,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -194,10 +203,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -248,10 +260,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -302,10 +317,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -33,10 +33,13 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "63",
-              "notes": "macOS support was enabled in Firefox 63."
+              "version_added": "64",
+              "notes": "macOS support was enabled in Firefox 64."
             }
           ],
+          "firefox_android": {
+            "version_added": "55"
+          },
           "ie": {
             "version_added": false
           },
@@ -87,10 +90,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -141,10 +147,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -195,10 +204,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -33,10 +33,13 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "63",
-              "notes": "macOS support was enabled in Firefox 63."
+              "version_added": "64",
+              "notes": "macOS support was enabled in Firefox 64."
             }
           ],
+          "firefox_android": {
+            "version_added": "55"
+          },
           "ie": {
             "version_added": false
           },
@@ -86,10 +89,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -129,10 +135,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -172,10 +181,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -226,10 +238,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -316,10 +331,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -406,10 +424,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -33,10 +33,13 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "63",
-              "notes": "macOS support was enabled in Firefox 63."
+              "version_added": "64",
+              "notes": "macOS support was enabled in Firefox 64."
             }
           ],
+          "firefox_android": {
+            "version_added": "55"
+          },
           "ie": {
             "version_added": false
           },
@@ -123,10 +126,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -177,10 +183,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -231,10 +240,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -285,10 +297,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -33,10 +33,13 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "63",
-              "notes": "macOS support was enabled in Firefox 63."
+              "version_added": "64",
+              "notes": "macOS support was enabled in Firefox 64."
             }
           ],
+          "firefox_android": {
+            "version_added": "55"
+          },
           "ie": {
             "version_added": false
           },
@@ -87,10 +90,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -141,10 +147,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -195,10 +204,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -249,10 +261,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -303,10 +318,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -357,10 +375,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -411,10 +432,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VRLayerInit.json
+++ b/api/VRLayerInit.json
@@ -33,10 +33,13 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "63",
-              "notes": "macOS support was enabled in Firefox 63."
+              "version_added": "64",
+              "notes": "macOS support was enabled in Firefox 64."
             }
           ],
+          "firefox_android": {
+            "version_added": "55"
+          },
           "ie": {
             "version_added": false
           },
@@ -86,10 +89,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -140,10 +146,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -194,10 +203,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -33,10 +33,13 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "63",
-              "notes": "macOS support was enabled in Firefox 63."
+              "version_added": "64",
+              "notes": "macOS support was enabled in Firefox 64."
             }
           ],
+          "firefox_android": {
+            "version_added": "55"
+          },
           "ie": {
             "version_added": false
           },
@@ -86,10 +89,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -140,10 +146,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -266,10 +275,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -320,10 +332,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -374,10 +389,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -428,10 +446,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -33,10 +33,13 @@
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
-              "version_added": "63",
-              "notes": "macOS support was enabled in Firefox 63."
+              "version_added": "64",
+              "notes": "macOS support was enabled in Firefox 64."
             }
           ],
+          "firefox_android": {
+            "version_added": "55"
+          },
           "ie": {
             "version_added": false
           },
@@ -86,10 +89,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -140,10 +146,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -194,10 +203,13 @@
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "63",
-                "notes": "macOS support was enabled in Firefox 63."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/Window.json
+++ b/api/Window.json
@@ -1065,9 +1065,16 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "55"
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
+              }
+            ],
             "firefox_android": {
               "version_added": "55"
             },
@@ -1180,12 +1187,12 @@
             },
             "firefox": [
               {
-                "version_added": "63",
-                "notes": "Only Windows and macOS support is enabled."
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "55",
-                "notes": "Only Windows support is enabled."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
             "firefox_android": {
@@ -1237,9 +1244,16 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "55"
-            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
+              }
+            ],
             "firefox_android": {
               "version_added": "55"
             },
@@ -1301,12 +1315,12 @@
             },
             "firefox": [
               {
-                "version_added": "63",
-                "notes": "Only Windows and macOS support is enabled."
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "55",
-                "notes": "Only Windows support is enabled."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
             "firefox_android": {
@@ -1422,12 +1436,12 @@
             },
             "firefox": [
               {
-                "version_added": "63",
-                "notes": "Only Windows and macOS support is enabled."
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
               },
               {
-                "version_added": "55",
-                "notes": "Only Windows support is enabled."
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
               }
             ],
             "firefox_android": {


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1476091

But I also decided to add in the FxA support data in places where it was (weirdly) missing.

The macOS support was added in around 62 or 63, then removed again, then added back in again in 64. So I thought it'd be less confusing if we just said it is supported in macOS in 64.