### PR TITLE
Bug 1258143 - remove LocalMediaStream (fx64)

### DIFF
--- a/api/LocalMediaStream.json
+++ b/api/LocalMediaStream.json
@@ -17,10 +17,12 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": "17"
+            "version_added": "17",
+            "version_removed": "64"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": true,
+            "version_removed": "64"
           },
           "ie": {
             "version_added": false


### PR DESCRIPTION
This notes removal of LocalMediaStream from Firefox 64.