### PR TITLE
adding Android support for prefers-reduced-motion media feature

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1213,7 +1213,7 @@
                 "version_added": "63"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "64"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1478505.