### PR TITLE
Use array form of support statement object

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -6,10 +6,15 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy",
             "support": {
-              "chrome": {
-                "version_added": "25",
-                "notes": "Implemented as X-Webkit-CSP header in Chrome 14."
-              },
+              "chrome": [
+                {
+                  "version_added": "25",
+                },
+                {
+                  "version_added": "14",
+                  "notes": "Implemented as X-Webkit-CSP header."
+                }
+              ],
               "chrome_android": {
                 "version_added": true
               },
@@ -19,10 +24,15 @@
               "edge_mobile": {
                 "version_added": true
               },
-              "firefox": {
-                "version_added": "23",
-                "notes": "Implemented as X-Content-Security-Policy header in Firefox 4."
-              },
+              "firefox": [
+                {
+                  "version_added": "23",
+                },
+                {
+                  "version_added": "4",
+                  "notes": "Implemented as X-Content-Security-Policy header."
+                }
+              ],
               "firefox_android": {
                 "version_added": "23"
               },
@@ -36,14 +46,24 @@
               "opera_android": {
                 "version_added": null
               },
-              "safari": {
-                "version_added": "7",
-                "notes": "Implemented as X-Webkit-CSP header in Safari 6."
-              },
-              "safari_ios": {
-                "version_added": "7.1",
-                "notes": "Implemented as X-Webkit-CSP header in iOS 5.1."
-              },
+              "safari": [
+                {
+                  "version_added": "7",
+                },
+                {
+                  "version_added": "6",
+                  "notes": "Implemented as X-Webkit-CSP header."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "7.1",
+                },
+                {
+                  "version_added": "5.1",
+                  "notes": "Implemented as X-Webkit-CSP header."
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": true
               },

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -12,7 +12,7 @@
                 },
                 {
                   "version_added": "14",
-                  "notes": "Implemented as X-Webkit-CSP header."
+                  "alternative_name": "X-Webkit-CSP"
                 }
               ],
               "chrome_android": {
@@ -30,7 +30,7 @@
                 },
                 {
                   "version_added": "4",
-                  "notes": "Implemented as X-Content-Security-Policy header."
+                  "alternative_name": "X-Content-Security-Policy"
                 }
               ],
               "firefox_android": {
@@ -38,7 +38,8 @@
               },
               "ie": {
                 "version_added": "10",
-                "notes": "Implemented as X-Content-Security-Policy header, only supporting 'sandbox' directive."
+                "notes": "Only supporting 'sandbox' directive.",
+                "alternative_name": "X-Content-Security-Policy"
               },
               "opera": {
                 "version_added": "15"
@@ -52,7 +53,7 @@
                 },
                 {
                   "version_added": "6",
-                  "notes": "Implemented as X-Webkit-CSP header."
+                  "alternative_name": "X-Webkit-CSP"
                 }
               ],
               "safari_ios": [
@@ -61,7 +62,7 @@
                 },
                 {
                   "version_added": "5.1",
-                  "notes": "Implemented as X-Webkit-CSP header."
+                  "notes": "X-Webkit-CSP"
                 }
               ],
               "samsunginternet_android": {

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -8,7 +8,7 @@
             "support": {
               "chrome": [
                 {
-                  "version_added": "25",
+                  "version_added": "25"
                 },
                 {
                   "version_added": "14",
@@ -26,7 +26,7 @@
               },
               "firefox": [
                 {
-                  "version_added": "23",
+                  "version_added": "23"
                 },
                 {
                   "version_added": "4",
@@ -48,7 +48,7 @@
               },
               "safari": [
                 {
-                  "version_added": "7",
+                  "version_added": "7"
                 },
                 {
                   "version_added": "6",
@@ -57,7 +57,7 @@
               ],
               "safari_ios": [
                 {
-                  "version_added": "7.1",
+                  "version_added": "7.1"
                 },
                 {
                   "version_added": "5.1",


### PR DESCRIPTION
I'm wondering whether we should just use [`prefix`](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#prefix), but HTTP header is not mentioned in the examples.