### PR TITLE
add compat: input events "color input"

### DIFF
--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -148,6 +148,53 @@
                 "deprecated": false
               }
             }
+          },
+          "input event": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
The "input event" should trigger during an interaction with the open menu.
This is the case for firefox but not Chrome or Edge

https://www.w3.org/TR/html50/forms.html#event-input-input
"The input event fires whenever the user has modified the data of the control. The change event fires when the value is committed"