### PR TITLE
Update BCD for Video/AudioStreamTrack removals

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": true
+            "version_added": "15"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "15"
           },
           "ie": {
             "version_added": false
@@ -48,7 +48,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -512,10 +512,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "22",
+              "notes": "Prior to Firefox 64, this method returned an array of <code>AudioStreamTrack</code> objects. However, <code>MediaStreamTrack</code> has now subsumed that interface's functionality."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "22",
+              "notes": "Prior to Firefox 64, this method returned an array of <code>AudioStreamTrack</code> objects. However, <code>MediaStreamTrack</code> has now subsumed that interface's functionality."
             },
             "ie": {
               "version_added": null
@@ -674,10 +676,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": "22",
+              "notes": "Prior to Firefox 64, this method returned an array of <code>VideoStreamTrack</code> objects. However, <code>MediaStreamTrack</code> has now subsumed that interface's functionality."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "22",
+              "notes": "Prior to Firefox 64, this method returned an array of <code>VideoStreamTrack</code> objects. However, <code>MediaStreamTrack</code> has now subsumed that interface's functionality."
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This updates the MediaStream interface data for the
removal of these two interfaces and adds introduction
version numbers to the MediaStream interface itself
as well as these two methods.