### PR TITLE
Bug 1425874: Make <marquee> construct HTMLMarqueeElement

### DIFF
--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -17,18 +17,12 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": false,
-            "notes": [
-              "<code>&lt;marquee&gt;</code> implements the <code>HTMLDivElement</code> interface.",
-              "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
-            ]
+            "version_added": "65",
+            "notes": "Before Firefox 65, <code>&lt;marquee&gt;</code> implemented the <code>HTMLDivElement</code> interface."
           },
           "firefox_android": {
-            "version_added": false,
-            "notes": [
-              "<code>&lt;marquee&gt;</code> implements the <code>HTMLDivElement</code> interface.",
-              "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
-            ]
+            "version_added": "65",
+            "notes": "Before Firefox 65, <code>&lt;marquee&gt;</code> implemented the <code>HTMLDivElement</code> interface."
           },
           "ie": {
             "version_added": "2"
@@ -71,12 +65,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "ie": {
               "version_added": "2"
@@ -120,12 +112,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "ie": {
               "version_added": "2"
@@ -169,12 +159,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "ie": {
               "version_added": "2"
@@ -218,12 +206,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "ie": {
               "version_added": "2"
@@ -267,12 +253,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "ie": {
               "version_added": null
@@ -316,12 +300,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "ie": {
               "version_added": null
@@ -365,12 +347,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "ie": {
               "version_added": "2"
@@ -414,12 +394,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "ie": {
               "version_added": "2"
@@ -463,12 +441,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "ie": {
               "version_added": "4"
@@ -512,12 +488,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "ie": {
               "version_added": null
@@ -561,12 +535,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1425874'>bug 1425874</a>."
+              "version_added": "65"
             },
             "ie": {
               "version_added": "2"

--- a/html/elements/marquee.json
+++ b/html/elements/marquee.json
@@ -17,16 +17,26 @@
             "edge_mobile": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "1",
-              "partial_implementation": true,
-              "notes": "Implements the <code>HTMLDivElement</code> interface."
-            },
-            "firefox_android": {
-              "version_added": "4",
-              "partial_implementation": true,
-              "notes": "Implements the <code>HTMLDivElement</code> interface."
-            },
+            "firefox": [
+              {
+                "version_added": "65"
+              },
+              {
+                "version_added": "1",
+                "partial_implementation": true,
+                "notes": "Implements the <code>HTMLDivElement</code> interface."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "65"
+              },
+              {
+                "version_added": "4",
+                "partial_implementation": true,
+                "notes": "Implements the <code>HTMLDivElement</code> interface."
+              }
+            ],
             "ie": {
               "version_added": "2"
             },


### PR DESCRIPTION
See [bug&nbsp;1425874](https://bugzilla.mozilla.org/show_bug.cgi?id=1425874) for details.

review?(@Elchi3)