### PR TITLE
Added Opera "class" support version

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -261,7 +261,7 @@
               "version_added": "6.0.0"
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
               "version_added": null
@@ -314,7 +314,7 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": "36"
               },
               "opera_android": {
                 "version_added": null
@@ -368,7 +368,7 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": "36"
               },
               "opera_android": {
                 "version_added": null


### PR DESCRIPTION
[classes.json](https://github.com/mdn/browser-compat-data/blob/master/javascript/classes.json#L53) shows that Opera 36 supports classes. This is mentioned in the Opera blog post for [version 36](https://dev.opera.com/blog/opera-36/#es6-block-scoped-bindings-in-sloppy-mode). Subclassing using Symbol.species support is described in detail in the blog post for [version 38](https://dev.opera.com/blog/opera-38/#es6-subclassing-using-symbolspecies). I'm not sure what to do with that information.