### PR TITLE
Add a "restriction" field to the compat-data schema

### DIFF
--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -340,6 +340,30 @@ Example for two flags required:
 }
 ```
 
+### `restriction`
+A string value which indicates a release channel restriction for this sub-feature; this
+supports features which are only compiled into nightly builds, for example. Possible
+values are:
+
+* `beta`: only built into beta (and nightly) builds
+* `nightly`: only built into nightly builds
+* `exclusive`: only available in specialized builds; use the `notes` field to explain; this should be used sparingly
+
+To describe a feature which is only compiled into nightly builds starting with version 55,
+but is disabled by default behind a preference, you could do this:
+
+```json
+{
+  "version_added": "55",
+  "restriction": "nightly",
+  "flags": [
+    "type": "preference",
+    "name": "dom.feature.enabled",
+    "value_to_set": "true"
+  ]
+}
+```
+
 #### `partial_implementation`
 A `boolean` value indicating whether or not the implementation of the sub-feature
 follows the current specification closely enough to not create major interoperability problems.
@@ -367,6 +391,7 @@ The `<code>` and `<a>` HTML elements can be used.
 ### Status information
 The status property contains information about stability of the feature. It is
 an optional object named `status` and has three mandatory properties:
+
 * `experimental`: a `boolean` value that indicates this functionality is
 intended to be an addition to the Web platform. Some features are added to
 conduct tests. Set to `false`, it means the functionality is mature, and no

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -45,6 +45,11 @@
         },
         "version_added": { "$ref": "#/definitions/version_value" },
         "version_removed": { "$ref": "#/definitions/version_value" },
+        "restriction": {
+          "type": "string",
+          "enum": ["exclusive", "beta", "nightly"],
+          "description": "A release type restriction (beta, nightly, exclusive only)."
+        },
         "notes": {
           "description": "An array of zero or more strings containing additional information.",
           "anyOf": [

--- a/test/sample-data.json
+++ b/test/sample-data.json
@@ -241,6 +241,80 @@
               "deprecated": false
             }
           }
+        },
+        "featureWithRestrictions": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "65",
+                "restriction": "beta"
+              },
+              "chrome_android": {
+                "version_added": "65"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "60",
+                "restriction": "nightly",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.feature.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": [
+                {
+                  "version_added": "63"
+                },
+                {
+                  "version_added": "60",
+                  "restriction": "nightly",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.feature.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": "11",
+                "restriction": "exclusive",
+                "notes": "Available only if built with the -X-FOOBAR compiler flag."
+              },
+              "opera": {
+                "version_added": "52"
+              },
+              "opera_android": {
+                "version_added": "52"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": "65"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This adds an optional "restriction" field to the version
information so you can indicate that a feature is only
available on specific build channels, such as nightly or
beta releases.

See [this Discourse thread](https://discourse.mozilla.org/t/bcd-question-flag-and-enabled-by-default-in-nightly-only) in which this concept is discussed
and this proposal reached.

Includes updated schema test data and documentation.