### PR TITLE
Add compatibility info for optional redirect_uri URL param in identity API

### DIFF
--- a/webextensions/api/identity.json
+++ b/webextensions/api/identity.json
@@ -34,36 +34,21 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "53"
-              },
+              "firefox": [
+                {
+                  "version_added": "53"
+                },
+                {
+                  "version_added": "53",
+                  "version_removed": "63",
+                  "notes": "The <code>redirect_uri</code> URL parameter is required"
+                }
+              ],
               "firefox_android": {
                 "version_added": false
               },
               "opera": {
                 "version_added": true
-              }
-            }
-          },
-          "redirect_uri": {
-            "__compat": {
-              "description": "The <code>redirect_uri</code> URL parameter is optional if the redirect URI matches the result of <code>getRedirectURL</code>",
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "64"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                }
               }
             }
           }

--- a/webextensions/api/identity.json
+++ b/webextensions/api/identity.json
@@ -44,6 +44,28 @@
                 "version_added": true
               }
             }
+          },
+          "redirect_uri": {
+            "__compat": {
+              "description": "The <code>redirect_uri</code> URL parameter is optional if the redirect URI matches the result of <code>getRedirectURL</code>",
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "64"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
           }
         }
       }

--- a/webextensions/api/identity.json
+++ b/webextensions/api/identity.json
@@ -41,7 +41,7 @@
                 {
                   "version_added": "53",
                   "version_removed": "63",
-                  "notes": "The <code>redirect_uri</code> URL parameter is required"
+                  "notes": "The <code>redirect_uri</code> URL parameter is required."
                 }
               ],
               "firefox_android": {


### PR DESCRIPTION
This was changed in 64: https://blog.mozilla.org/addons/2018/11/08/extensions-in-firefox-64/

Not sure if this warrants an entry, since it's not a new addition, instead it's properly aligning Firefox behavior.