### PR TITLE
Extension alarms set in the past fire immediately in 64

### DIFF
--- a/webextensions/api/alarms.json
+++ b/webextensions/api/alarms.json
@@ -88,6 +88,28 @@
                 "version_added": true
               }
             }
+          },
+          "pastAlarm": {
+            "__compat": {
+              "description": "Alarms scheduled for a time in the past fire immediately",
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "64"
+                },
+                "firefox_android": {
+                  "version_added": "64"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "get": {

--- a/webextensions/api/alarms.json
+++ b/webextensions/api/alarms.json
@@ -78,36 +78,28 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "45"
-              },
-              "firefox_android": {
-                "version_added": "48"
-              },
+              "firefox": [
+                {
+                  "version_added": "45"
+                },
+                {
+                  "version_added": "45",
+                  "version_removed": "64",
+                  "notes": "Alarms scheduled for a time in the past never fire."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "48"
+                },
+                {
+                  "version_added": "48",
+                  "version_removed": "64",
+                  "notes": "Alarms scheduled for a time in the past never fire."
+                }
+              ],
               "opera": {
                 "version_added": true
-              }
-            }
-          },
-          "pastAlarm": {
-            "__compat": {
-              "description": "Alarms scheduled for a time in the past fire immediately",
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "64"
-                },
-                "firefox_android": {
-                  "version_added": "64"
-                },
-                "opera": {
-                  "version_added": false
-                }
               }
             }
           }


### PR DESCRIPTION
This was changed in 64: https://blog.mozilla.org/addons/2018/11/08/extensions-in-firefox-64/

Same as #3104 