### PR TITLE
updating buildID compat data

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -286,12 +286,24 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "2"
-            },
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox": [
+              {
+                "version_added": "64",
+                "notes": "Returns a fixed timestamp as a privacy measure — <code>20181001000000</code>."
+              },
+              {
+                "version_added": "2"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "64",
+                "notes": "Returns a fixed timestamp as a privacy measure — <code>20181001000000</code>."
+              },
+              {
+                "version_added": true
+              }
+            ],
             "ie": {
               "version_added": null
             },


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=583181

See also https://www.fxsitecompat.com/en-CA/docs/2018/navigator-buildid-now-returns-a-fixed-timestamp/