### PR TITLE
updating window.sidebar and adding window.external

### DIFF
--- a/api/External.json
+++ b/api/External.json
@@ -16,24 +16,12 @@
           "edge_mobile": {
             "version_added": null
           },
-          "firefox": [
-            {
-              "version_added": "65",
-              "notes": "Functionality removed in Firefox 65. The methods still exist, but do nothing."
-            },
-            {
-              "version_added": true
-            }
-          ],
-          "firefox_android": [
-            {
-              "version_added": "65",
-              "notes": "Functionality removed in Firefox 65. The methods still exist, but do nothing."
-            },
-            {
-              "version_added": true
-            }
-          ],
+          "firefox": {
+            "version_added": true
+          },
+          "firefox_android": {
+            "version_added": true
+          },
           "ie": {
             "version_added": null
           },

--- a/api/External.json
+++ b/api/External.json
@@ -1,0 +1,55 @@
+{
+  "api": {
+    "External": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/external",
+        "support": {
+          "chrome": {
+            "version_added": null
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": [
+            {
+              "version_added": "65",
+              "notes": "Functionality removed in Firefox 65. The methods still exist, but do nothing."
+            },
+            {
+              "version_added": true
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "65",
+              "notes": "Functionality removed in Firefox 65. The methods still exist, but do nothing."
+            },
+            {
+              "version_added": true
+            }
+          ],
+          "ie": {
+            "version_added": null
+          },
+          "samsunginternet_android": {
+            "version_added": null
+          },
+          "webview_android": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": true
+        }
+      }
+    }
+  }
+}

--- a/api/External.json
+++ b/api/External.json
@@ -2,7 +2,7 @@
   "api": {
     "External": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/external",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/External",
         "support": {
           "chrome": {
             "version_added": null
@@ -36,6 +36,84 @@
           "experimental": false,
           "standard_track": true,
           "deprecated": true
+        }
+      },
+      "AddSearchProvider": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/External/AddSearchProvider",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "IsSearchProviderInstalled": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/External/IsSearchProviderInstalled",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
         }
       }
     }

--- a/api/Window.json
+++ b/api/Window.json
@@ -6659,12 +6659,38 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": true
-            },
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox": [
+              {
+                "version_added": "65",
+                "notes": "Behind a flag in Nightly only.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.sidebar.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": true
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "65",
+                "notes": "Behind a flag in Nightly only.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.sidebar.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": true
+              }
+            ],
             "ie": {
               "version_added": null
             },
@@ -6690,7 +6716,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Window.json
+++ b/api/Window.json
@@ -6659,38 +6659,12 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": [
-              {
-                "version_added": "65",
-                "notes": "Behind a flag in Nightly only.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.sidebar.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "65",
-                "notes": "Behind a flag in Nightly only.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.sidebar.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true
-              }
-            ],
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
             "ie": {
               "version_added": null
             },

--- a/api/Window.json
+++ b/api/Window.json
@@ -468,6 +468,45 @@
           }
         }
       },
+      "external": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/external",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
       "focus": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/focus",


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1503551.

This is a strange one — window.sidebar is in the process of being removed, so for now we've put it behind a pref in Nightly only. This is not in any spec, afaics

window.external is in the HTML spec, but it has been made so the functions are dummy functions — they return nothing. And this is the other thing this bug is doing.

That's what I understand anyhow. I'll get baku to review the content asap to make sure I've not got this completely wrong.