### PR TITLE
adding data about getAllResponseHeaders() returning all lower case he…

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1103,6 +1103,57 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "lowercase": {
+          "__compat": {
+            "description": "Header names returned in all lower case",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "64"
+              },
+              "firefox_android": {
+                "version_added": "64"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "getResponseHeader": {


### PR DESCRIPTION
…ader names

As per https://bugzilla.mozilla.org/show_bug.cgi?id=1398718

https://www.fxsitecompat.com/en-CA/docs/2018/xhr-getallresponseheaders-now-returns-header-names-in-lowercase/ is also useful here.