### PR TITLE
feat(css): `:blank` has been merged into `:empty` and redefined

### DIFF
--- a/css/selectors/blank.json
+++ b/css/selectors/blank.json
@@ -19,14 +19,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
-              "alternative_name": ":-moz-only-whitespace",
-              "notes": "See <a href='https://bugzil.la/1106296'>bug 1106296</a>."
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": true,
-              "alternative_name": ":-moz-only-whitespace",
-              "notes": "See <a href='https://bugzil.la/1106296'>bug 1106296</a>."
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/css/selectors/empty.json
+++ b/css/selectors/empty.json
@@ -51,6 +51,63 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "matches_whitespace": {
+          "__compat": {
+            "description": "Matches elements with whitespace",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true,
+                "partial_implementation": true,
+                "alternative_name": ":-moz-only-whitespace",
+                "notes": "See <a href='https://bugzil.la/1106296'>bug 1106296</a>."
+              },
+              "firefox_android": {
+                "version_added": true,
+                "partial_implementation": true,
+                "alternative_name": ":-moz-only-whitespace",
+                "notes": "See <a href='https://bugzil.la/1106296'>bug 1106296</a>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
`:blank` now matches empty user‑input elements (eg. empty `<input>` and `<textarea>`) and `:empty` matches elements with only whitespace.

review?(@Elchi3, @ddbeck)