### PR TITLE
Add PayerErrors to BCD

### DIFF
--- a/api/PayerErrors.json
+++ b/api/PayerErrors.json
@@ -1,0 +1,520 @@
+{
+  "api": {
+    "PayerErrors": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/PayerErrors",
+        "support": {
+          "chrome": [
+            {
+              "version_added": "71",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-payments",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "69",
+              "version_removed": "71",
+              "alternative_name": "PayerErrorFields",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-payments",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "71",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-payments",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "69",
+              "version_removed": "71",
+              "alternative_name": "PayerErrorFields",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-payments",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": [
+            {
+              "version_added": "64",
+              "notes": "Enabled by default in nightly US English builds of Firefox 64 and later, and on other localizations when geolocation indicates the user is in the United States or Canada."
+            },
+            {
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.supportedRegions",
+                  "value_to_set": "<em>comma-delineated 2-character country code list</em>"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "64",
+              "notes": "Enabled by default in nightly US English builds of Firefox 64 and later, and on other localizations when geolocation indicates the user is in the United States or Canada."
+            },
+            {
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.supportedRegions",
+                  "value_to_set": "<em>comma-delineated 2-character country code list</em>"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          },
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "email": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PayerErrors/email",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "71",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#web-payments",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "69",
+                "version_removed": "71",
+                "alternative_name": "payerEmailError",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#web-payments",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "71",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#web-payments",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "69",
+                "version_removed": "71",
+                "alternative_name": "payerEmailError",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#web-payments",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "64",
+                "notes": "Enabled by default in nightly US English builds of Firefox 64 and later, and on other localizations when geolocation indicates the user is in the United States or Canada."
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.payments.request.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.payments.request.supportedRegions",
+                    "value_to_set": "<em>comma-delineated 2-character country code list</em>"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "64",
+                "notes": "Enabled by default in nightly US English builds of Firefox 64 and later, and on other localizations when geolocation indicates the user is in the United States or Canada."
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.payments.request.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.payments.request.supportedRegions",
+                    "value_to_set": "<em>comma-delineated 2-character country code list</em>"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "name": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PayerErrors/name",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "71",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#web-payments",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "69",
+                "version_removed": "71",
+                "alternative_name": "payerNameError",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#web-payments",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "71",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#web-payments",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "69",
+                "version_removed": "71",
+                "alternative_name": "payerNameError",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#web-payments",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "64",
+                "notes": "Enabled by default in nightly US English builds of Firefox 64 and later, and on other localizations when geolocation indicates the user is in the United States or Canada."
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.payments.request.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.payments.request.supportedRegions",
+                    "value_to_set": "<em>comma-delineated 2-character country code list</em>"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "64",
+                "notes": "Enabled by default in nightly US English builds of Firefox 64 and later, and on other localizations when geolocation indicates the user is in the United States or Canada."
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.payments.request.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.payments.request.supportedRegions",
+                    "value_to_set": "<em>comma-delineated 2-character country code list</em>"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "phone": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PayerErrors/phone",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "71",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#web-payments",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "69",
+                "version_removed": "71",
+                "alternative_name": "payerPhoneError",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#web-payments",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "71",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#web-payments",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "69",
+                "version_removed": "71",
+                "alternative_name": "payerPhoneError",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#web-payments",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "64",
+                "notes": "Enabled by default in nightly US English builds of Firefox 64 and later, and on other localizations when geolocation indicates the user is in the United States or Canada."
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.payments.request.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.payments.request.supportedRegions",
+                    "value_to_set": "<em>comma-delineated 2-character country code list</em>"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "64",
+                "notes": "Enabled by default in nightly US English builds of Firefox 64 and later, and on other localizations when geolocation indicates the user is in the United States or Canada."
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.payments.request.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.payments.request.supportedRegions",
+                    "value_to_set": "<em>comma-delineated 2-character country code list</em>"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the PayerErrors dictionary to BCD, with
data for Chrome and Firefox. Part of Q4S3.

Supporting information:
* Spec: https://w3c.github.io/payment-request/#payererrors-dictionary
* Firefox renaming `PayerErrorFields` to `PayerErrors` (in same release as shipped, so no special coverage required): https://bugzilla.mozilla.org/show_bug.cgi?id=1495335
* Chrome: https://cs.chromium.org/chromium/src/third_party/blink/renderer/modules/payments/payer_errors.idl?type=cs&sq=package:chromium&g=0