### PR TITLE
Revert "Bug 1487982: Rename `applications` to `browser_specific_settings`"

### DIFF
--- a/webextensions/manifest/applications.json
+++ b/webextensions/manifest/applications.json
@@ -1,15 +1,16 @@
 {
   "webextensions": {
     "manifest": {
-      "browser_specific_settings": {
+      "applications": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings",
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/applications",
           "support": {
             "chrome": {
               "version_added": false
             },
             "edge": {
-              "version_added": "15"
+              "version_added": "15",
+              "alternative_name": "browser_specific_settings"
             },
             "firefox": [
               {
@@ -17,7 +18,7 @@
               },
               {
                 "version_added": "48",
-                "alternative_name": "applications"
+                "alternative_name": "browser_specific_settings"
               }
             ],
             "firefox_android": [
@@ -26,7 +27,7 @@
               },
               {
                 "version_added": "48",
-                "alternative_name": "applications"
+                "alternative_name": "browser_specific_settings"
               }
             ],
             "opera": {


### PR DESCRIPTION
Reverts mdn/browser-compat-data#3064 - This has not been implemented yet. The documentation has been reverted as well.