### PR TITLE
Safari supports HTMLHyperlinkElementUtils properties

### DIFF
--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -36,10 +36,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": true
           },
           "webview_android": {
             "version_added": true,
@@ -88,10 +88,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,
@@ -142,10 +142,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,
@@ -248,10 +248,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,
@@ -307,10 +307,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,
@@ -354,10 +354,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,
@@ -417,10 +417,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,
@@ -470,10 +470,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,
@@ -523,10 +523,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,
@@ -633,10 +633,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": "52"
@@ -679,10 +679,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,

--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -195,10 +195,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,


### PR DESCRIPTION
Both Safari and iOS Safari support the `a.hostname` property:

```<script>
var a = document.createElement('a');
a.href = "https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/hostname";
alert(a.hostname);
</script>
```

Alerts "developer.mozilla.org".

I cannot find when this has been supported since, but it is likely to have been a few versions at least.