### PR TITLE
Add Firefox versions to isPrototypeOf and propertyIsEnumerable

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -1891,10 +1891,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -1945,10 +1945,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true


### PR DESCRIPTION
@jpmedley sent me some csv files containing burn lists for missing BCD data. 
If I see it correctly, these two are the only JavaScript compat data entries where we are missing actual Firefox versions, so I'm adding these two :)