### PR TITLE
Edge doesn't support onunhandledrejection/onrejectionhandled

### DIFF
--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -547,10 +547,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false,
@@ -570,10 +570,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": 11
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": 11
             },
             "webview_android": {
               "version_added": false
@@ -645,10 +645,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": {
               "version_added": false,
@@ -668,10 +668,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": 11
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": 11
             },
             "webview_android": {
               "version_added": false

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -570,10 +570,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": 11
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": 11
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": false
@@ -668,10 +668,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": 11
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": 11
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
Edge doesn't support onunhandledrejection/onrejectionhandled, but Safari 11+ does.
Verified using https://tests.caniuse.com/?feat=unhandledrejection