### PR TITLE
update to gradients to add multipoint color stops

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -302,15 +302,15 @@
                 }
               }
             },
-            "interpolation_hints": {
+            "multiposition": {
               "__compat": {
-                "description": "Interpolation Hints / Gradient Midpoints",
+                "description": "Multi-position color stops",
                 "support": {
                   "chrome": {
-                    "version_added": "40"
+                    "version_added": "71"
                   },
                   "chrome_android": {
-                    "version_added": "40"
+                    "version_added": "71"
                   },
                   "edge": {
                     "version_added": false
@@ -319,31 +319,33 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "36"
+                    "version_added": "64"
                   },
                   "firefox_android": {
-                    "version_added": "36"
+                    "version_added": "64"
                   },
                   "ie": {
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "27"
+                    "version_added": "58"
                   },
                   "opera_android": {
-                    "version_added": true
+                    "version_added": "58"
                   },
                   "safari": {
-                    "version_added": "6.1"
+                    "version_added": null,
+                    "notes": "In Safari Technology Preview Release 66"
                   },
                   "safari_ios": {
-                    "version_added": true
+                    "version_added": null,
+                    "notes": "In Safari Technology Preview Release 66"
                   },
                   "samsunginternet_android": {
                     "version_added": true
                   },
                   "webview_android": {
-                    "version_added": "40"
+                    "version_added": "71"
                   }
                 },
                 "status": {


### PR DESCRIPTION
https://www.chromestatus.com/feature/5712111258828800
https://bugs.webkit.org/show_bug.cgi?id=186154

to make solid areas in css gradients you no longer have to declare a color stop twice, instead you declare it once but with two position values.