### PR TITLE
Updated availability of RTCDataChannel in Firefox

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -132,10 +132,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -183,10 +183,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -234,10 +234,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -285,10 +285,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -336,10 +336,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -387,10 +387,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -438,10 +438,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -489,10 +489,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -540,10 +540,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -591,10 +591,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -648,10 +648,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "60"
             },
             "ie": {
               "version_added": null
@@ -708,10 +708,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -759,10 +759,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -810,10 +810,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -861,10 +861,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -963,10 +963,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -1014,10 +1014,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -1116,10 +1116,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Firefox does support the DataChannel since a long time. In Firefox 60 the DataChannel got renamed to the spec compliant name RTCDataChannel. So pretty much all of the attributes are supported by Firefox in release.