### PR TITLE
add opera 57 release data

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -322,18 +322,23 @@
         "56": {
           "release_date": "2018-09-25",
           "release_notes": "https://dev.opera.com/blog/opera-56/",
-          "status": "current"
+          "status": "retired"
         },
         "57": {
-          "status": "beta"
+          "release_date": "2018-11-28",
+          "release_notes": "https://dev.opera.com/blog/opera-57/",
+          "status": "current"
         },
         "58": {
-          "status": "nightly"
+          "status": "beta"
         },
         "59": {
-          "status": "planned"
+          "status": "nightly"
         },
         "60": {
+          "status": "planned"
+        },
+        "61": {
           "status": "planned"
         }
       }


### PR DESCRIPTION
Opera just released a new desktop browser version

https://blogs.opera.com/desktop/2018/11/opera-57-stable