### PR TITLE
Fix typo in KeyboardEvent

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -431,7 +431,7 @@
             },
             "ie": {
               "version_added": "9",
-              "notes": "IE's impementation does not completely match the current spec because it is based on an older version of the spec."
+              "notes": "IE's implementation does not completely match the current spec because it is based on an older version of the spec."
             },
             "opera": {
               "version_added": "38"
@@ -482,7 +482,7 @@
               },
               "ie": {
                 "version_added": "9",
-                "notes": "IE's impementation does not completely match the current spec because it is based on an older version of the spec."
+                "notes": "IE's implementation does not completely match the current spec because it is based on an older version of the spec."
               },
               "opera": {
                 "version_added": "38"
@@ -534,7 +534,7 @@
               },
               "ie": {
                 "version_added": "9",
-                "notes": "IE's impementation does not completely match the current spec because it is based on an older version of the spec."
+                "notes": "IE's implementation does not completely match the current spec because it is based on an older version of the spec."
               },
               "opera": {
                 "version_added": "38"


### PR DESCRIPTION
Saw this on https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent 🙂