### PR TITLE
Revert "Revert "Bug 1487982: Rename `applications` to `browser_specific_settings`""

### DIFF
--- a/webextensions/manifest/browser_specific_settings.json
+++ b/webextensions/manifest/browser_specific_settings.json
@@ -1,16 +1,15 @@
 {
   "webextensions": {
     "manifest": {
-      "applications": {
+      "browser_specific_settings": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/applications",
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings",
           "support": {
             "chrome": {
               "version_added": false
             },
             "edge": {
-              "version_added": "15",
-              "alternative_name": "browser_specific_settings"
+              "version_added": "15"
             },
             "firefox": [
               {
@@ -18,7 +17,7 @@
               },
               {
                 "version_added": "48",
-                "alternative_name": "browser_specific_settings"
+                "alternative_name": "applications"
               }
             ],
             "firefox_android": [
@@ -27,7 +26,7 @@
               },
               {
                 "version_added": "48",
-                "alternative_name": "browser_specific_settings"
+                "alternative_name": "applications"
               }
             ],
             "opera": {


### PR DESCRIPTION
Reverts mdn/browser-compat-data#3122

Following&nbsp;https://github.com/mozilla/addons-server/pull/9990 and&nbsp;https://github.com/mozilla/addons-linter/pull/2296 being deployed to&nbsp;AMO production, it&nbsp;will once again be possible to update MDN to use `browser_compat_data`.

## See&nbsp;also
- https://github.com/mozilla/addons-server/issues/9989#issuecomment-439943147
- https://github.com/mozilla/addons-linter/issues/2280#issuecomment-442413066

---

review?(@irenesmith)