### PR TITLE
added chrome version supporting CSS "inset" property

### DIFF
--- a/css/properties/inset.json
+++ b/css/properties/inset.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "67"
             },
             "chrome_android": {
               "version_added": false


### PR DESCRIPTION
It is available to use CSS property "inset" in Chrome 67+ v.