### PR TITLE
fix(css): `cursor` property - Replace `true` with known versions

### DIFF
--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -15,7 +15,7 @@
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": null
             },
             "firefox": {
               "version_added": "1"
@@ -66,7 +66,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -117,7 +117,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -168,7 +168,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -219,7 +219,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "3"
@@ -271,7 +271,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1.5",
@@ -323,7 +323,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -374,7 +374,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -425,7 +425,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -476,7 +476,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -527,7 +527,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1.5"
@@ -578,7 +578,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -629,7 +629,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -680,7 +680,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1.5"
@@ -731,7 +731,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1.5"
@@ -782,7 +782,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1.5"
@@ -833,7 +833,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -884,7 +884,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1.5"
@@ -935,7 +935,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1.5"
@@ -986,7 +986,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1.5"
@@ -1037,7 +1037,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1.5"
@@ -1088,7 +1088,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1.5"
@@ -1139,7 +1139,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -1190,7 +1190,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1.5"
@@ -1247,7 +1247,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": [
                 {
@@ -1325,7 +1325,7 @@
                 "version_added": "14"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": [
                 {
@@ -1343,7 +1343,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": null
               },
               "opera_android": {
                 "version_added": null
@@ -1388,7 +1388,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": null
               },
               "firefox": {
                 "version_added": "1.5",
@@ -1401,7 +1401,7 @@
                 "version_added": "6"
               },
               "opera": {
-                "version_added": null
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": null
@@ -1431,7 +1431,7 @@
             "description": "<code>url()</code> positioning syntax",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
                 "version_added": null
@@ -1443,7 +1443,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1.5",
+                "notes": "Firefox 4 added macOS support."
               },
               "firefox_android": {
                 "version_added": null
@@ -1452,13 +1453,13 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": null
               },
               "safari": {
-                "version_added": true
+                "version_added": "3"
               },
               "safari_ios": {
                 "version_added": null


### PR DESCRIPTION
Part&nbsp;of https://github.com/mdn/browser-compat-data/issues/3126

I’ve changed **Edge&nbsp;Mobile** to `null` as&nbsp;mobile browsers don’t tend to&nbsp;support features which are&nbsp;primarily intended for&nbsp;desktop browsers.

Version information was gathered from “[Using&nbsp;URL values for the&nbsp;`cursor` property](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Basic_User_Interface/Using_URL_values_for_the_cursor_property#Browser_compatibility)”.

review?(@ddbeck, @Elchi3)