### PR TITLE
Update nodejs flatMap support - works in v11.2.0

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -599,7 +599,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "11.2.0"
               },
               "opera": {
                 "version_added": "56"


### PR DESCRIPTION
Hi. I can't google any official references, but `[].flatMap` does work in at least node `11.2.0`.