### PR TITLE
Adds getDisplayMedia() to MediaDevices

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -225,6 +225,75 @@
           }
         }
       },
+      "getDisplayMedia": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/getDisplayMedia",
+          "description": "<code>getDisplayMedia()</code>",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "70",
+                "version_removed": "72",
+                "alternative_name": "navigator.getDisplayMedia",
+                "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code> in Chrome 70 and 71."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "70",
+                "version_removed": "72",
+                "alternative_name": "navigator.getDisplayMedia",
+                "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code> in Chrome 70 and 71."
+              }
+            ],
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "However, since Firefox 33 you can capture screen data by calling <code>getUserMedia()</code>, specifying a <code>video</code> constraint called <code>mediaSource</code> with one of the values <code>screen</code>, <code>window</code>, or <code>application</code>."
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "70"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getUserMedia": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/getUserMedia",

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -230,28 +230,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/getDisplayMedia",
           "description": "<code>getDisplayMedia()</code>",
           "support": {
-            "chrome": [
-              {
-                "version_added": "72"
-              },
-              {
-                "version_added": "70",
-                "version_removed": "72",
-                "alternative_name": "navigator.getDisplayMedia",
-                "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code> in Chrome 70 and 71."
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "72"
-              },
-              {
-                "version_added": "70",
-                "version_removed": "72",
-                "alternative_name": "navigator.getDisplayMedia",
-                "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code> in Chrome 70 and 71."
-              }
-            ],
+            "chrome": {
+              "version_added": "70",
+              "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code> in Chrome 70 and 71."
+            },
+            "chrome_android": {
+              "version_added": "70",
+              "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code> in Chrome 70 and 71."
+            },
             "edge": {
               "version_added": true
             },
@@ -260,7 +246,7 @@
             },
             "firefox": {
               "version_added": false,
-              "notes": "However, since Firefox 33 you can capture screen data by calling <code>getUserMedia()</code>, specifying a <code>video</code> constraint called <code>mediaSource</code> with one of the values <code>screen</code>, <code>window</code>, or <code>application</code>."
+              "notes": "Since Firefox 33 you can capture screen data using <code><a href='https://developer.mozilla.org/docs/Web/API/MediaDevices/getUserMedia'>getUserMedia()</a></code>, with a <code>video</code> constraint called <code>mediaSource</code>."
             },
             "firefox_android": {
               "version_added": false
@@ -291,6 +277,58 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "audio-capture-support": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen_Capture_API/Using_Screen_Capture#Capturing_shared_audio",
+            "description": "Audio capture support",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },


### PR DESCRIPTION
This covers the addition of this method in Chrome 70,
as well as its existence in Edge and that there's another
way to do the same thing in Firefox (getDisplayMedia() is
coming soon).

Part of Chaka Khan (S4S3).