### PR TITLE
DocumentFragment() constructor is supported in Edge

### DIFF
--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -62,7 +62,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": true


### PR DESCRIPTION
This has been verified using Edge's browser console:

![image](https://user-images.githubusercontent.com/209270/49258474-dc398000-f435-11e8-802b-1a9f31501238.png)

Also `edge_mobile` already is `true`.