### PR TITLE
Add support info for Web APIs that node supports

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -909,9 +909,15 @@
             "ie": {
               "version_added": "8"
             },
-            "nodejs": {
-              "version_added": true
-            },
+            "nodejs": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": "9.3.0",
+                "alternative_name": "debug"
+              }
+            ],
             "opera": {
               "version_added": true
             },

--- a/api/Console.json
+++ b/api/Console.json
@@ -225,9 +225,6 @@
             "nodejs": {
               "version_added": "8.3.0"
             },
-            "nodejs": {
-              "version_added": "8.3.0"
-            },
             "opera": {
               "version_added": true
             },

--- a/api/Console.json
+++ b/api/Console.json
@@ -24,6 +24,9 @@
             "partial_implementation": true,
             "notes": "Only functions when developer tools are opened. Otherwise, the 'console' object is undefined."
           },
+          "nodejs": {
+            "version_added": "0.1.100"
+          },
           "opera": {
             "version_added": "10.1"
           },
@@ -67,6 +70,9 @@
             },
             "ie": {
               "version_added": true
+            },
+            "nodejs": {
+              "version_added": null
             },
             "opera": {
               "version_added": true
@@ -113,6 +119,16 @@
             "ie": {
               "version_added": true
             },
+            "nodejs": [
+              {
+                "version_added": "10.0.0"
+              },
+              {
+                "version_added": "0.1.101",
+                "partial_implementation": true,
+                "notes": "Throws error when assertion fails."
+              }
+            ],
             "opera": {
               "version_added": true
             },
@@ -158,6 +174,9 @@
             "ie": {
               "version_added": true
             },
+            "nodejs": {
+              "version_added": "8.3.0"
+            },
             "opera": {
               "version_added": true
             },
@@ -202,6 +221,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "8.3.0"
             },
             "nodejs": {
               "version_added": "8.3.0"
@@ -348,6 +370,9 @@
             "ie": {
               "version_added": "9"
             },
+            "nodejs": {
+              "version_added": "0.1.101"
+            },
             "opera": {
               "version_added": true
             },
@@ -393,6 +418,16 @@
             "ie": {
               "version_added": true
             },
+            "nodejs": [
+              {
+                "version_added": "9.3.0"
+              },
+              {
+                "version_added": "8.0.0",
+                "partial_implementation": true,
+                "notes": "Does not use Logger to log data."
+              }
+            ],
             "opera": {
               "version_added": true
             },
@@ -438,6 +473,9 @@
             "ie": {
               "version_added": "8"
             },
+            "nodejs": {
+              "version_added": true
+            },
             "opera": {
               "version_added": true
             },
@@ -482,6 +520,9 @@
               "ie": {
                 "version_added": "10",
                 "notes": "%c is not supported, %d will render as 0 when it is not a number"
+              },
+              "nodejs": {
+                "version_added": true
               },
               "opera": {
                 "version_added": null
@@ -530,6 +571,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": false
             },
@@ -572,6 +616,9 @@
                 "version_added": true
               },
               "ie": {
+                "version_added": false
+              },
+              "nodejs": {
                 "version_added": false
               },
               "opera": {
@@ -620,6 +667,9 @@
             "ie": {
               "version_added": "11"
             },
+            "nodejs": {
+              "version_added": "8.5.0"
+            },
             "opera": {
               "version_added": true
             },
@@ -664,6 +714,9 @@
             },
             "ie": {
               "version_added": "11"
+            },
+            "nodejs": {
+              "version_added": "8.5.0"
             },
             "opera": {
               "version_added": null
@@ -710,6 +763,9 @@
             "ie": {
               "version_added": "11"
             },
+            "nodejs": {
+              "version_added": "8.5.0"
+            },
             "opera": {
               "version_added": true
             },
@@ -754,6 +810,9 @@
             },
             "ie": {
               "version_added": "8"
+            },
+            "nodejs": {
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -801,6 +860,9 @@
                 "version_added": "10",
                 "notes": "%c is not supported, %d will render as 0 when it is not a number"
               },
+              "nodejs": {
+                "version_added": true
+              },
               "opera": {
                 "version_added": null
               },
@@ -846,6 +908,9 @@
             },
             "ie": {
               "version_added": "8"
+            },
+            "nodejs": {
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -893,6 +958,9 @@
               "ie": {
                 "version_added": "10",
                 "notes": "%c is not supported, %d will render as 0 when it is not a number"
+              },
+              "nodejs": {
+                "version_added": true
               },
               "opera": {
                 "version_added": null
@@ -941,6 +1009,15 @@
             "ie": {
               "version_added": true
             },
+            "nodejs": {
+              "version_added": "8.0.0",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--inspect"
+                }
+              ]
+            },
             "opera": {
               "version_added": null
             },
@@ -985,6 +1062,15 @@
             },
             "ie": {
               "version_added": true
+            },
+            "nodejs": {
+              "version_added": "8.0.0",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--inspect"
+                }
+              ]
             },
             "opera": {
               "version_added": null
@@ -1031,6 +1117,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "10.0.0"
+            },
             "opera": {
               "version_added": true
             },
@@ -1075,6 +1164,9 @@
             },
             "ie": {
               "version_added": "11"
+            },
+            "nodejs": {
+              "version_added": "0.1.104"
             },
             "opera": {
               "version_added": true
@@ -1121,6 +1213,9 @@
             "ie": {
               "version_added": "11"
             },
+            "nodejs": {
+              "version_added": "0.1.104"
+            },
             "opera": {
               "version_added": true
             },
@@ -1165,6 +1260,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "10.7.0"
             },
             "opera": {
               "version_added": "60"
@@ -1212,6 +1310,15 @@
             "ie": {
               "version_added": "11"
             },
+            "nodejs": {
+              "version_added": "8.0.0",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--inspect"
+                }
+              ]
+            },
             "opera": {
               "version_added": true
             },
@@ -1256,6 +1363,9 @@
             },
             "ie": {
               "version_added": "11"
+            },
+            "nodejs": {
+              "version_added": "0.1.104"
             },
             "opera": {
               "version_added": true
@@ -1302,6 +1412,9 @@
             "ie": {
               "version_added": "8"
             },
+            "nodejs": {
+              "version_added": true
+            },
             "opera": {
               "version_added": true
             },
@@ -1346,6 +1459,9 @@
               "ie": {
                 "version_added": "10",
                 "notes": "%c is not supported, %d will render as 0 when it is not a number"
+              },
+              "nodejs": {
+                "version_added": true
               },
               "opera": {
                 "version_added": null

--- a/api/Console.json
+++ b/api/Console.json
@@ -484,7 +484,6 @@
             },
             "nodejs": {
               "version_added": "0.1.100",
-              "alternative_name": "warn"
             },
             "opera": {
               "version_added": true
@@ -679,7 +678,6 @@
             },
             "nodejs": {
               "version_added": "8.5.0",
-              "alternative_name": "groupCollapsed"
             },
             "opera": {
               "version_added": true
@@ -824,7 +822,8 @@
               "version_added": "8"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.1.100",
+              "notes": "Alias for <code>console.log</code>"
             },
             "opera": {
               "version_added": true
@@ -873,8 +872,7 @@
                 "notes": "%c is not supported, %d will render as 0 when it is not a number"
               },
               "nodejs": {
-                "version_added": true,
-                "notes": "Alias for <code>console.log</code>"
+                "version_added": true
               },
               "opera": {
                 "version_added": null
@@ -922,16 +920,9 @@
             "ie": {
               "version_added": "8"
             },
-            "nodejs": [
-              {
-                "version_added": "0.1.100",
-                "alternative_name": "info"
-              },
-              {
-                "version_added": "9.3.0",
-                "alternative_name": "debug"
-              }
-            ],
+            "nodejs": {
+              "version_added": "0.1.100"
+            },
             "opera": {
               "version_added": true
             },

--- a/api/Console.json
+++ b/api/Console.json
@@ -71,9 +71,16 @@
             "ie": {
               "version_added": true
             },
-            "nodejs": {
-              "version_added": null
-            },
+            "nodejs": [
+              {
+                "version_added": "10.0.0"
+              },
+              {
+                "version_added": "0.1.101",
+                "partial_implementation": true,
+                "notes": "Throws error when assertion fails."
+              }
+            ],
             "opera": {
               "version_added": true
             },
@@ -119,16 +126,9 @@
             "ie": {
               "version_added": true
             },
-            "nodejs": [
-              {
-                "version_added": "10.0.0"
-              },
-              {
-                "version_added": "0.1.101",
-                "partial_implementation": true,
-                "notes": "Throws error when assertion fails."
-              }
-            ],
+            "nodejs": {
+              "version_added": "8.3.0"
+            },
             "opera": {
               "version_added": true
             },
@@ -270,6 +270,15 @@
             "ie": {
               "version_added": true
             },
+            "nodejs": [
+              {
+                "version_added": "8.10.0",
+                "notes": "Alias for <code>console.log</code>"
+              },
+              {
+                "version_added": "8.0.0"
+              }
+            ],
             "opera": {
               "version_added": null
             },
@@ -319,6 +328,9 @@
                   "<code>%c</code> is not supported.",
                   "<code>%d</code> outputs a 0 if the specified value isn't a number."
                 ]
+              },
+              "nodejs": {
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": null
@@ -471,7 +483,8 @@
               "version_added": "8"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100",
+              "alternative_name": "warn"
             },
             "opera": {
               "version_added": true
@@ -519,7 +532,7 @@
                 "notes": "%c is not supported, %d will render as 0 when it is not a number"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": null
@@ -665,7 +678,8 @@
               "version_added": "11"
             },
             "nodejs": {
-              "version_added": "8.5.0"
+              "version_added": "8.5.0",
+              "alternative_name": "groupCollapsed"
             },
             "opera": {
               "version_added": true
@@ -713,7 +727,8 @@
               "version_added": "11"
             },
             "nodejs": {
-              "version_added": "8.5.0"
+              "version_added": "8.5.0",
+              "notes": "Alias for <code>console.group</code>"
             },
             "opera": {
               "version_added": null
@@ -809,7 +824,7 @@
               "version_added": "8"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": true
@@ -858,7 +873,8 @@
                 "notes": "%c is not supported, %d will render as 0 when it is not a number"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Alias for <code>console.log</code>"
               },
               "opera": {
                 "version_added": null
@@ -908,7 +924,8 @@
             },
             "nodejs": [
               {
-                "version_added": true
+                "version_added": "0.1.100",
+                "alternative_name": "info"
               },
               {
                 "version_added": "9.3.0",
@@ -963,7 +980,7 @@
                 "notes": "%c is not supported, %d will render as 0 when it is not a number"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": null
@@ -1416,7 +1433,8 @@
               "version_added": "8"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100",
+              "notes": "Alias for <code>console.error</code>"
             },
             "opera": {
               "version_added": true
@@ -1464,7 +1482,7 @@
                 "notes": "%c is not supported, %d will render as 0 when it is not a number"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": null
@@ -1511,6 +1529,9 @@
             },
             "ie": {
               "version_added": true
+            },
+            "nodejs": {
+              "version_added": "10.5.0"
             },
             "opera": {
               "version_added": true

--- a/api/Console.json
+++ b/api/Console.json
@@ -483,7 +483,7 @@
               "version_added": "8"
             },
             "nodejs": {
-              "version_added": "0.1.100",
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": true
@@ -677,7 +677,7 @@
               "version_added": "11"
             },
             "nodejs": {
-              "version_added": "8.5.0",
+              "version_added": "8.5.0"
             },
             "opera": {
               "version_added": true

--- a/api/MessageChannel.json
+++ b/api/MessageChannel.json
@@ -22,6 +22,10 @@
           "ie": {
             "version_added": "10"
           },
+          "nodejs": {
+            "version_added": "10.5.0",
+            "notes": "Must be imported from the <code>worker_threads</code> module."
+          },
           "opera": {
             "version_added": "10.6"
           },
@@ -69,6 +73,10 @@
             },
             "ie": {
               "version_added": "10"
+            },
+            "nodejs": {
+              "version_added": "10.5.0",
+              "notes": "Must be imported from the <code>worker_threads</code> module."
             },
             "opera": {
               "version_added": "10.6"
@@ -118,6 +126,9 @@
             "ie": {
               "version_added": "10"
             },
+            "nodejs": {
+              "version_added": "10.5.0"
+            },
             "opera": {
               "version_added": "10.6"
             },
@@ -165,6 +176,9 @@
             },
             "ie": {
               "version_added": "10"
+            },
+            "nodejs": {
+              "version_added": "10.5.0"
             },
             "opera": {
               "version_added": "10.6"

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -22,6 +22,10 @@
           "ie": {
             "version_added": "10"
           },
+          "nodejs": {
+            "version_added": "10.5.0",
+            "notes": "Is a Node <code>EventEmitter</code> instead of DOM <code>EventTarget</code>."
+          },
           "opera": {
             "version_added": "10.6"
           },
@@ -68,6 +72,9 @@
             },
             "ie": {
               "version_added": "10"
+            },
+            "nodejs": {
+              "version_added": "10.5.0"
             },
             "opera": {
               "version_added": "10.6"
@@ -118,6 +125,11 @@
             "ie": {
               "version_added": "10"
             },
+            "nodejs": {
+              "version_added": "10.5.0",
+              "partial_implementation": true,
+              "notes": "Supports the event, but only via Node <code>EventEmitter</code>."
+            },
             "opera": {
               "version_added": "10.6"
             },
@@ -167,6 +179,9 @@
             "ie": {
               "version_added": null
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "47"
             },
@@ -214,6 +229,9 @@
             },
             "ie": {
               "version_added": "10"
+            },
+            "nodejs": {
+              "version_added": false
             },
             "opera": {
               "version_added": "10.6"
@@ -263,6 +281,9 @@
             "ie": {
               "version_added": null
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "47"
             },
@@ -310,6 +331,9 @@
             },
             "ie": {
               "version_added": "10"
+            },
+            "nodejs": {
+              "version_added": "10.5.0"
             },
             "opera": {
               "version_added": "10.6"
@@ -359,6 +383,9 @@
             "ie": {
               "version_added": "10"
             },
+            "nodejs": {
+              "version_added": "10.5.0"
+            },
             "opera": {
               "version_added": "10.6"
             },
@@ -405,6 +432,9 @@
               "version_added": "41"
             },
             "ie": {
+              "version_added": true
+            },
+            "nodejs": {
               "version_added": true
             },
             "opera": {

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -22,6 +22,14 @@
           "ie": {
             "version_added": "9"
           },
+          "nodejs": {
+            "version_added": "8.5.0",
+            "notes": [
+              "Stability: Experimental",
+              "Exported from the <code>perf_hooks</code> module"
+            ],
+            "partial_implementation": true
+          },
           "opera": {
             "version_added": "15"
           },
@@ -79,6 +87,9 @@
             },
             "ie": {
               "version_added": "10"
+            },
+            "nodejs": {
+              "version_added": "8.5.0"
             },
             "opera": {
               "version_added": "33"
@@ -139,6 +150,9 @@
             "ie": {
               "version_added": "10"
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "33"
             },
@@ -197,6 +211,9 @@
             },
             "ie": {
               "version_added": true
+            },
+            "nodejs": {
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -264,6 +281,9 @@
             "ie": {
               "version_added": true
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": false
             },
@@ -323,6 +343,9 @@
             "ie": {
               "version_added": true
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": false
             },
@@ -381,6 +404,9 @@
             },
             "ie": {
               "version_added": true
+            },
+            "nodejs": {
+              "version_added": false
             },
             "opera": [
               {
@@ -455,6 +481,9 @@
             "ie": {
               "version_added": "10"
             },
+            "nodejs": {
+              "version_added": "8.5.0"
+            },
             "opera": {
               "version_added": "33"
             },
@@ -514,6 +543,9 @@
             "ie": {
               "version_added": "10"
             },
+            "nodejs": {
+              "version_added": "8.5.0"
+            },
             "opera": {
               "version_added": "33"
             },
@@ -559,6 +591,9 @@
             "ie": {
               "version_added": null
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": true
             },
@@ -603,6 +638,9 @@
             },
             "ie": {
               "version_added": "9"
+            },
+            "nodejs": {
+              "version_added": false
             },
             "opera": {
               "version_added": "15"
@@ -666,6 +704,9 @@
             "ie": {
               "version_added": "10"
             },
+            "nodejs": {
+              "version_added": "8.5.0"
+            },
             "opera": {
               "version_added": "15"
             },
@@ -723,6 +764,9 @@
               "version_added": true
             },
             "ie": {
+              "version_added": false
+            },
+            "nodejs": {
               "version_added": false
             },
             "opera": {
@@ -792,6 +836,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": false
             },
@@ -858,6 +905,9 @@
             "ie": {
               "version_added": true
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": true
             },
@@ -910,6 +960,9 @@
             "ie": {
               "version_added": null
             },
+            "nodejs": {
+              "version_added": "8.5.0"
+            },
             "opera": {
               "version_added": "49"
             },
@@ -955,6 +1008,12 @@
             "ie": {
               "version_added": "9"
             },
+            "nodejs": {
+              "version_added": "8.5.0",
+              "alternative_name": "nodeTiming",
+              "partial_implementation": true,
+              "notes": "Returns node specific timing object"
+            },
             "opera": {
               "version_added": "15"
             },
@@ -999,6 +1058,9 @@
             },
             "ie": {
               "version_added": null
+            },
+            "nodejs": {
+              "version_added": false
             },
             "opera": {
               "version_added": false

--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -34,6 +34,10 @@
           "ie": {
             "version_added": true
           },
+          "nodejs": {
+            "version_added": "8.5.0",
+            "notes": "Stability: Experimental"
+          },
           "opera": {
             "version_added": "33"
           },
@@ -87,6 +91,9 @@
             "ie": {
               "version_added": true
             },
+            "nodejs": {
+              "version_added": null
+            },
             "opera": {
               "version_added": true
             },
@@ -134,6 +141,9 @@
             },
             "ie": {
               "version_added": true
+            },
+            "nodejs": {
+              "version_added": "8.5.0"
             },
             "opera": {
               "version_added": true
@@ -183,6 +193,9 @@
             "ie": {
               "version_added": true
             },
+            "nodejs": {
+              "version_added": "8.5.0"
+            },
             "opera": {
               "version_added": true
             },
@@ -230,6 +243,9 @@
             },
             "ie": {
               "version_added": true
+            },
+            "nodejs": {
+              "version_added": "8.5.0"
             },
             "opera": {
               "version_added": true
@@ -279,6 +295,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "8.5.0"
+            },
             "opera": {
               "version_added": true
             },
@@ -326,6 +345,9 @@
             },
             "ie": {
               "version_added": null
+            },
+            "nodejs": {
+              "version_added": false
             },
             "opera": {
               "version_added": "49"

--- a/api/PerformanceMark.json
+++ b/api/PerformanceMark.json
@@ -22,6 +22,9 @@
           "ie": {
             "version_added": "10"
           },
+          "nodejs": {
+            "version_added": "8.5.0"
+          },
           "opera": {
             "version_added": "33"
           },

--- a/api/PerformanceMeasure.json
+++ b/api/PerformanceMeasure.json
@@ -22,6 +22,9 @@
           "ie": {
             "version_added": "10"
           },
+          "nodejs": {
+            "version_added": "8.5.0"
+          },
           "opera": {
             "version_added": "33"
           },

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -22,6 +22,14 @@
           "ie": {
             "version_added": false
           },
+          "nodejs": {
+            "version_added": "8.5.0",
+            "notes": [
+              "Stability: Experimental",
+              "Exported from the <code>perf_hooks</code> module"
+            ],
+            "partial_implementation": true
+          },
           "opera": {
             "version_added": "39"
           },
@@ -66,6 +74,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": null
             },
             "opera": {
               "version_added": "39"
@@ -112,6 +123,11 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "8.5.0",
+              "notes": "Exported from the <code>perf_hooks</code> module",
+              "partial_implementation": true
+            },
             "opera": {
               "version_added": "39"
             },
@@ -156,6 +172,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "8.5.0"
             },
             "opera": {
               "version_added": "39"
@@ -202,6 +221,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "8.5.0"
+            },
             "opera": {
               "version_added": true
             },
@@ -245,6 +267,9 @@
               "version_added": "60"
             },
             "ie": {
+              "version_added": false
+            },
+            "nodejs": {
               "version_added": false
             },
             "opera": {
@@ -291,6 +316,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": null
             },
             "opera": {
               "version_added": "49"

--- a/api/PerformanceObserverEntryList.json
+++ b/api/PerformanceObserverEntryList.json
@@ -22,6 +22,10 @@
           "ie": {
             "version_added": false
           },
+          "nodejs": {
+            "version_added": "8.5.0",
+            "notes": "Stability: Experimental"
+          },
           "opera": {
             "version_added": "39"
           },
@@ -68,6 +72,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "8.5.0"
             },
             "opera": {
               "version_added": "39"
@@ -117,6 +124,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "8.5.0"
+            },
             "opera": {
               "version_added": "39"
             },
@@ -164,6 +174,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "8.5.0"
             },
             "opera": {
               "version_added": "39"

--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -36,6 +36,16 @@
           "ie": {
             "version_added": false
           },
+          "nodejs": [
+            {
+              "version_added": "11.0.0"
+            },
+            {
+              "version_added": "8.3.0",
+              "partial_implementation": true,
+              "notes": "Exported from the <code>util</code> module but not globally available."
+            }
+          ],
           "opera": {
             "version_added": "25"
           },
@@ -97,6 +107,9 @@
             ],
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": null
             },
             "opera": {
               "version_added": "25"
@@ -160,6 +173,15 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": [
+              {
+                "version_added": "11.0.0"
+              },
+              {
+                "version_added": "8.3.0",
+                "notes": "Exported from the <code>util</code> module but not globally available."
+              }
+            ],
             "opera": {
               "version_added": "25"
             },
@@ -222,6 +244,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "8.3.0"
+            },
             "opera": {
               "version_added": "25"
             },
@@ -269,6 +294,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "8.3.0"
             },
             "opera": {
               "version_added": true
@@ -318,6 +346,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "8.3.0"
+            },
             "opera": {
               "version_added": true
             },
@@ -365,6 +396,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "10.5.0"
             },
             "opera": {
               "version_added": "25"

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -34,6 +34,16 @@
           "ie": {
             "version_added": false
           },
+          "nodejs": [
+            {
+              "version_added": "11.0.0"
+            },
+            {
+              "version_added": "8.3.0",
+              "partial_implementation": true,
+              "notes": "Exported from the <code>util</code> module but not globally available."
+            }
+          ],
           "opera": {
             "version_added": "25"
           },
@@ -124,6 +134,15 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": [
+              {
+                "version_added": "11.0.0"
+              },
+              {
+                "version_added": "8.3.0",
+                "notes": "Exported from the <code>util</code> module but not globally available."
+              }
+            ],
             "opera": {
               "version_added": "25"
             },
@@ -184,6 +203,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "8.3.0"
+            },
             "opera": {
               "version_added": "25"
             },
@@ -231,6 +253,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": null
             },
             "opera": {
               "version_added": false
@@ -292,6 +317,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "8.3.0"
+            },
             "opera": {
               "version_added": "25"
             },
@@ -339,6 +367,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "10.5.0"
             },
             "opera": {
               "version_added": "25"

--- a/api/URL.json
+++ b/api/URL.json
@@ -236,7 +236,7 @@
                 "version_added": null
               },
               "nodejs": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null,

--- a/api/URL.json
+++ b/api/URL.json
@@ -42,6 +42,15 @@
           "ie": {
             "version_added": true
           },
+          "nodejs": [
+            {
+              "version_added": "10.0.0"
+            },
+            {
+              "version_added": "7.0.0",
+              "notes": "Has to be imported from the URL module."
+            }
+          ],
           "opera": [
             {
               "version_added": "19"
@@ -121,6 +130,9 @@
               "version_added": true,
               "version_removed": "11"
             },
+            "nodejs": {
+              "version_added": true
+            },
             "opera": {
               "version_added": true
             },
@@ -171,6 +183,9 @@
             "ie": {
               "version_added": "10"
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "15"
             },
@@ -218,6 +233,9 @@
                 "version_added": "62"
               },
               "ie": {
+                "version_added": null
+              },
+              "nodejs": {
                 "version_added": null
               },
               "opera": {
@@ -274,6 +292,9 @@
             "ie": {
               "version_added": null
             },
+            "nodejs": {
+              "version_added": true
+            },
             "opera": {
               "version_added": true
             },
@@ -321,6 +342,9 @@
             },
             "ie": {
               "version_added": null
+            },
+            "nodejs": {
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -370,6 +394,9 @@
             "ie": {
               "version_added": null
             },
+            "nodejs": {
+              "version_added": true
+            },
             "opera": {
               "version_added": true
             },
@@ -417,6 +444,9 @@
             },
             "ie": {
               "version_added": null
+            },
+            "nodejs": {
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -480,6 +510,9 @@
             "ie": {
               "version_added": null
             },
+            "nodejs": {
+              "version_added": true
+            },
             "opera": {
               "version_added": true
             },
@@ -527,6 +560,9 @@
             },
             "ie": {
               "version_added": null
+            },
+            "nodejs": {
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -590,6 +626,9 @@
             "ie": {
               "version_added": null
             },
+            "nodejs": {
+              "version_added": true
+            },
             "opera": {
               "version_added": true
             },
@@ -638,6 +677,9 @@
             "ie": {
               "version_added": null
             },
+            "nodejs": {
+              "version_added": true
+            },
             "opera": {
               "version_added": true
             },
@@ -685,6 +727,9 @@
             },
             "ie": {
               "version_added": null
+            },
+            "nodejs": {
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -735,6 +780,9 @@
             },
             "ie": {
               "version_added": "10"
+            },
+            "nodejs": {
+              "version_added": false
             },
             "opera": {
               "version_added": "15"
@@ -798,6 +846,9 @@
             "ie": {
               "version_added": null
             },
+            "nodejs": {
+              "version_added": true
+            },
             "opera": {
               "version_added": true
             },
@@ -846,6 +897,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "7.5.0"
+            },
             "opera": {
               "version_added": true
             },
@@ -893,6 +947,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -989,6 +1046,9 @@
             },
             "ie": {
               "version_added": null
+            },
+            "nodejs": {
+              "version_added": true
             },
             "opera": {
               "version_added": true

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -24,6 +24,15 @@
           "ie": {
             "version_added": false
           },
+          "nodejs": [
+            {
+              "version_added": "10.0.0"
+            },
+            {
+              "version_added": "7.5.0",
+              "notes": "Only available implicitly or as import from the URL module."
+            }
+          ],
           "opera": {
             "version_added": "36"
           },
@@ -72,6 +81,16 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": [
+              {
+                "version_added": "7.10.0"
+              },
+              {
+                "version_added": "7.5.0",
+                "partial_implementation": true,
+                "notes": "Only string as <code>init</code> object supported."
+              }
+            ],
             "opera": {
               "version_added": "36"
             },
@@ -119,6 +138,16 @@
               "ie": {
                 "version_added": false
               },
+              "nodejs": [
+                {
+                  "version_added": "7.10.0"
+                },
+                {
+                  "version_added": "7.5.0",
+                  "partial_implementation": true,
+                  "notes": "Only string as <code>init</code> object supported."
+                }
+              ],
               "opera": {
                 "version_added": "48"
               },
@@ -168,6 +197,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": true
+            },
             "opera": {
               "version_added": "36"
             },
@@ -215,6 +247,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": true
             },
             "opera": {
               "version_added": "36"
@@ -267,6 +302,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": true
             },
             "opera": {
               "version_added": "36"
@@ -364,6 +402,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": true
+            },
             "opera": {
               "version_added": "36"
             },
@@ -411,6 +452,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": true
             },
             "opera": {
               "version_added": "36"
@@ -460,6 +504,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": true
+            },
             "opera": {
               "version_added": "36"
             },
@@ -507,6 +554,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": true
             },
             "opera": {
               "version_added": "36"
@@ -556,6 +606,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": true
+            },
             "opera": {
               "version_added": "36"
             },
@@ -603,6 +656,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "7.7.0"
             },
             "opera": {
               "version_added": "48"
@@ -652,6 +708,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": true
+            },
             "opera": {
               "version_added": "36"
             },
@@ -699,6 +758,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": true
             },
             "opera": {
               "version_added": "36"

--- a/api/Window.json
+++ b/api/Window.json
@@ -1042,6 +1042,7 @@
             },
             "nodejs": {
               "version_added": "0.9.1",
+              "partial_implementation": true,
               "notes": "Takes an <code>Immediate</code> object instead of the <code>immediateID</code>."
             },
             "opera": {
@@ -8736,6 +8737,7 @@
             },
             "nodejs": {
               "version_added": "0.9.1",
+              "partial_implementation": true,
               "notes": "Returns an <code>Immediate</code> object instead of the <code>immediateID</code>."
             },
             "opera": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -1040,6 +1040,10 @@
             "ie": {
               "version_added": true
             },
+            "nodejs": {
+              "version_added": "0.9.1",
+              "notes": "Takes an <code>Immediate</code> object instead of the <code>immediateID</code>."
+            },
             "opera": {
               "version_added": false
             },
@@ -8729,6 +8733,10 @@
             },
             "ie": {
               "version_added": "10"
+            },
+            "nodejs": {
+              "version_added": "0.9.1",
+              "notes": "Returns an <code>Immediate</code> object instead of the <code>immediateID</code>."
             },
             "opera": {
               "version_added": false

--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -257,6 +257,11 @@
             "ie": {
               "version_added": "4"
             },
+            "nodejs": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Takes a <code>Timeout</code> object instead of the <code>intervalID</code>."
+            },
             "opera": {
               "version_added": "4"
             },
@@ -313,6 +318,11 @@
             ],
             "ie": {
               "version_added": "4"
+            },
+            "nodejs": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Takes a <code>Timeout</code> object instead of the <code>timeoutID</code>."
             },
             "opera": {
               "version_added": "4"
@@ -1089,6 +1099,14 @@
             "ie": {
               "version_added": "4"
             },
+            "nodejs": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": [
+                "Returns a <code>Timeout</code> object instead of the <code>intervalID</code>.",
+                "Does not support passing a <code>code</code> string and throws when the first parameter is not a function."
+              ]
+            },
             "opera": {
               "version_added": "4"
             },
@@ -1132,6 +1150,9 @@
               },
               "ie": {
                 "version_added": "10"
+              },
+              "nodejs": {
+                "version_added": true
               },
               "opera": {
                 "version_added": true
@@ -1191,6 +1212,14 @@
             "ie": {
               "version_added": "4"
             },
+            "nodejs": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": [
+                "Returns a <code>Timeout</code> object instead of the <code>timeoutID</code>.",
+                "Does not support passing a <code>code</code> string and throws when the first parameter is not a function."
+              ]
+            },
             "opera": {
               "version_added": "4"
             },
@@ -1235,6 +1264,9 @@
               "ie": {
                 "version_added": "10"
               },
+              "nodejs": {
+                "version_added": true
+              },
               "opera": {
                 "version_added": true
               },
@@ -1278,6 +1310,9 @@
                 "version_added": "55"
               },
               "ie": {
+                "version_added": null
+              },
+              "nodejs": {
                 "version_added": null
               },
               "opera": {

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -27,7 +27,7 @@
               "version_added": "11.7.0",
               "partial_implementation": true,
               "notes": [
-                "Is a Node EventEmitter instead of DOM EventTarget.",
+                "Is a Node <code>EventEmitter</code> instead of DOM <code>EventTarget</code>.",
                 "Worker script environment expects CommonJS modules.",
                 "Must be imported from the <code>worker_threads</code> module."
               ]
@@ -36,7 +36,7 @@
               "version_added": "10.5.0",
               "partial_implementation": true,
               "notes": [
-                "Is a Node EventEmitter instead of DOM EventTarget.",
+                "Is a Node <code>EventEmitter</code> instead of DOM <code>EventTarget</code>.",
                 "Worker script environment expects CommonJS modules.",
                 "Must be imported from the <code>worker_threads</code> module."
               ],
@@ -252,8 +252,9 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": false,
-              "notes": "Supports the event, but only via Node EventEmitter."
+              "version_added": "10.5.0",
+              "partial_implementation": true,
+              "notes": "Supports the event, but only via Node <code>EventEmitter</code>."
             },
             "opera": {
               "version_added": "10.6"

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -22,6 +22,32 @@
           "ie": {
             "version_added": "10"
           },
+          "nodejs": [
+            {
+              "version_added": "11.7.0",
+              "partial_implementation": true,
+              "notes": [
+                "Is a Node EventEmitter instead of DOM EventTarget.",
+                "Worker script environment expects CommonJS modules.",
+                "Must be imported from the <code>worker_threads</code> module."
+              ]
+            },
+            {
+              "version_added": "10.5.0",
+              "partial_implementation": true,
+              "notes": [
+                "Is a Node EventEmitter instead of DOM EventTarget.",
+                "Worker script environment expects CommonJS modules.",
+                "Must be imported from the <code>worker_threads</code> module."
+              ],
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--experimental-worker"
+                }
+              ]
+            }
+          ],
           "opera": {
             "version_added": "10.6"
           },
@@ -69,6 +95,11 @@
             },
             "ie": {
               "version_added": "10"
+            },
+            "nodejs": {
+              "version_added": "10.5.0",
+              "partial_implementation": true,
+              "notes": "Takes an entirely different options object."
             },
             "opera": {
               "version_added": "10.6"
@@ -165,6 +196,9 @@
               "ie": {
                 "version_added": false
               },
+              "nodejs": {
+                "version_added": false
+              },
               "opera": {
                 "version_added": "57"
               },
@@ -217,6 +251,10 @@
             "ie": {
               "version_added": "10"
             },
+            "nodejs": {
+              "version_added": false,
+              "notes": "Supports the event, but only via Node EventEmitter."
+            },
             "opera": {
               "version_added": "10.6"
             },
@@ -266,6 +304,9 @@
             "ie": {
               "version_added": null
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "47"
             },
@@ -314,6 +355,9 @@
             "ie": {
               "version_added": "10"
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "10.6"
             },
@@ -361,6 +405,9 @@
             },
             "ie": {
               "version_added": null
+            },
+            "nodejs": {
+              "version_added": false
             },
             "opera": {
               "version_added": "47"
@@ -411,6 +458,9 @@
               "version_added": "10",
               "notes": "Internet Explorer does not support <code>Transferable</code> objects."
             },
+            "nodejs": {
+              "version_added": "10.5.0"
+            },
             "opera": {
               "version_added": "47"
             },
@@ -458,6 +508,10 @@
             },
             "ie": {
               "version_added": "10"
+            },
+            "nodejs": {
+              "version_added": "10.5.0",
+              "notes": "Also takes an optional callback to be executed when the worker has terminated."
             },
             "opera": {
               "version_added": "10.6"

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -169,6 +169,10 @@
           "engine": "V8",
           "engine_version": "6.7"
         },
+        "10.5.0": {
+          "release_date": "2018-06-20",
+          "release_notes": "https://nodejs.org/en/blog/release/v10.5.0/"
+        },
         "10.7.0": {
           "release_date": "2018-07-18",
           "release_notes": "https://nodejs.org/en/blog/release/v10.7.0/"

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -75,6 +75,10 @@
           "engine": "V8",
           "engine_version": "5.4"
         },
+        "7.5.0": {
+          "release_date": "2017-01-31",
+          "release_notes": "https://nodejs.org/en/blog/release/v7.5.0/"
+        },
         "7.6.0": {
           "release_date": "2017-02-21",
           "release_notes": "https://nodejs.org/en/blog/release/v7.6.0/",
@@ -92,6 +96,14 @@
           "release_notes": "https://nodejs.org/en/blog/release/v7.10.0/",
           "engine": "V8",
           "engine_version": "5.5"
+        },
+        "7.7.0": {
+          "release_date": "2017-02-28",
+          "release_notes": "https://nodejs.org/en/blog/release/v7.7.0/"
+        },
+        "7.10.0": {
+          "release_date": "2017-05-02",
+          "release_notes": "https://nodejs.org/en/blog/release/v7.10.0/"
         },
         "8.0.0": {
           "release_date": "2017-05-30",

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -141,6 +141,10 @@
           "engine": "V8",
           "engine_version": "6.2"
         },
+        "9.3.0": {
+          "release_date": "2017-12-12",
+          "release_notes": "https://nodejs.org/en/blog/release/v9.3.0/"
+        },
         "10.0.0": {
           "release_date": "2018-04-24",
           "release_notes": "https://nodejs.org/en/blog/release/v10.0.0/",
@@ -164,6 +168,10 @@
           "release_notes": "https://nodejs.org/en/blog/release/v10.7.0/",
           "engine": "V8",
           "engine_version": "6.7"
+        },
+        "10.7.0": {
+          "release_date": "2018-07-18",
+          "release_notes": "https://nodejs.org/en/blog/release/v10.7.0/"
         },
         "10.9.0": {
           "release_date": "2018-08-16",

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -75,10 +75,6 @@
           "engine": "V8",
           "engine_version": "5.4"
         },
-        "7.5.0": {
-          "release_date": "2017-01-31",
-          "release_notes": "https://nodejs.org/en/blog/release/v7.5.0/"
-        },
         "7.6.0": {
           "release_date": "2017-02-21",
           "release_notes": "https://nodejs.org/en/blog/release/v7.6.0/",
@@ -96,14 +92,6 @@
           "release_notes": "https://nodejs.org/en/blog/release/v7.10.0/",
           "engine": "V8",
           "engine_version": "5.5"
-        },
-        "7.7.0": {
-          "release_date": "2017-02-28",
-          "release_notes": "https://nodejs.org/en/blog/release/v7.7.0/"
-        },
-        "7.10.0": {
-          "release_date": "2017-05-02",
-          "release_notes": "https://nodejs.org/en/blog/release/v7.10.0/"
         },
         "8.0.0": {
           "release_date": "2017-05-30",
@@ -141,10 +129,6 @@
           "engine": "V8",
           "engine_version": "6.2"
         },
-        "9.3.0": {
-          "release_date": "2017-12-12",
-          "release_notes": "https://nodejs.org/en/blog/release/v9.3.0/"
-        },
         "10.0.0": {
           "release_date": "2018-04-24",
           "release_notes": "https://nodejs.org/en/blog/release/v10.0.0/",
@@ -168,14 +152,6 @@
           "release_notes": "https://nodejs.org/en/blog/release/v10.7.0/",
           "engine": "V8",
           "engine_version": "6.7"
-        },
-        "10.5.0": {
-          "release_date": "2018-06-20",
-          "release_notes": "https://nodejs.org/en/blog/release/v10.5.0/"
-        },
-        "10.7.0": {
-          "release_date": "2018-07-18",
-          "release_notes": "https://nodejs.org/en/blog/release/v10.7.0/"
         },
         "10.9.0": {
           "release_date": "2018-08-16",


### PR DESCRIPTION
Node supports a couple of web APIs out of the box:

- `URL` is implemented to follow the whatwg spec
- `URLQueryParams` is implemented to follow the whatwg spec
- `console` follows the console spec too, afaik
- `setInterval`/`setTimeout` are very close to their web equivalent

I am aware that currently this information is not shown on MDN at all, since node is not enabled to be rendered in api/

---
## Table of all the APIs and corresponding node docs:
| API | Node documentation |
|------|---------------------------|
| `URL` | https://nodejs.org/api/url.html#url_the_whatwg_url_api and https://nodejs.org/api/globals.html#globals_url |
| `URLSearchParams` | https://nodejs.org/api/url.html#url_class_urlsearchparams and https://nodejs.org/api/globals.html#globals_urlsearchparams |
| `console` | https://nodejs.org/api/console.html and https://nodejs.org/api/globals.html#globals_console |
| `setInterval` | https://nodejs.org/api/timers.html#timers_setinterval_callback_delay_args and https://nodejs.org/api/globals.html#globals_setinterval_callback_delay_args |
| `setTimeout` | https://nodejs.org/api/timers.html#timers_settimeout_callback_delay_args and https://nodejs.org/api/globals.html#globals_settimeout_callback_delay_args |
| `clearInterval` | https://nodejs.org/api/timers.html#timers_clearinterval_timeout and https://nodejs.org/api/globals.html#globals_clearinterval_intervalobject |
| `clearTimeout` | https://nodejs.org/api/timers.html#timers_cleartimeout_timeout and https://nodejs.org/api/globals.html#globals_cleartimeout_timeoutobject |
| `setImmediate` | https://nodejs.org/api/timers.html#timers_setimmediate_callback_args and https://nodejs.org/api/globals.html#globals_setimmediate_callback_args |
| `clearImmediate` | https://nodejs.org/api/timers.html#timers_clearimmediate_immediate and https://nodejs.org/api/globals.html#globals_clearimmediate_immediateobject |
| `TextDecoder` | https://nodejs.org/api/util.html#util_class_util_textdecoder and https://nodejs.org/api/globals.html#globals_textdecoder |
| `TextEncoder` | https://nodejs.org/api/util.html#util_class_util_textencoder and https://nodejs.org/api/globals.html#globals_textencoder |
| Performance API (not listing those out) | https://nodejs.org/api/perf_hooks.html |
| `Worker`, `Message*` | https://nodejs.org/api/worker_threads.html#worker_threads_class_messagechannel and onward |