### PR TITLE
Update desktop Edge compability data for URLSearchParams

### DIFF
--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -114,7 +114,7 @@
                 "version_added": "61"
               },
               "edge": {
-                "version_added": null
+                "version_added": 17
               },
               "edge_mobile": {
                 "version_added": null
@@ -268,7 +268,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": 17
             },
             "edge_mobile": {
               "version_added": null
@@ -472,7 +472,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": 17
             },
             "edge_mobile": {
               "version_added": null
@@ -625,7 +625,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": 17
             },
             "edge_mobile": {
               "version_added": null
@@ -676,7 +676,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": 17
             },
             "edge_mobile": {
               "version_added": null


### PR DESCRIPTION
The data updated with accordance to http://docs.w3cub.com/browser_support_tables/urlsearchparams/