### PR TITLE
Update nodejs flatMap support - works in v11.0.0

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -64,6 +64,10 @@
         "10.9.0": {
           "release_date": "2018-08-16",
           "release_notes": "https://nodejs.org/en/blog/release/v10.9.0/"
+        },
+        "11.0.0": {
+          "release_date": "2018-10-23",
+          "release_notes": "https://nodejs.org/en/blog/release/v11.0.0/"
         }
       }
     }

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -599,7 +599,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "11.0.0"
               },
               "opera": {
                 "version_added": "56"


### PR DESCRIPTION
Hi. I can't google any official references, but `[].flatMap` does work in at least node `11.0.0`.

@ddbeck, I'm re-opening the https://github.com/mdn/browser-compat-data/pull/3151 with discused fixes.