### PR TITLE
Document.hasFocus, ChildNode.remove are not supported by Opera 12.18

### DIFF
--- a/api/ChildNode.json
+++ b/api/ChildNode.json
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "10"
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": "10"

--- a/api/Document.json
+++ b/api/Document.json
@@ -4203,7 +4203,7 @@
               "version_added": "6"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true


### PR DESCRIPTION
I've tested these 2 methods in Opera 12.18 (Presto) and they are not supported. I did not test the support in Opera 15 (Blink).

This might apply to Opera Mobile (opera_android) as well, but I didn't test it.

Note that Presto docs claim compatibility. #2678 was based on those docs. There might be more incorrect compat data based on those docs.

I also have a general concern about Opera Presto and Blink sharing the same compat id. While Presto definitely deserves its place in the table (being one of the very few browser engines), Opera Blink simply reflects the Chrome column, like myriads of other Chrome clones.