### PR TITLE
Update Public key pinning

### DIFF
--- a/http/headers/content-security-policy-report-only.json
+++ b/http/headers/content-security-policy-report-only.json
@@ -6,10 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only",
           "support": {
             "chrome": {
-              "version_added": "25"
+              "version_added": "25",
+              "version_removed": "72"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "72"
             },
             "edge": {
               "version_added": "14"

--- a/http/headers/public-key-pins.json
+++ b/http/headers/public-key-pins.json
@@ -25,7 +25,7 @@
               "version_added": "35"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -34,10 +34,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true

--- a/http/headers/public-key-pins.json
+++ b/http/headers/public-key-pins.json
@@ -6,10 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Public-Key-Pins",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "72"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "72"
             },
             "edge": {
               "version_added": false,
@@ -57,10 +59,12 @@
             "description": "report-uri",
             "support": {
               "chrome": {
-                "version_added": "46"
+                "version_added": "46",
+                "version_removed": "72"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "72"
               },
               "edge": {
                 "version_added": null


### PR DESCRIPTION
Tested on:
  - Safari 12.0.1 on macOS High Sierra 10.13.6
  - Safari on iOS 12.1
  - IE 11.407.17134.0 on Windows 10

Tested with https://projects.dm.id.lv/Public-Key-Pins_test