### PR TITLE
Add getStats() to RTC interfaces.

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2899,10 +2899,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getStats",
           "support": {
             "chrome": {
-              "version_added": "67"
+              "version_added": "58"
             },
             "chrome_android": {
-              "version_added": "67"
+              "version_added": "58"
             },
             "edge": {
               "version_added": null
@@ -2920,10 +2920,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "54"
+              "version_added": "45"
             },
             "opera_android": {
-              "version_added": "54"
+              "version_added": "45"
             },
             "safari": {
               "version_added": null
@@ -2935,13 +2935,64 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "67"
+              "version_added": "58"
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "MediaStreamTrack_argument": {
+          "__compat": {
+            "description": "Optional <code>MediaStreamTrack</code> argument.",
+            "support": {
+              "chrome": {
+                "version_added": "67"
+              },
+              "chrome_android": {
+                "version_added": "67"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "54"
+              },
+              "opera_android": {
+                "version_added": "54"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": "67"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2989,7 +2989,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2946,7 +2946,7 @@
         },
         "MediaStreamTrack_argument": {
           "__compat": {
-            "description": "Optional <code>MediaStreamTrack</code> argument.",
+            "description": "Optional <code>MediaStreamTrack</code> argument",
             "support": {
               "chrome": {
                 "version_added": "67"

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2894,6 +2894,57 @@
           }
         }
       },
+      "getStats": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getStats",
+          "support": {
+            "chrome": {
+              "version_added": "67"
+            },
+            "chrome_android": {
+              "version_added": "67"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "54"
+            },
+            "opera_android": {
+              "version_added": "54"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "67"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getStreamById": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getStreamById",

--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -426,10 +426,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/getStats",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "58"
+              "version_added": "67"
             },
             "edge": {
               "version_added": null
@@ -447,10 +447,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "45"
+              "version_added": "54"
             },
             "opera_android": {
-              "version_added": "45"
+              "version_added": "54"
             },
             "safari": {
               "version_added": null
@@ -462,7 +462,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": "55"
+              "version_added": "67"
             }
           },
           "status": {

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -106,10 +106,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender/getStats",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "67"
             },
             "edge": {
               "version_added": null
@@ -127,10 +127,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "54"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "54"
             },
             "safari": {
               "version_added": null
@@ -142,7 +142,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "67"
             }
           },
           "status": {


### PR DESCRIPTION
This addresses issue #2497.

The weirdness in the number had to do with the feature being behind a test flag. This method shipped and the flag taken away with [this commit](https://chromium.googlesource.com/chromium/src/+/fe8a5e81a3b68c6b3c388728288591165a5a8c63) which [landed in Chrome 67](https://storage.googleapis.com/chromium-find-releases-static/fe8.html#fe8a5e81a3b68c6b3c388728288591165a5a8c63).

I apologize for the delay on this. This got lost in my inbox.