### PR TITLE
scroll-snap-stop is not implemented anywhere

### DIFF
--- a/css/properties/scroll-snap-stop.json
+++ b/css/properties/scroll-snap-stop.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-stop",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -27,10 +27,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "56"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -42,7 +42,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
This was flagged as being in Chrome, but I do not believe it is implemented. See Chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=823998