### PR TITLE
Lookbehind has no firefox support

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -738,7 +738,7 @@
                 "version_added": null
               },
               "nodejs": {
-                "version_added": 9
+                "version_added": null
               },
               "opera": {
                 "version_added": "49"

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -729,10 +729,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": null

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -723,7 +723,7 @@
                 "version_added": "62"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -738,7 +738,7 @@
                 "version_added": null
               },
               "nodejs": {
-                "version_added": null
+                "version_added": 9
               },
               "opera": {
                 "version_added": "49"


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1225665, https://github.com/Microsoft/ChakraCore/issues/3448 and https://node.green/
