### PR TITLE
Web API: PerformanceNavigation - Correct to Show as Unsupported in Firefox

### DIFF
--- a/api/PerformanceNavigation.json
+++ b/api/PerformanceNavigation.json
@@ -67,7 +67,8 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": false
+              "version_added": "7",
+              "notes": "This property can return incorrect values. See <a href='https://bugzil.la/1459711'>bug 1459711</a>."
             },
             "firefox_android": {
               "version_added": false

--- a/api/PerformanceNavigation.json
+++ b/api/PerformanceNavigation.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": "7"
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": "7"
+            "version_added": false
           },
           "ie": {
             "version_added": "9"
@@ -67,10 +67,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "7"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "7"
+              "version_added": false
             },
             "ie": {
               "version_added": "9"
@@ -118,10 +118,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "7"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "7"
+              "version_added": false
             },
             "ie": {
               "version_added": "9"
@@ -169,10 +169,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "25"
+              "version_added": false
             },
             "ie": {
               "version_added": "9"

--- a/api/PerformanceNavigation.json
+++ b/api/PerformanceNavigation.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": false
+            "version_added": "7"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "7"
           },
           "ie": {
             "version_added": "9"
@@ -119,10 +119,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": false
+              "version_added": "7"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "7"
             },
             "ie": {
               "version_added": "9"
@@ -170,10 +170,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "25",
+              "notes": "This property can return incorrect values. See <a href='https://bugzil.la/1459711'>bug 1459711</a>."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "25",
+              "notes": "This property can return incorrect values. See <a href='https://bugzil.la/1459711'>bug 1459711</a>."
             },
             "ie": {
               "version_added": "9"

--- a/api/PerformanceNavigation.json
+++ b/api/PerformanceNavigation.json
@@ -71,7 +71,8 @@
               "notes": "This property can return incorrect values. See <a href='https://bugzil.la/1459711'>bug 1459711</a>."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "7",
+              "notes": "This property can return incorrect values. See <a href='https://bugzil.la/1459711'>bug 1459711</a>."
             },
             "ie": {
               "version_added": "9"


### PR DESCRIPTION
Firefox does not support this. Please see: https://bugzilla.mozilla.org/show_bug.cgi?id=1459711