### PR TITLE
Update URLSearchParams for Safari

### DIFF
--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -88,7 +88,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -138,7 +138,7 @@
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": null
@@ -190,7 +190,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -242,7 +242,8 @@
               "partial_implementation": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true,
+              "partial_implementation": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -293,7 +294,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -344,7 +345,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -395,7 +396,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -446,7 +447,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -497,7 +498,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -548,7 +549,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -599,7 +600,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -650,7 +651,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -701,7 +702,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -240,12 +240,12 @@
             "safari": {
               "version_added": true,
               "partial_implementation": true,
-              "note": "Removing a non-existent query parameter doesn't remove <code>?</code> from the URL. See <a href='https://bugs.webkit.org/show_bug.cgi?id=193022'>bug 193022</a>."
+              "notes": "Removing a non-existent query parameter doesn't remove <code>?</code> from the URL. See <a href='https://bugs.webkit.org/show_bug.cgi?id=193022'>bug 193022</a>."
             },
             "safari_ios": {
               "version_added": true,
               "partial_implementation": true,
-              "note": "Removing a non-existent query parameter doesn't remove <code>?</code> from the URL. See <a href='https://bugs.webkit.org/show_bug.cgi?id=193022'>bug 193022</a>."
+              "notes": "Removing a non-existent query parameter doesn't remove <code>?</code> from the URL. See <a href='https://bugs.webkit.org/show_bug.cgi?id=193022'>bug 193022</a>."
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -85,7 +85,7 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
@@ -135,7 +135,7 @@
                 "version_added": "48"
               },
               "safari": {
-                "version_added": null
+                "version_added": true
               },
               "safari_ios": {
                 "version_added": null
@@ -187,7 +187,7 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
@@ -238,7 +238,8 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": true,
+              "partial_implementation": true
             },
             "safari_ios": {
               "version_added": null
@@ -289,7 +290,7 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
@@ -340,7 +341,7 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
@@ -391,7 +392,7 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
@@ -442,7 +443,7 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
@@ -493,7 +494,7 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
@@ -544,7 +545,7 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
@@ -595,7 +596,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
@@ -646,7 +647,7 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
@@ -697,7 +698,7 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -239,11 +239,13 @@
             },
             "safari": {
               "version_added": true,
-              "partial_implementation": true
+              "partial_implementation": true,
+              "note": "Removing a non-existent query parameter doesn't remove <code>?</code> from the URL. See <a href='https://bugs.webkit.org/show_bug.cgi?id=193022'>bug 193022</a>."
             },
             "safari_ios": {
               "version_added": true,
-              "partial_implementation": true
+              "partial_implementation": true,
+              "note": "Removing a non-existent query parameter doesn't remove <code>?</code> from the URL. See <a href='https://bugs.webkit.org/show_bug.cgi?id=193022'>bug 193022</a>."
             },
             "samsunginternet_android": {
               "version_added": null


### PR DESCRIPTION
Features are tested with [test suites provided by W3C](https://w3c-test.org/url/). [One test](https://w3c-test.org/url/urlsearchparams-delete.any.html) is failing in Safari 12.0.2 in macOS High Sierra (10.13.6).

Todo:
 - [x] Update Safari on iOS