### PR TITLE
basic CSS Font API from 2014 is well supported and not experimental.

### DIFF
--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -26,23 +26,23 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": "22"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "22"
           },
           "safari": {
-            "version_added": null
+            "version_added": "10"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "10"
           },
           "webview_android": {
             "version_added": "37"
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -74,23 +74,23 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "22"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10"
             },
             "webview_android": {
               "version_added": "37"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
the API has at least basic support, and is supported in Opera, Chrome, Safari and FF, so is not experimental anymore.