### PR TITLE
updating experimental/standard status of onbeforeinstallprompt

### DIFF
--- a/api/BeforeInstallPromptEvent.json
+++ b/api/BeforeInstallPromptEvent.json
@@ -45,8 +45,8 @@
           }
         },
         "status": {
-          "experimental": false,
-          "standard_track": false,
+          "experimental": true,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -96,8 +96,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": false,
+            "experimental": true,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -147,7 +147,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": false,
             "deprecated": false
           }
@@ -198,8 +198,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": false,
+            "experimental": true,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -249,8 +249,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": false,
+            "experimental": true,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
If you check the spec, most of this stuff is clearly specced, with the exception of the platforms property: https://w3c.github.io/manifest/#beforeinstallpromptevent-interface