### PR TITLE
Deprecation and non-standard were removed

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -1988,7 +1988,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -2000,16 +2000,16 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
@@ -2020,8 +2020,6 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
This method neither deprecated nor non-standard.
 It does work in Edge, IE, and Safari.