### PR TITLE
Add addons-linter as a user of BCD

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,4 @@ Here are some projects using the data, as an [npm module](https://www.npmjs.com/
 * [mdncomp](https://github.com/epistemex/mdncomp) - View compatibility data on the command line.
 * [Browser Compatibility Data Explorer](https://github.com/connorshea/mdn-compat-data-explorer) - View, search, and visualize data from the compatibility dataset.
 * [Visual Studio Code](https://code.visualstudio.com) - Shows the compatibility information in [the code completion popup](https://code.visualstudio.com/updates/v1_25#_improved-accuracy-of-browser-compatibility-data).
+* [Add-ons Linter](https://github.com/mozilla/addons-linter) - the Add-ons Linter is used on [addons.mozilla.org](https://addons.mozilla.org/) and the [web-ext](https://github.com/mozilla/web-ext/) tool. It uses browser-compat-data to check that the Firefox version that the add-on lists support for does in fact support the APIs used by the add-on.


### PR DESCRIPTION
The Firefox addons-linter uses now BCD -> https://github.com/mozilla/addons-linter/pull/2290. At Florian's request, this PR adds that fact to the README.