### PR TITLE
Media constraint and setting updates for Screen Capture

### DIFF
--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -208,10 +208,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/cursor",
           "support": {
             "chrome": {
-              "version_added": "71"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "71"
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -304,10 +304,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/displaySurface",
           "support": {
             "chrome": {
-              "version_added": "71"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "71"
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -640,10 +640,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/logicalSurface",
           "support": {
             "chrome": {
-              "version_added": "71"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "71"
+              "version_added": false
             },
             "edge": {
               "version_added": null

--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -203,6 +203,54 @@
           }
         }
       },
+      "cursor": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/cursor",
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "71"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "71"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "deviceId": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/deviceId",
@@ -242,6 +290,54 @@
             },
             "webview_android": {
               "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "displaySurface": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/displaySurface",
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "71"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "71"
             }
           },
           "status": {
@@ -530,6 +626,54 @@
             },
             "webview_android": {
               "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "logicalSurface": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/logicalSurface",
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "71"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "71"
             }
           },
           "status": {

--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -85,7 +85,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -241,7 +241,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "71"
+              "version_added": false
             }
           },
           "status": {
@@ -337,7 +337,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "71"
+              "version_added": false
             }
           },
           "status": {
@@ -673,7 +673,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "71"
+              "version_added": false
             }
           },
           "status": {

--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/aspectRatio",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": null
@@ -85,7 +85,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -160,10 +160,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/channelCount",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": null
@@ -193,7 +193,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -256,10 +256,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/deviceId",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": null
@@ -289,7 +289,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -352,10 +352,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/echoCancellation",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": null
@@ -385,7 +385,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -400,10 +400,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/facingMode",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": null
@@ -433,7 +433,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -448,10 +448,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/frameRate",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": null
@@ -481,7 +481,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -496,10 +496,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/groupId",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": null
@@ -529,7 +529,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -544,10 +544,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/height",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": null
@@ -577,7 +577,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -592,10 +592,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/latency",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": null
@@ -625,7 +625,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -748,10 +748,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/sampleRate",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": null
@@ -781,7 +781,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -796,10 +796,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/sampleSize",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": null
@@ -829,7 +829,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -844,10 +844,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/volume",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": null
@@ -877,7 +877,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -892,10 +892,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/width",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": null
@@ -925,7 +925,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {

--- a/api/MediaTrackSettings.json
+++ b/api/MediaTrackSettings.json
@@ -303,7 +303,7 @@
       },
       "displaySurface": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSettings/displaySettings",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSettings/displaySurface",
           "support": {
             "chrome": {
               "version_added": "71"

--- a/api/MediaTrackSettings.json
+++ b/api/MediaTrackSettings.json
@@ -205,6 +205,54 @@
           }
         }
       },
+      "cursor": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSettings/cursor",
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "71"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "71"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "deviceId": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSettings/deviceId",
@@ -244,6 +292,54 @@
             },
             "webview_android": {
               "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "displaySurface": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSettings/displaySettings",
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "71"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "71"
             }
           },
           "status": {
@@ -532,6 +628,54 @@
             },
             "webview_android": {
               "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "logicalSurface": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSettings/logicalSurface",
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "71"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "71"
             }
           },
           "status": {

--- a/api/MediaTrackSettings.json
+++ b/api/MediaTrackSettings.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSettings",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "59"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "59"
           },
           "edge": {
             "version_added": null
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "webview_android": {
-            "version_added": null
+            "version_added": "59"
           }
         },
         "status": {

--- a/api/MediaTrackSupportedConstraints.json
+++ b/api/MediaTrackSupportedConstraints.json
@@ -191,6 +191,102 @@
           }
         }
       },
+      "cursor": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSupportedConstraints/cursor",
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "71"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "71"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "displaySurface": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSettings/displaySurface",
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "71"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "71"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "frameRate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSupportedConstraints/frameRate",
@@ -278,6 +374,54 @@
             },
             "webview_android": {
               "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "logicalSurface": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSettings/logicalSurface",
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "71"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "71"
             }
           },
           "status": {

--- a/api/MediaTrackSupportedConstraints.json
+++ b/api/MediaTrackSupportedConstraints.json
@@ -229,7 +229,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "71"
+              "version_added": false
             }
           },
           "status": {
@@ -277,7 +277,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "71"
+              "version_added": false
             }
           },
           "status": {
@@ -421,7 +421,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "71"
+              "version_added": false
             }
           },
           "status": {

--- a/api/MediaTrackSupportedConstraints.json
+++ b/api/MediaTrackSupportedConstraints.json
@@ -196,10 +196,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSupportedConstraints/cursor",
           "support": {
             "chrome": {
-              "version_added": "71"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "71"
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -244,10 +244,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSettings/displaySurface",
           "support": {
             "chrome": {
-              "version_added": "71"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "71"
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -388,10 +388,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSettings/logicalSurface",
           "support": {
             "chrome": {
-              "version_added": "71"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "71"
+              "version_added": false
             },
             "edge": {
               "version_added": null


### PR DESCRIPTION
Updated MediaTrackConstraints, MediaTrackSettings, and
MediaTrackSupportedConstraints to include the new
cursor, displaySurface, and logicalSurface properties
added by the Screen Capture API. Currently only supported
in Chrome 71.