### PR TITLE
Bug 1512386: Implement case‑sensitive attribute selectors (`s`)

### DIFF
--- a/css/selectors/attribute.json
+++ b/css/selectors/attribute.json
@@ -120,12 +120,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1512386'>bug 1512386</a>."
+                "version_added": "66"
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1512386'>bug 1512386</a>."
+                "version_added": "66"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
See [bug&nbsp;1512386](https://bugzilla.mozilla.org/show_bug.cgi?id=1512386) for details.

---

review?(@ddbeck, @Elchi3)

See&nbsp;also: https://github.com/mdn/browser-compat-data/pull/3179