### PR TITLE
Update RTCRtpSender.setParameters for Firefox

### DIFF
--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -474,12 +474,24 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
+            "firefox": [
+              {
+                "version_added": "64",
+                "notes": "Changes to parameters which should be changeable after initial creation of the <code>RTCRtpSender</code> now work as expected."
+              },
+              {
+                "version_added": "46"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "64",
+                "notes": "Changes to parameters which should be changeable after initial creation of the <code>RTCRtpSender</code> now work as expected."
+              },
+              {
+                "version_added": "46"
+              }
+            ],
             "ie": {
               "version_added": null
             },

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -104,6 +104,7 @@
       "getStats": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender/getStats",
+          "description": "<code>getStats()</code>",
           "support": {
             "chrome": {
               "version_added": "67"
@@ -308,6 +309,7 @@
       "getCapabilities": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender/getCapabilities",
+          "description": "<code>getCapabilities()</code>",
           "support": {
             "chrome": {
               "version_added": null
@@ -359,6 +361,7 @@
       "getParameters": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender/getParameters",
+          "description": "<code>getParameters()</code>",
           "support": {
             "chrome": {
               "version_added": "67"
@@ -410,6 +413,7 @@
       "replaceTrack": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender/replaceTrack",
+          "description": "<code>replaceTrack()</code>",
           "support": {
             "chrome": {
               "version_added": "65"
@@ -461,6 +465,7 @@
       "setParameters": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender/setParameters",
+          "description": "<code>setParameters()</code>",
           "support": {
             "chrome": {
               "version_added": null
@@ -477,7 +482,7 @@
             "firefox": [
               {
                 "version_added": "64",
-                "notes": "Changes to parameters which should be changeable after initial creation of the <code>RTCRtpSender</code> now work as expected."
+                "notes": "Changes to parameters that should update live now do so starting in Firefox 64."
               },
               {
                 "version_added": "46"
@@ -486,7 +491,7 @@
             "firefox_android": [
               {
                 "version_added": "64",
-                "notes": "Changes to parameters which should be changeable after initial creation of the <code>RTCRtpSender</code> now work as expected."
+                "notes": "Changes to parameters that should update live now do so starting in Firefox 64."
               },
               {
                 "version_added": "46"


### PR DESCRIPTION
This method was added in Firefox 46 and live-updating
of values was added in Firefox 64.

I've also added `description` properties to each method so that they render in tables as `methodname()` the way they should.

https://bugzilla.mozilla.org/show_bug.cgi?id=1230184 (Addition of setParameters() in FIrefox 46)
https://bugzilla.mozilla.org/show_bug.cgi?id=1253499 (live updating support added in Firefox 64)