### PR TITLE
api.Node.removeChild is standard and non-deprecated

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -2020,8 +2020,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
"deprecated": set to FALSE
"standard_track": set to TRUE