### PR TITLE
Mark the Clipboard API as unsupported in Edge and IE

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -11,10 +11,10 @@
             "version_added": "66"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "edge_mobile": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": "63"
@@ -23,7 +23,7 @@
             "version_added": "63"
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": "53"
@@ -61,10 +61,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "63",
@@ -89,7 +89,7 @@
               "notes": "Currently works just like <code>readText()</code>; non-text content is not currently supported."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -128,10 +128,10 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "63",
@@ -142,7 +142,7 @@
               "notes": "Firefox only supports reading the clipboard in browser extensions, using the <code>\"clipboardRead\"</code> extension permission."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "53"
@@ -181,10 +181,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "63",
@@ -209,7 +209,7 @@
               "notes": "Currently works exactly like <code>writeText()</code>, including the availability limitations currently imposed by Firefox."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -248,10 +248,10 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "63",
@@ -262,7 +262,7 @@
               "notes": "Writing to the clipboard is available without permission in secure contexts and browser extensions, but only from user-initiated event callbacks. Browser extensions with the <code>\"clipboardWrite\"</code> permission can write to the clipboard at any time."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "53"


### PR DESCRIPTION
According to https://developer.microsoft.com/en-us/microsoft-edge/platform/catalog/?q=specName%3Aclipboard-apis, Edge only support the ClipboardEvent, not Clipboard.

https://developer.microsoft.com/en-us/microsoft-edge/platform/status/clipboardapi/ does not distinguish the 2 APIs and so marks it as shipped, but it is only a partial implementation being shipped.

I haven't updated the Safari data based on that source, as I'm not sure it can be trusted for non-MS browsers (Firefox is marked as unsupported there for instance, which is not the case anymore).