### PR TITLE
Add MediaStreamAudioSourceOptions dictionary

### DIFF
--- a/api/MediaStreamAudioSourceOptions.json
+++ b/api/MediaStreamAudioSourceOptions.json
@@ -1,0 +1,106 @@
+{
+  "api": {
+    "MediaStreamAudioSourceOptions": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamAudioSourceOptions",
+        "support": {
+          "chrome": {
+            "version_added": "55"
+          },
+          "chrome_android": {
+            "version_added": "55"
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "53"
+          },
+          "firefox_android": {
+            "version_added": "53"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "15"
+          },
+          "opera_android": {
+            "version_added": "15"
+          },
+          "safari": {
+            "version_added": "6"
+          },
+          "safari_ios": {
+            "version_added": null
+          },
+          "samsunginternet_android": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": "55"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "mediaStream": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamAudioSourceOptions/mediaStream",
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "55"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "55"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Data for Firefox comes from:

https://hg.mozilla.org/mozilla-central/annotate/c2593a3058afdfeaac5c990e18794ee8257afe99/dom/webidl/MediaStreamAudioSourceNode.webidl#l

Data for Chrome comes from:

https://chromium.googlesource.com/chromium/src/+blame/HEAD/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_options.idl