### PR TITLE
fix(webext): Firefox required `applications` before version 48

### DIFF
--- a/webextensions/manifest/browser_action.json
+++ b/webextensions/manifest/browser_action.json
@@ -57,7 +57,7 @@
               },
               "edge": {
                 "version_added": false,
-                "notes": "Microsoft Edge instead uses the <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/applications#Microsoft_Edge_properties'><code>browser_action_next_to_addressbar</code> property</a> of the <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/applications'><code>browser_specific_settings</code> manifest key</a>"
+                "notes": "Microsoft Edge instead uses the <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#Microsoft_Edge_properties'><code>browser_action_next_to_addressbar</code> property</a> of the <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings'><code>browser_specific_settings</code> manifest key</a>"
               },
               "firefox": {
                 "version_added": "54"

--- a/webextensions/manifest/browser_specific_settings.json
+++ b/webextensions/manifest/browser_specific_settings.json
@@ -16,8 +16,9 @@
                 "version_added": "48"
               },
               {
-                "version_added": "48",
-                "alternative_name": "applications"
+                "version_added": "42",
+                "alternative_name": "applications",
+                "notes": "Mandatory before Firefox 48."
               }
             ],
             "firefox_android": [
@@ -25,8 +26,9 @@
                 "version_added": "48"
               },
               {
-                "version_added": "48",
-                "alternative_name": "applications"
+                "version_added": "42",
+                "alternative_name": "applications",
+                "notes": "Mandatory before Firefox 48."
               }
             ],
             "opera": {


### PR DESCRIPTION
This also updates the link in `browser_action`.

review?(@wbamberg)