### PR TITLE
Opera still supports @keyframes

### DIFF
--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -84,8 +84,7 @@
             },
             "opera": [
               {
-                "version_added": "12.1",
-                "version_removed": "15"
+                "version_added": "12.1"
               },
               {
                 "prefix": "-webkit-",

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -84,11 +84,15 @@
             },
             "opera": [
               {
-                "version_added": "12.1"
+                "version_added": "30"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",


### PR DESCRIPTION
Looks like a typo in the data. The examples from https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations still work in the latest version of Opera.