### PR TITLE
Bug 903372: Remove support for xml:base

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
         "/svg/*.json",
         "/webdriver/*.json",
         "/webextensions/*.json",
+        "/xml/*.json",
         "/xpath/*.json",
         "/xslt/*.json",
       ],

--- a/.vscode/snippets.code-snippets
+++ b/.vscode/snippets.code-snippets
@@ -4,7 +4,7 @@
     "prefix": ["bcd", "browser-compat"],
     "body": [
       "{",
-      "  \"${1|api,css,html,http,javascript,mathml,svg,webdriver,webextensions,xpath,xslt|}\": {",
+      "  \"${1|api,css,html,http,javascript,mathml,svg,webdriver,webextensions,xml,xpath,xslt|}\": {",
       "    \"${2:${TM_FILENAME_BASE}}\": {",
       "      \"__compat\": {",
       "        \"mdn_url\": \"${3:mdn-url}\",",

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ JSON file containing the compatibility data.
 
 - [webextensions/](https://github.com/mdn/browser-compat-data/tree/master/webextensions) contains data for [WebExtensions](https://developer.mozilla.org/en-US/Add-ons/WebExtensions) JavaScript APIs and manifest keys.
 
+- [xml/](https://github.com/mdn/browser-compat-data/tree/master/xml) contains data for [XML](https://developer.mozilla.org/docs/Web/XML) attributes.
+
 - [xpath/](https://github.com/mdn/browser-compat-data/tree/master/xpath) contains data for [XPath](https://developer.mozilla.org/docs/Web/XPath) axes, and functions.
 
 - [xslt/](https://github.com/mdn/browser-compat-data/tree/master/xslt) contains data for [XSLT](https://developer.mozilla.org/docs/Web/XSLT) elements, attributes, and global attributes.

--- a/index.d.ts
+++ b/index.d.ts
@@ -328,6 +328,12 @@ interface CompatData extends Record<Exclude<string, 'browsers'>, Identifier> {
   webextensions: Identifier;
 
   /**
+   * Contains data for [XML](https://developer.mozilla.org/docs/Web/XML)
+   * attributes.
+   */
+  xml: Identifier;
+
+  /**
    * Contains data for [XPath](https://developer.mozilla.org/docs/Web/XPath)
    * axes, and functions.
    */

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ module.exports = load(
   'svg',
   'webdriver',
   'webextensions',
+  'xml',
   'xpath',
   'xslt',
 );

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -27,6 +27,8 @@ JSON files containing the compatibility data.
 
 - [webextensions/](https://github.com/mdn/browser-compat-data/tree/master/webextensions) contains data for [WebExtensions](https://developer.mozilla.org/en-US/Add-ons/WebExtensions) JavaScript APIs and manifest keys.
 
+- [xml/](https://github.com/mdn/browser-compat-data/tree/master/xml) contains data for [XML](https://developer.mozilla.org/docs/Web/XML) attributes.
+
 - [xpath/](https://github.com/mdn/browser-compat-data/tree/master/xpath) contains data for [XPath](https://developer.mozilla.org/docs/Web/XPath) axes, and functions.
 
 - [xslt/](https://github.com/mdn/browser-compat-data/tree/master/xslt) contains data for [XSLT](https://developer.mozilla.org/docs/Web/XSLT) elements, attributes, and global attributes.

--- a/test/lint.js
+++ b/test/lint.js
@@ -97,6 +97,7 @@ if (argv.files) {
     'test',
     'webdriver',
     'webextensions',
+    'xml',
     'xpath',
     'xslt',
   );

--- a/xml/attributes/base.json
+++ b/xml/attributes/base.json
@@ -8,11 +8,11 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "version_removed": true
+              "version_removed": "45"
             },
             "chrome_android": {
               "version_added": true,
-              "version_removed": true
+              "version_removed": "45"
             },
             "firefox": {
               "version_added": true,
@@ -24,15 +24,15 @@
             },
             "opera": {
               "version_added": true,
-              "version_removed": true
+              "version_removed": "32"
             },
             "opera_android": {
               "version_added": true,
-              "version_removed": true
+              "version_removed": "32"
             },
             "webview_android": {
               "version_added": true,
-              "version_removed": true
+              "version_removed": "45"
             }
           },
           "status": {

--- a/xml/attributes/base.json
+++ b/xml/attributes/base.json
@@ -36,9 +36,9 @@
             }
           },
           "status": {
-            "deprecated": true,
             "experimental": false,
-            "standard_track": false
+            "standard_track": true,
+            "deprecated": true
           }
         }
       }

--- a/xml/attributes/base.json
+++ b/xml/attributes/base.json
@@ -1,0 +1,47 @@
+{
+  "xml": {
+    "attributes": {
+      "base": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/XML_Introduction/xml:base",
+          "description": "xml:base",
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "version_removed": true
+            },
+            "chrome_android": {
+              "version_added": true,
+              "version_removed": true
+            },
+            "firefox": {
+              "version_added": true,
+              "version_removed": "66"
+            },
+            "firefox_android": {
+              "version_added": true,
+              "version_removed": "66"
+            },
+            "opera": {
+              "version_added": true,
+              "version_removed": true
+            },
+            "opera_android": {
+              "version_added": true,
+              "version_removed": true
+            },
+            "webview_android": {
+              "version_added": true,
+              "version_removed": true
+            }
+          },
+          "status": {
+            "deprecated": true,
+            "experimental": false,
+            "standard_track": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/xml/attributes/base.json
+++ b/xml/attributes/base.json
@@ -3,7 +3,7 @@
     "attributes": {
       "base": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/XML_Introduction/xml:base",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/XML/xml:base",
           "description": "xml:base",
           "support": {
             "chrome": {


### PR DESCRIPTION
See [bug&nbsp;903372](https://bugzilla.mozilla.org/show_bug.cgi?id=903372) for details.

review?(@Elchi3)
needinfo?(@jpmedley): In which version of **Google&nbsp;Chrome** was this removed ([Chromium&nbsp;bug&nbsp;341854](https://bugs.chromium.org/p/chromium/issues/detail?id=341854))?