### PR TITLE
Avoid line ending inconsistencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.json text eol=lf

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -2,6 +2,17 @@
 const fs = require('fs');
 const path = require('path');
 
+function escapeInvisibles(str) {
+  const invisibles = [['\b', '\\b'], ['\f', '\\f'], ['\n', '\\n'], ['\r', '\\r'], ['\v', '\\v'], ['\0', '\\']];
+  let finalString = str;
+
+  invisibles.forEach(([invisible, replacement]) => {
+    finalString = finalString.replace(invisible, replacement);
+  });
+
+  return finalString;
+}
+
 function jsonDiff(actual, expected) {
   var actualLines = actual.split(/\n/);
   var expectedLines = expected.split(/\n/);
@@ -10,8 +21,8 @@ function jsonDiff(actual, expected) {
     if (actualLines[i] !== expectedLines[i]) {
       return [
         '#' + (i + 1) + '\x1b[0m',
-        '    Actual:   ' + actualLines[i],
-        '    Expected: ' + expectedLines[i]
+        '    Actual:   ' + escapeInvisibles(actualLines[i]),
+        '    Expected: ' + escapeInvisibles(expectedLines[i]),
       ].join('\n');
     }
   }

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -3,7 +3,15 @@ const fs = require('fs');
 const path = require('path');
 
 function escapeInvisibles(str) {
-  const invisibles = [['\b', '\\b'], ['\f', '\\f'], ['\n', '\\n'], ['\r', '\\r'], ['\v', '\\v'], ['\0', '\\0']];
+  const invisibles = [
+    ['\b', '\\b'],
+    ['\f', '\\f'],
+    ['\n', '\\n'],
+    ['\r', '\\r'],
+    ['\v', '\\v'],
+    ['\t', '\\t'],
+    ['\0', '\\0'],
+  ];
   let finalString = str;
 
   invisibles.forEach(([invisible, replacement]) => {

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 
 function escapeInvisibles(str) {
-  const invisibles = [['\b', '\\b'], ['\f', '\\f'], ['\n', '\\n'], ['\r', '\\r'], ['\v', '\\v'], ['\0', '\\']];
+  const invisibles = [['\b', '\\b'], ['\f', '\\f'], ['\n', '\\n'], ['\r', '\\r'], ['\v', '\\v'], ['\0', '\\0']];
   let finalString = str;
 
   invisibles.forEach(([invisible, replacement]) => {


### PR DESCRIPTION
Prompted by #3224, this PR replaces line endings and some other invisible characters in the linter diff output with their respective escape sequences.

For example, if you have CRLF line endings in a JSON file, then the resulting linter diff makes it seem as if both the expected and actual lines are the same.

Unfortunately, I suspect my implementation is rather naive. I really want to believe there's some kind of regex trickery that would generalize this to any invisible character. I did some fruitless searching, then gave up and did the simplest thing that worked for me. 🤷‍♂️
