### PR TITLE
Fix typo in preference name

### DIFF
--- a/css/properties/scrollbar-color.json
+++ b/css/properties/scrollbar-color.json
@@ -27,7 +27,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "layout.css.scrollbar-colors.enabled",
+                    "name": "layout.css.scrollbar-color.enabled",
                     "value_to_set": "true"
                   }
                 ]
@@ -42,7 +42,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "layout.css.scrollbar-colors.enabled",
+                    "name": "layout.css.scrollbar-color.enabled",
                     "value_to_set": "true"
                   }
                 ]


### PR DESCRIPTION
Issue:
The listed about:config flag is not correct. In the current version of Firefox, it is `layout.css.scrollbar-color.enabled` rather than `layout.css.scrollbar-colors.enabled`.
<img width="965" alt="screen shot" src="https://user-images.githubusercontent.com/1479244/50368517-5c876880-053e-11e9-8b12-f440e39fb683.png">
