### PR TITLE
Map.prototype[@@toStringTag] exists it Firefox

### DIFF
--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -1065,10 +1065,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Since Firefox 51: https://bugzilla.mozilla.org/show_bug.cgi?id=1114580
