### PR TITLE
Update animateMotion.json for basic Safari compatibility

### DIFF
--- a/svg/elements/animateMotion.json
+++ b/svg/elements/animateMotion.json
@@ -33,7 +33,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null


### PR DESCRIPTION
Tested with Safari 12 on macOS Mojave. Animation motion clearly visible.