### PR TITLE
fix(css): update edge support table for basic-shape and shape-outside

### DIFF
--- a/css/properties/shape-outside.json
+++ b/css/properties/shape-outside.json
@@ -12,10 +12,10 @@
               "version_added": "37"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -89,10 +89,10 @@
                 "version_added": "37"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": [
                 {
@@ -167,10 +167,10 @@
                 "version_added": "37"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": [
                 {
@@ -245,10 +245,10 @@
                 "version_added": "37"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": [
                 {
@@ -323,10 +323,10 @@
                 "version_added": "37"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": [
                 {
@@ -401,10 +401,10 @@
                 "version_added": "37"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": [
                 {

--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -13,10 +13,10 @@
               "version_added": "37"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "61",
@@ -78,10 +78,10 @@
                 "version_added": "37"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "61",
@@ -144,10 +144,10 @@
                 "version_added": "37"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "61",
@@ -210,10 +210,10 @@
                 "version_added": "37"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "61",
@@ -280,10 +280,10 @@
                 "notes": "Only supported on the <code>offset-path</code> property."
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "63",
@@ -358,10 +358,10 @@
                 "version_added": "37"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "61",


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] **Summarize your changes**
  This PR updates the edge support table for basic-shape and shape-outside CSS properties. Edge doesn't support either, but the compat table showed this as 'data not available'. I tested this on Edge (Windows 10, 1809), and it is not implemented till now.
- [x] **Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)**
  + https://developer.microsoft.com/en-us/microsoft-edge/platform/status/?q=shape
  + https://developer.microsoft.com/en-us/microsoft-edge/platform/catalog/?q=specName%3Acss-shapes-1
- [x] **Data: if you tested something, describe how you tested with details like browser and version**
  Go to these resources in Edge:
  + https://developer.mozilla.org/en-US/docs/Web/CSS/shape-outside
  + https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape
  Edge doesn't render any of the examples.
- [x] **Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)**
  Lint passed successfully
- [ ] **Link to related issues or pull requests, if any**
  N/A