### PR TITLE
New BCD for image() CSS function notation.

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1506,7 +1506,7 @@
         "conic-gradient": {
           "__compat": {
             "description": "<code>conic-gradient()</code>",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/conic-gradient",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/conic-gradient()",
             "support": {
               "chrome": [
                 {
@@ -1558,12 +1558,10 @@
                 "version_added": "56"
               },
               "safari": {
-                "version_added": null,
-                "notes": "In Safari Technology Preview Release 66"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null,
-                "notes": "In Safari Technology Preview Release 66"
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -1640,6 +1638,58 @@
                 "standard_track": true,
                 "deprecated": false
               }
+            }
+          }
+        },
+        "image": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/_image",
+            "description": "<code>image()</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1659,7 +1659,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=703217'>Bugzilla 703217</a>"
               },
               "firefox_android": {
                 "version_added": false
@@ -1674,7 +1675,9 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=72584'>WebKit bug 72584</a>"
+           
               },
               "safari_ios": {
                 "version_added": false

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1660,7 +1660,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=703217'>Bugzilla 703217</a>"
+                "notes": "See <a href='https://bugzil.la/703217'>bug 703217</a>"
               },
               "firefox_android": {
                 "version_added": false
@@ -1677,7 +1677,6 @@
               "safari": {
                 "version_added": false,
                 "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=72584'>WebKit bug 72584</a>"
-           
               },
               "safari_ios": {
                 "version_added": false


### PR DESCRIPTION
MDN URL: 
https://developer.mozilla.org/en-US/docs/Web/CSS/_image
note: ../CSS/image is already <image>, so the underscore is intentional.

Bugzilla DDN:
https://bugzilla.mozilla.org/show_bug.cgi?id=703217


