### PR TITLE
Update AbortController Safari compatibility

### DIFF
--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -32,10 +32,18 @@
             "version_added": "53"
           },
           "safari": {
-            "version_added": "11.1"
+            "version_added": "11.1",
+            "partial_implementation": true,
+            "notes": [
+              "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://bugs.webkit.org/show_bug.cgi?id=174980'>bug 174980</a>."
+            ]
           },
           "safari_ios": {
-            "version_added": "11.1"
+            "version_added": "11.1",
+            "partial_implementation": true,
+            "notes": [
+              "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://bugs.webkit.org/show_bug.cgi?id=174980'>bug 174980</a>."
+            ]
           },
           "samsunginternet_android": {
             "version_added": false


### PR DESCRIPTION
According to https://bugs.webkit.org/show_bug.cgi?id=174980, while `AbortController` is present, and `fetch` will take an `AbortSignal`, it will never actually abort the request. This affects Safari and iOS Safari.

A quick test like http://temp.minimum.se/abort-native.html (from a comment in the ticket) proves this is indeed the case. I tested on macOS with Safari 12 and on latest iOS.

See also https://caniuse.com/#feat=abortcontroller.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
