### PR TITLE
Update env() support in Chrome for Desktop

### DIFF
--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -177,7 +177,7 @@
             "description": "<code>env()</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "69"
               },
               "chrome_android": {
                 "version_added": "69"


### PR DESCRIPTION
According to this Chromium bug:
https://bugs.chromium.org/p/chromium/issues/detail?id=860604
Initial Chrome 69 release brought env custom properties support, but without defining the safe-area variables. Later fix added default values of 0px on Desktop too:
https://chromium.googlesource.com/chromium/src.git/+/817ca3d4d1ddf5e8571bb79eccf8d73f6efa65c3
If I'm reading this correctly, this fix landed directly in release?
https://storage.googleapis.com/chromium-find-releases-static/817.html#817ca3d4d1ddf5e8571bb79eccf8d73f6efa65c3

Tested in Chrome 71:
* using env() with existing custom variable and no fallback does nothing, but the spec is not very clear about definitions
* using env() with existing custom variable triggers the fallback
* using env() with non-existing custom variable triggers the fallback
* using env() with env(safe-area-inset-top) doesn't trigger the fallback, outputs 0

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
