### PR TITLE
Safari iOS cannot enter multiple email addresses

### DIFF
--- a/html/elements/input/email.json
+++ b/html/elements/input/email.json
@@ -41,6 +41,7 @@
                 "version_added": "3.1",
                 "notes": [
                   "Doesn't do validation, but instead offers a custom 'email' keyboard, which is designed to make entering email addresses easier.",
+                  "The custom 'email' keyboard does not provide a comma key, so users cannot enter multiple email addresses.",
                   "Automatically applies a default style of <code>opacity: 0.4</code> to disable textual <code>&lt;input&gt;</code> elements, including those of type 'email'. Other major browsers don't currently share this particular default style."
                 ]
               },


### PR DESCRIPTION
I noticed that the Safari iOS e-mail keyboard doesn't allow users to enter a comma character to separate multiple e-mail addresses. A workaround is to paste the comma (or the entire value), but this is not usable for the majority of users.

I checked this myself on an iPhone 7 running iOS 12.1.2. I also sent a bug report to the Safari team.