### PR TITLE
scroll-behavior compatibility for Chrome/Opera

### DIFF
--- a/css/properties/scroll-behavior.json
+++ b/css/properties/scroll-behavior.json
@@ -6,17 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-behavior",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Enable experimental web platform features",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "61"
             },
             "edge": {
               "version_added": false
@@ -34,17 +27,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Smooth Scrolling",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
According to the [ChromeStatus Page](https://www.chromestatus.com/features/5812155903377408) Chrome 61 supports `scroll-behavior` property in CSS (CSSOM View smooth scroll API) by default without any flag.
 Moreover, according to the same site Opera supports it only from the Opera 48 version.