### PR TITLE
Fix Chrome compatibility data of ServiceWorkerContainer.getRegistrations

### DIFF
--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -508,10 +508,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/getRegistrations",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": "45"
             },
             "edge": [
               {


### PR DESCRIPTION
The [old table at MDN page](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/getRegistrations$revision/1319389) states that it is only supported on Chrome 45 onwards

This error has been there since initial PR #1011

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any 
