### PR TITLE
[Firefox] Add RTCDataChannel.maxRetransmits and .maxPacketLifeTime

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -387,10 +387,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "62"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "ie": {
               "version_added": false
@@ -438,10 +438,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "62"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Firefox supports both the `maxRetransmits` and `maxPacketLifeTime` properties on `RTCDataChannel`.

The issue which added these properties in Firefox 62:

https://bugzilla.mozilla.org/show_bug.cgi?id=1464917