### PR TITLE
Mark dynamic import as supported in FF66 behind a flag

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1854,12 +1854,24 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1342012'>bug 1342012</a>."
+                "version_added": "66",
+                "flags": [
+                  {
+                    "name": "javascript.options.dynamicImport",
+                    "type": "preference"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1517546'>bug 1517546</a>."
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1342012'>bug 1342012</a>."
+                "version_added": "66",
+                "flags": [
+                  {
+                    "name": "javascript.options.dynamicImport",
+                    "type": "preference"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1517546'>bug 1517546</a>."
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This feature has now landed in bug 1342012 but is disabled by default behind a pref.  I updated the notes to reference bug 1517546 which tracks enabling it.
