### PR TITLE
418 is supported.

### DIFF
--- a/http/status.json
+++ b/http/status.json
@@ -971,6 +971,21 @@
           }
         }
       },
+      "418": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418",
+          "support": {
+            "chrome": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "425": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/425",


### PR DESCRIPTION
I don't know why it isn't in here, considering the fact that it is supported by Chrome, and is official.  I have not tested the status code elsewhere.

A checklist to help your pull request get merged faster:
- I added code 418 (I am a teapot) to the support list
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418 is where this should end up living
- I tested it with Chrome v70, and got 
`<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>418 I'm a teapot</title>
<h1>I'm a teapot</h1>`

