### PR TITLE
fix(html): Mark <nobr> as supported in all browsers

### DIFF
--- a/html/elements/nobr.json
+++ b/html/elements/nobr.json
@@ -6,48 +6,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/nobr",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": true
             },
             "firefox": {
-              "version_added": false
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true
             },
             "ie": {
-              "version_added": false
+              "version_added": true
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }


### PR DESCRIPTION
Given that [`<nobr>`](https://developer.mozilla.org/docs/Web/HTML/Element/nobr) is&nbsp;one of&nbsp;the&nbsp;oldest HTML&nbsp;elements, its&nbsp;support matrix is&nbsp;likely similar to&nbsp;that of&nbsp;other legacy HTML&nbsp;elements.

Fixes&nbsp;https://github.com/mdn/browser-compat-data/issues/3240

---

**P.S.:** `<nobr>` is&nbsp;defined at&nbsp;https://html.spec.whatwg.org/multipage/obsolete.html#nobr

review?(@ddbeck, @Elchi3)