### PR TITLE
Add the supported regions pref for Firefox to PaymentItem

### DIFF
--- a/api/PaymentItem.json
+++ b/api/PaymentItem.json
@@ -32,21 +32,33 @@
           },
           "firefox": {
             "version_added": "55",
+            "notes": "Available only in nightly builds.",
             "flags": [
               {
                 "type": "preference",
                 "name": "dom.payments.request.enabled",
                 "value_to_set": "true"
+              },
+              {
+                "name": "dom.payments.request.supportedRegions",
+                "type": "preference",
+                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
               }
             ]
           },
           "firefox_android": {
             "version_added": "55",
+            "notes": "Available only in nightly builds.",
             "flags": [
               {
                 "type": "preference",
                 "name": "dom.payments.request.enabled",
                 "value_to_set": "true"
+              },
+              {
+                "name": "dom.payments.request.supportedRegions",
+                "type": "preference",
+                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
               }
             ]
           },

--- a/api/PaymentItem.json
+++ b/api/PaymentItem.json
@@ -42,7 +42,7 @@
               {
                 "name": "dom.payments.request.supportedRegions",
                 "type": "preference",
-                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
+                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
               }
             ]
           },
@@ -58,7 +58,7 @@
               {
                 "name": "dom.payments.request.supportedRegions",
                 "type": "preference",
-                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
+                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
               }
             ]
           },


### PR DESCRIPTION
This adds the dom.payments.request.supportedRegions
preference to the PaymentItem interface for Firefox.

Used the fact that all of Payment Request is influenced by that flag as covered by previous PRs to determine that it should be added here. Tested using `npm test` and confirmed that at least `npm run render api.PaymentItem` outputs a table as valid as possible given its limitations.
