### PR TITLE
Update SVGImageElement

### DIFF
--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/decode",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": "65"
             },
             "chrome_android": {
-              "version_added": "66"
+              "version_added": "65"
             },
             "edge": {
               "version_added": null
@@ -133,7 +133,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "66"
+              "version_added": "65"
             }
           },
           "status": {
@@ -148,10 +148,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/decoding",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": "65"
             },
             "chrome_android": {
-              "version_added": "66"
+              "version_added": "65"
             },
             "edge": {
               "version_added": null
@@ -181,7 +181,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "66"
+              "version_added": "65"
             }
           },
           "status": {

--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
             "version_added": true
@@ -47,11 +47,156 @@
           "deprecated": false
         }
       },
-      "x": {
+      "crossOrigin": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/crossOrigin",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "decode": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/decode",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "decoding": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/decoding",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "height": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/height",
+          "support": {
+            "chrome": {
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -94,11 +239,60 @@
           }
         }
       },
-      "y": {
+      "href": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/href",
           "support": {
             "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
               "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "preserveAspectRatio": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/prserveAspectRatio",
+          "support": {
+            "chrome": {
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -143,9 +337,10 @@
       },
       "width": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/width",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -188,11 +383,12 @@
           }
         }
       },
-      "height": {
+      "x": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/x",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -235,11 +431,12 @@
           }
         }
       },
-      "preserveAspectRatio": {
+      "y": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/y",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -273,53 +470,6 @@
             },
             "webview_android": {
               "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "crossOrigin": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
* [decode/decoding were enabled](https://storage.googleapis.com/chromium-find-releases-static/fcf.html#fcf63eae9e6a3b12b096d70340d40d1181d0b9f6) via the [ImageDecodingAttribute](https://chromium.googlesource.com/chromium/src/+/fcf63eae9e6a3b12b096d70340d40d1181d0b9f6%5E%21/#F2). 
* href is here because in Chrome SVGImageElement implements the [SVGURIReference](https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/svg/svg_image_element.idl?g=0&l=44).
* Everything else was in the [first release of Chrome](https://chromium.googlesource.com/chromium/src/+/538e3175c45fd8c4bb164d67bcb8b5564a668548/third_party/WebKit/WebCore/svg/SVGImageElement.idl).
* The file has been alphabetized.