### PR TITLE
Add compat data for CSS `align-items` property

### DIFF
--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -170,10 +170,10 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge_mobile": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "45"
@@ -182,7 +182,7 @@
                   "version_added": "45"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": null
@@ -221,10 +221,10 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge_mobile": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "45"
@@ -233,7 +233,7 @@
                   "version_added": "45"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": null
@@ -272,10 +272,10 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge_mobile": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "45"
@@ -284,7 +284,7 @@
                   "version_added": "45"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": null
@@ -410,6 +410,57 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "start_end": {
+            "__compat": {
+              "description": "<code>start</code> and <code>end</code>",
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": true
+                },
+                "safari_ios": {
+                  "version_added": true
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }


### PR DESCRIPTION
IE and Edge do not support any of the newer `align-items` values.

Firefox, Chrome, and Safari _do_ support `start` and `end` values in grid layouts.

I tested flexbox support using this [CodePen](https://codepen.io/acdvorak/pen/LMBxjw), and grid support using the demo at the top of the
[MDN `align-items` docs](https://mdn.io/css/align-items) page.

Both layouts were tested in the following browsers:

* IE 11
* Edge 18
* Firefox 64
* Chrome 71
* Safari 12