### PR TITLE
<image>: add image(), image-set(), and cross-fade()

### DIFF
--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -107,6 +107,7 @@
         },
         "gradients": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient",
             "description": "Gradients",
             "support": {
               "chrome": {
@@ -272,6 +273,7 @@
         },
         "image-rect": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-image-rect",
             "description": "<code>image-rect()</code>",
             "support": {
               "chrome": {
@@ -316,6 +318,72 @@
               },
               "webview_android": {
                 "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "image-set": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image-set",
+            "description": "<code>image-set()</code>",
+            "support": {
+              "chrome": {
+                "prefix": "-webkit-",
+                "version_added": "21"
+              },
+              "chrome_android": {
+                "prefix": "-webkit-",
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null,
+                "notes": "See <a href='https://bugzil.la/1107646'>bug 1107646</a>."
+              },
+              "firefox_android": {
+                "version_added": null,
+                "notes": "See <a href='https://bugzil.la/1107646'>bug 1107646</a>."
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "safari": {
+                "prefix": "-webkit-",
+                "version_added": "6",
+                "partial_implementation": true,
+                "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit. See <a href='https://bugs.webkit.org/show_bug.cgi?id=160934'>bug 160934</a>"
+              },
+              "safari_ios": {
+                "prefix": "-webkit-",
+                "version_added": "6",
+                "partial_implementation": true,
+                "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit. See <a href='https://bugs.webkit.org/show_bug.cgi?id=160934'>bug 160934</a>"
+              },
+              "samsunginternet_android": {
+                "prefix": "-webkit-",
+                "version_added": "4.0"
+              },
+              "webview_android": {
+                "prefix": "-webkit-",
+                "version_added": "4.4"
               }
             },
             "status": {

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1697,6 +1697,90 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "crossfade": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/cross-fade",
+              "description": "<code>cross-fade()</code>",
+              "support": {
+                "chrome": {
+                  "prefix": "-webkit-",
+                  "version_added": "17",
+                  "notes": "Original 2-image only implementation, prefixed"
+                },
+                "chrome_android": {
+                  "prefix": "-webkit-",
+                  "version_added": true,
+                  "notes": "Original, 2-image only implementation, prefixed"
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "prefix": "-moz-",
+                  "version_added": "4",
+                  "notes": "<code>element()</code> is limited to <a href='https://developer.mozilla.org/docs/Web/CSS/background-image'><code>background-image</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/background'><code>background</code></a>."
+                },
+                "firefox_android": {
+                  "prefix": "-moz-",
+                  "version_added": "4",
+                  "notes": "<code>element()</code> is limited to <a href='https://developer.mozilla.org/docs/Web/CSS/background-image'><code>background-image</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/background'><code>background</code></a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "prefix": "-webkit-",
+                  "version_added": "15",
+                  "notes": "Original, 2-image only implementation, prefixed"
+                },
+                "opera_android": {
+                  "prefix": "-webkit-",
+                  "version_added": "15",
+                  "notes": "Original, 2-image only implementation, prefixed"
+                },
+                "safari": [
+                  {
+                    "version_added": "10",
+                    "notes": "Original 2-image only implementation, un-prefixed"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "5.1",
+                    "notes": "Original 2-image only implementation, prefixed"
+                  }
+                ],
+                "safari_ios": [
+                  {
+                    "version_added": "9.3",
+                    "notes": "Original 2-image only implementation, un-prefixed"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "5",
+                    "notes": "Original 2-image only implementation, prefixed"
+                  }
+                ],
+                "samsunginternet_android": {
+                  "prefix": "-webkit-",
+                  "version_added": true,
+                  "notes": "Original, 2-image only implementation, prefixed"
+                },
+                "webview_android": {
+                  "prefix": "-webkit-",
+                  "version_added": true,
+                  "notes": "Original, 2-image only implementation, prefixed"
+                }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1753,6 +1753,72 @@
             }
           }
         },
+        "image-set": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image-set",
+            "description": "<code>image-set()</code>",
+            "support": {
+              "chrome": {
+                "prefix": "-webkit-",
+                "version_added": "21"
+              },
+              "chrome_android": {
+                "prefix": "-webkit-",
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null,
+                "notes": "See <a href='https://bugzil.la/1107646'>bug 1107646</a>."
+              },
+              "firefox_android": {
+                "version_added": null,
+                "notes": "See <a href='https://bugzil.la/1107646'>bug 1107646</a>."
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "safari": {
+                "prefix": "-webkit-",
+                "version_added": "6",
+                "partial_implementation": true,
+                "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit. See <a href='https://bugs.webkit.org/show_bug.cgi?id=160934'>bug 160934</a>"
+              },
+              "safari_ios": {
+                "prefix": "-webkit-",
+                "version_added": "6",
+                "partial_implementation": true,
+                "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit. See <a href='https://bugs.webkit.org/show_bug.cgi?id=160934'>bug 160934</a>"
+              },
+              "samsunginternet_android": {
+                "prefix": "-webkit-",
+                "version_added": "4.0"
+              },
+              "webview_android": {
+                "prefix": "-webkit-",
+                "version_added": "4.4"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "crossfade": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/cross-fade",

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1718,11 +1718,11 @@
               },
               "firefox": {
                 "version_added": null,
-                "notes" : "The <a href='https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-image-rect'>-moz-image-rect()</a> function supports fragments since FF4."
+                "notes": "The <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-image-rect'>-moz-image-rect()</a> function supports fragments as of FF4."
               },
               "firefox_android": {
                 "version_added": null,
-                "notes" : "The <a href='https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-image-rect'>-moz-image-rect()</a> function supports fragments since FF4."
+                "notes": "The <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-image-rect'>-moz-image-rect()</a> function supports fragments as of FF4."
               },
               "ie": {
                 "version_added": false
@@ -1775,14 +1775,10 @@
                 "version_added": null
               },
               "firefox": {
-                "prefix": "-moz-",
-                "version_added": "4",
-                "notes": "<code>element()</code> is limited to <a href='https://developer.mozilla.org/docs/Web/CSS/background-image'><code>background-image</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/background'><code>background</code></a>."
+                "version_added": null
               },
               "firefox_android": {
-                "prefix": "-moz-",
-                "version_added": "4",
-                "notes": "<code>element()</code> is limited to <a href='https://developer.mozilla.org/docs/Web/CSS/background-image'><code>background-image</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/background'><code>background</code></a>."
+                "version_added": null
               },
               "ie": {
                 "version_added": false

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1697,89 +1697,143 @@
               "standard_track": true,
               "deprecated": false
             }
-          },
-          "crossfade": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/cross-fade",
-              "description": "<code>cross-fade()</code>",
-              "support": {
-                "chrome": {
-                  "prefix": "-webkit-",
-                  "version_added": "17",
-                  "notes": "Original 2-image only implementation, prefixed"
-                },
-                "chrome_android": {
-                  "prefix": "-webkit-",
-                  "version_added": true,
-                  "notes": "Original, 2-image only implementation, prefixed"
-                },
-                "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox": {
-                  "prefix": "-moz-",
-                  "version_added": "4",
-                  "notes": "<code>element()</code> is limited to <a href='https://developer.mozilla.org/docs/Web/CSS/background-image'><code>background-image</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/background'><code>background</code></a>."
-                },
-                "firefox_android": {
-                  "prefix": "-moz-",
-                  "version_added": "4",
-                  "notes": "<code>element()</code> is limited to <a href='https://developer.mozilla.org/docs/Web/CSS/background-image'><code>background-image</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/background'><code>background</code></a>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "prefix": "-webkit-",
-                  "version_added": "15",
-                  "notes": "Original, 2-image only implementation, prefixed"
-                },
-                "opera_android": {
-                  "prefix": "-webkit-",
-                  "version_added": "15",
-                  "notes": "Original, 2-image only implementation, prefixed"
-                },
-                "safari": [
-                  {
-                    "version_added": "10",
-                    "notes": "Original 2-image only implementation, un-prefixed"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "5.1",
-                    "notes": "Original 2-image only implementation, prefixed"
-                  }
-                ],
-                "safari_ios": [
-                  {
-                    "version_added": "9.3",
-                    "notes": "Original 2-image only implementation, un-prefixed"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "5",
-                    "notes": "Original 2-image only implementation, prefixed"
-                  }
-                ],
-                "samsunginternet_android": {
-                  "prefix": "-webkit-",
-                  "version_added": true,
-                  "notes": "Original, 2-image only implementation, prefixed"
-                },
-                "webview_android": {
-                  "prefix": "-webkit-",
-                  "version_added": true,
-                  "notes": "Original, 2-image only implementation, prefixed"
-                }
+          }
+        },
+        "image": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/imagefunction",
+            "description": "<code>image()</code>",
+            "support": {
+              "chrome": {
+                "version_added": null
               },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null,
+                "notes" : "The <a href='https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-image-rect'>-moz-image-rect()</a> function supports fragments since FF4."
+              },
+              "firefox_android": {
+                "version_added": null,
+                "notes" : "The <a href='https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-image-rect'>-moz-image-rect()</a> function supports fragments since FF4."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "crossfade": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/cross-fade",
+            "description": "<code>cross-fade()</code>",
+            "support": {
+              "chrome": {
+                "prefix": "-webkit-",
+                "version_added": "17",
+                "notes": "Original 2-image only implementation, prefixed"
+              },
+              "chrome_android": {
+                "prefix": "-webkit-",
+                "version_added": true,
+                "notes": "Original, 2-image only implementation, prefixed"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "prefix": "-moz-",
+                "version_added": "4",
+                "notes": "<code>element()</code> is limited to <a href='https://developer.mozilla.org/docs/Web/CSS/background-image'><code>background-image</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/background'><code>background</code></a>."
+              },
+              "firefox_android": {
+                "prefix": "-moz-",
+                "version_added": "4",
+                "notes": "<code>element()</code> is limited to <a href='https://developer.mozilla.org/docs/Web/CSS/background-image'><code>background-image</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/background'><code>background</code></a>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15",
+                "notes": "Original, 2-image only implementation, prefixed"
+              },
+              "opera_android": {
+                "prefix": "-webkit-",
+                "version_added": "15",
+                "notes": "Original, 2-image only implementation, prefixed"
+              },
+              "safari": [
+                {
+                  "version_added": "10",
+                  "notes": "Original 2-image only implementation, un-prefixed"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "5.1",
+                  "notes": "Original 2-image only implementation, prefixed"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "9.3",
+                  "notes": "Original 2-image only implementation, un-prefixed"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "5",
+                  "notes": "Original 2-image only implementation, prefixed"
+                }
+              ],
+              "samsunginternet_android": {
+                "prefix": "-webkit-",
+                "version_added": true,
+                "notes": "Original, 2-image only implementation, prefixed"
+              },
+              "webview_android": {
+                "prefix": "-webkit-",
+                "version_added": true,
+                "notes": "Original, 2-image only implementation, prefixed"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/types/imagetypes.json
+++ b/css/types/imagetypes.json
@@ -1,0 +1,383 @@
+{
+  "css": {
+    "types": {
+      "image": {
+        "__compat": {
+          "description": "<code>image</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "background-image": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-image",
+            "description": "<code>background-image</code>",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "url()": {
+            "__compat": {
+              "description": "<code>url()</code>",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url",
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "opera_android": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": true
+                },
+                "safari_ios": {
+                  "version_added": true
+                },
+                "samsunginternet_android": {
+                  "version_added": true
+                },
+                "webview_android": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            },
+            "image()": {
+              "__compat": {
+                "description": "<code>image()</code>",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/_image",
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": true
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": true
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": true
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  },
+                  "samsunginternet_android": {
+                    "version_added": true
+                  },
+                  "webview_android": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              },
+              "image-set()": {
+                "__compat": {
+                  "description": "<code>image-set()</code>",
+                  "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image-set",
+                  "support": {
+                    "chrome": {
+                      "prefix": "-webkit-",
+                      "version_added": "21"
+                    },
+                    "chrome_android": {
+                      "prefix": "-webkit-",
+                      "version_added": true
+                    },
+                    "edge": {
+                      "version_added": null
+                    },
+                    "edge_mobile": {
+                      "version_added": null
+                    },
+                    "firefox": {
+                      "version_added": null,
+                      "notes": "See <a href='https://bugzil.la/1107646'>bug 1107646</a>."
+                    },
+                    "firefox_android": {
+                      "version_added": null,
+                      "notes": "See <a href='https://bugzil.la/1107646'>bug 1107646</a>."
+                    },
+                    "ie": {
+                      "version_added": null
+                    },
+                    "opera": {
+                      "prefix": "-webkit-",
+                      "version_added": "15"
+                    },
+                    "opera_android": {
+                      "prefix": "-webkit-",
+                      "version_added": "15"
+                    },
+                    "safari": {
+                      "prefix": "-webkit-",
+                      "version_added": "6",
+                      "partial_implementation": true,
+                      "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit. See <a href='https://bugs.webkit.org/show_bug.cgi?id=160934'>bug 160934</a>"
+                    },
+                    "safari_ios": {
+                      "prefix": "-webkit-",
+                      "version_added": "6",
+                      "partial_implementation": true,
+                      "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit. See <a href='https://bugs.webkit.org/show_bug.cgi?id=160934'>bug 160934</a>"
+                    },
+                    "samsunginternet_android": {
+                      "prefix": "-webkit-",
+                      "version_added": "4.0"
+                    },
+                    "webview_android": {
+                      "prefix": "-webkit-",
+                      "version_added": "4.4"
+                    }
+                  },
+                  "status": {
+                    "experimental": false,
+                    "standard_track": true,
+                    "deprecated": false
+                  }
+                },
+                "gradients": {
+                  "__compat": {
+                    "description": "gradients",
+                    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradients",
+                    "support": {
+                      "chrome": {
+                        "version_added": true
+                      },
+                      "chrome_android": {
+                        "version_added": true
+                      },
+                      "edge": {
+                        "version_added": true
+                      },
+                      "edge_mobile": {
+                        "version_added": true
+                      },
+                      "firefox": {
+                        "version_added": true
+                      },
+                      "firefox_android": {
+                        "version_added": true
+                      },
+                      "ie": {
+                        "version_added": true
+                      },
+                      "opera": {
+                        "version_added": true
+                      },
+                      "opera_android": {
+                        "version_added": true
+                      },
+                      "safari": {
+                        "version_added": true
+                      },
+                      "safari_ios": {
+                        "version_added": true
+                      },
+                      "samsunginternet_android": {
+                        "version_added": true
+                      },
+                      "webview_android": {
+                        "version_added": true
+                      }
+                    },
+                    "status": {
+                      "experimental": false,
+                      "standard_track": true,
+                      "deprecated": false
+                    }
+                  },
+                  "element": {
+                    "__compat": {
+                      "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/element",
+                      "description": "<code>element()</code>",
+                      "support": {
+                        "chrome": {
+                          "version_added": false
+                        },
+                        "chrome_android": {
+                          "version_added": null
+                        },
+                        "edge": {
+                          "version_added": null
+                        },
+                        "edge_mobile": {
+                          "version_added": null
+                        },
+                        "firefox": {
+                          "prefix": "-moz-",
+                          "version_added": "4"
+                        },
+                        "firefox_android": {
+                          "prefix": "-moz-",
+                          "version_added": "4"
+                        },
+                        "ie": {
+                          "version_added": false
+                        },
+                        "opera": {
+                          "version_added": false
+                        },
+                        "opera_android": {
+                          "version_added": false
+                        },
+                        "safari": {
+                          "version_added": false
+                        },
+                        "safari_ios": {
+                          "version_added": false
+                        },
+                        "samsunginternet_android": {
+                          "version_added": false
+                        },
+                        "webview_android": {
+                          "version_added": false
+                        }
+                      },
+                      "status": {
+                        "experimental": true,
+                        "standard_track": true,
+                        "deprecated": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/types/imagetypes.json
+++ b/css/types/imagetypes.json
@@ -100,7 +100,7 @@
               "deprecated": false
             }
           },
-          "url()": {
+          "url": {
             "__compat": {
               "description": "<code>url()</code>",
               "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url",
@@ -151,7 +151,7 @@
                 "deprecated": false
               }
             },
-            "image()": {
+            "image": {
               "__compat": {
                 "description": "<code>image()</code>",
                 "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/_image",
@@ -202,7 +202,7 @@
                   "deprecated": false
                 }
               },
-              "image-set()": {
+              "image-set": {
                 "__compat": {
                   "description": "<code>image-set()</code>",
                   "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image-set",


### PR DESCRIPTION
Added the following CSS functions:
image()
image-set()
cross-fade()

Resources:
image() - tested chrome canary, opera next, safari technology preview, and FF Nightly 
image-set() - https://caniuse.com/#search=image-set
cross-fade() - https://caniuse.com/#search=cross-fade

Tickets:
image() - https://bugzilla.mozilla.org/show_bug.cgi?id=703217 

