### PR TITLE
feat(css): Add the `:‑moz‑only‑whitespace` selector

### DIFF
--- a/css/selectors/-moz-only-whitespace.json
+++ b/css/selectors/-moz-only-whitespace.json
@@ -1,10 +1,10 @@
 {
   "css": {
     "selectors": {
-      "blank": {
+      "-moz-only-whitespace": {
         "__compat": {
-          "description": "<code>:blank</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:blank",
+          "description": "<code>:-moz-only-whitespace</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:-moz-only-whitespace",
           "support": {
             "chrome": {
               "version_added": false
@@ -19,10 +19,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": true,
+              "notes": "See <a href='https://bugzil.la/1106296'>bug 1106296</a>."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true,
+              "notes": "See <a href='https://bugzil.la/1106296'>bug 1106296</a>."
             },
             "ie": {
               "version_added": false
@@ -47,8 +49,8 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
+            "experimental": false,
+            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
This adds compat data for the non&#x2011;standard [<code>:&#x2011;moz&#x2011;only&#x2011;whitespace</code> selector](https://developer.mozilla.org/docs/Web/CSS/:-moz-only-whitespace) and removes mentions of&nbsp;it&nbsp;from the&nbsp;fluctuating and experimental [`:blank` selector](https://developer.mozilla.org/docs/Web/CSS/:blank).

review?(@ddbeck, @Elchi3)