### PR TITLE
Bug 1370077: Don’t log warning when `background.persistent` is `true`

### DIFF
--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -33,10 +33,20 @@
                 "version_added": "14"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "48",
+                "partial_implementation": true,
+                "notes": [
+                  "Only persistent pages are supported.",
+                  "Before version 66, Firefox would log a warning even if the value was set to <code>true</code>."
+                ]
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "48",
+                "partial_implementation": true,
+                "notes": [
+                  "Only persistent pages are supported.",
+                  "Before version 66, Firefox would log a warning even if the value was set to <code>true</code>."
+                ]
               },
               "opera": {
                 "version_added": true


### PR DESCRIPTION
See [bug&nbsp;1370077](https://bugzilla.mozilla.org/show_bug.cgi?id=1370077) for&nbsp;details.

review?(@wbamberg)