### PR TITLE
overflow-wrap: anywhere

### DIFF
--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -15,7 +15,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": "70"
+              "version_added": true
             },
             "edge": [
               {
@@ -154,7 +154,7 @@
         },
         "anywhere": {
           "__compat": {
-            "description": "anywhere",
+            "description": "<code>anywhere</code>",
             "support": {
               "chrome": {
                 "version_added": null

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -7,7 +7,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": true
+                "version_added": "23"
               },
               {
                 "alternative_name": "word-wrap",
@@ -15,7 +15,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": null
+              "version_added": "70"
             },
             "edge": [
               {
@@ -54,7 +54,7 @@
             },
             "opera": [
               {
-                "version_added": true
+                "version_added": "12.1"
               },
               {
                 "alternative_name": "word-wrap",
@@ -62,11 +62,11 @@
               }
             ],
             "opera_android": {
-              "version_added": true
+              "version_added": "46"
             },
             "safari": [
               {
-                "version_added": true
+                "version_added": "6.1"
               },
               {
                 "alternative_name": "word-wrap",
@@ -75,7 +75,7 @@
             ],
             "safari_ios": [
               {
-                "version_added": true
+                "version_added": "7"
               },
               {
                 "alternative_name": "word-wrap",
@@ -83,11 +83,11 @@
               }
             ],
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "4.4"
               },
               {
                 "alternative_name": "word-wrap",
@@ -99,6 +99,108 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "break-word": {
+          "__compat": {
+            "description": "break-word",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "70"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "5.5"
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "opera_android": {
+                "version_added": "46"
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": "1"
+              },
+              "samsunginternet_android": {
+                "version_added": "4.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "anywhere": {
+          "__compat": {
+            "description": "anywhere",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "65"
+              },
+              "firefox_android": {
+                "version_added": "65"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -142,7 +142,7 @@
                 "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": "1"
+                "version_added": true
               }
             },
             "status": {

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -103,7 +103,7 @@
         },
         "break-word": {
           "__compat": {
-            "description": "break-word",
+            "description": "<code>break-word</code>",
             "support": {
               "chrome": {
                 "version_added": "1"


### PR DESCRIPTION

added 'anywhere' value to bcd for overflow-wrap property

based on https://bugzilla.mozilla.org/show_bug.cgi?id=1505786 (FF 65 supports 'anywhere') and testing it in the inspector in canary and safari tech preview, and based on caniuse for additional updates.

spec: https://drafts.csswg.org/css-text-3/#propdef-overflow-wrap
