### PR TITLE
Fix the note for position:fixed in IE

### DIFF
--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -25,8 +25,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "4",
-              "notes": "In Internet Explorer, fixed positioning doesn't work if the document is in <a href='http://msdn.microsoft.com/en-us/library/ie/ms531140(v=vs.85).aspx'>quirks mode</a>."
+              "version_added": "4"
             },
             "opera": {
               "version_added": "4"
@@ -77,7 +76,8 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": "7"
+                "version_added": "7",
+                "notes": "In Internet Explorer, fixed positioning doesn't work if the document is in <a href='http://msdn.microsoft.com/en-us/library/ie/ms531140(v=vs.85).aspx'>quirks mode</a>."
               },
               "opera": {
                 "version_added": "4"


### PR DESCRIPTION
The note is related to the behavior of `position: fixed`. So it is better placed in the compat data for `fixed` than for `Basic support`
