### PR TITLE
Adding request credential default for chromium/edge/safari

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -755,13 +755,13 @@
             "description": "Default value <code>same-origin</code>",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "68"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "68"
               },
               "edge": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge_mobile": {
                 "version_added": null
@@ -776,13 +776,13 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "55"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "55"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12"
               },
               "safari_ios": {
                 "version_added": false
@@ -791,7 +791,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "68"
               }
             },
             "status": {


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any  
  
---

Added more values to browser compatibility on [Request Credentials defaulting to `'same-origin'`](https://github.com/mdn/browser-compat-data/commit/f0da98443ec09379c636ca7085cf77072cda9e6b) for Chromium browsers, Edge and Safari

Reference
- [Chromium](https://www.chromestatus.com/feature/4539473312350208)
  - Chrome[desktop/android]68
  - Webview Android 68
  - Opera[desktop/android]55
- [Edge](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/13474598/) 
  - Edge 18.18218: 
- [Safari](https://bugs.webkit.org/show_bug.cgi?id=176023) - [also here](https://trac.webkit.org/changeset/233720/webkit) - [and here](https://webkit.org/blog/8365/release-notes-for-safari-technology-preview-61/)
  - Safari Tech Preview 61 ~ Safari 12

Testing done by making fetch call to endpoint requiring cookies.
Chrome65, Edge17 did not default to 'same-origin'
Safari 12 did default to 'same-origin'


Passes all tests, but `npm run show-errors` gives `Browsers - Unknown category` (This is also happening on master)