### PR TITLE
[All] Improvements to RTCPeerConnection.json

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -185,7 +185,7 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "47"
             },
             "firefox_android": {
               "version_added": "44"
@@ -251,7 +251,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -316,7 +316,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -352,7 +352,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "56"
+              "version_added": "57"
             },
             "firefox_android": {
               "version_added": null
@@ -367,7 +367,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -456,11 +456,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/iceConnectionState",
           "support": {
             "chrome": {
-              "notes": "disconnected",
-              "version_added": "48"
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": "57"
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -498,7 +497,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -507,8 +506,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "notes": "disconnected",
-              "version_added": "48"
+              "version_added": true
             }
           },
           "status": {
@@ -523,10 +521,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/iceGatheringState",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -564,7 +562,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -573,7 +571,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -588,10 +586,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/localDescription",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -629,7 +627,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -638,7 +636,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -759,7 +757,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -824,7 +822,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -848,10 +846,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/remoteDescription",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -891,7 +889,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -900,7 +898,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -980,10 +978,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/signalingState",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -1021,7 +1019,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -1030,7 +1028,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -1045,10 +1043,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/onaddstream",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -1086,7 +1084,8 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "11",
+              "version_removed": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1095,7 +1094,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -1137,7 +1136,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1161,10 +1160,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/ondatachannel",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -1202,7 +1201,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -1211,7 +1210,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -1226,10 +1225,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/onicecandidate",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -1267,7 +1266,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -1276,7 +1275,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -1291,7 +1290,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/oniceconnectionstatechange",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "43"
             },
             "chrome_android": {
               "version_added": "56"
@@ -1332,7 +1331,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -1397,7 +1396,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -1616,7 +1615,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/onnegotiationneeded",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "43"
             },
             "chrome_android": {
               "version_added": "56"
@@ -1657,7 +1656,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -1746,10 +1745,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/onremovestream",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -1798,7 +1797,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -1813,7 +1812,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/onsignalingstatechange",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "43"
             },
             "chrome_android": {
               "version_added": "56"
@@ -1854,7 +1853,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -1878,10 +1877,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/ontrack",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "64"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "64"
             },
             "edge": {
               "version_added": true
@@ -1919,7 +1918,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -1928,7 +1927,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "64"
             }
           },
           "status": {
@@ -1944,24 +1943,20 @@
           "support": {
             "chrome": [
               {
-                "version_added": "56",
-                "notes": "Promise based version and unprefixed."
+                "version_added": "24"
               },
               {
-                "version_added": "50",
-                "notes": "Promise based version.",
-                "version_removed": "56"
+                "version_added": "51",
+                "notes": "Promise based version."
               }
             ],
             "chrome_android": [
               {
-                "version_added": "56",
-                "notes": "Promise based version and unprefixed."
+                "version_added": true
               },
               {
-                "version_added": "50",
-                "notes": "Promise based version.",
-                "version_removed": "56"
+                "version_added": "51",
+                "notes": "Promise based version."
               }
             ],
             "edge": {
@@ -2000,7 +1995,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -2018,13 +2013,11 @@
             ],
             "webview_android": [
               {
-                "version_added": "56",
-                "notes": "Promise based version and unprefixed."
+                "version_added": true
               },
               {
-                "version_added": "50",
-                "notes": "Promise based version.",
-                "version_removed": "56"
+                "version_added": "51",
+                "notes": "Promise based version."
               }
             ]
           },
@@ -2081,7 +2074,8 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11",
+              "version_removed": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -2132,7 +2126,7 @@
               "version_added": "51"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -2183,7 +2177,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -2264,7 +2258,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -2304,10 +2298,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/createDataChannel",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": true
             },
             "edge": {
               "version_added": false
@@ -2354,7 +2348,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -2426,7 +2420,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -2466,10 +2460,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/generateCertificate",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "49"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "49"
             },
             "edge": {
               "version_added": true
@@ -2516,7 +2510,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "49"
             }
           },
           "status": {
@@ -2572,7 +2566,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -2661,10 +2655,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getLocalStreams",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -2702,7 +2696,8 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11",
+              "version_removed": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -2711,7 +2706,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -2753,7 +2748,7 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -2777,10 +2772,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getRemoteStreams",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -2818,7 +2813,8 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11",
+              "version_removed": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -2827,7 +2823,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -2869,7 +2865,7 @@
               "version_added": "51"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -2899,13 +2895,13 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": null
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -2920,7 +2916,7 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -2995,10 +2991,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getStreamById",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "56",
+              "version_removed": "62"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "56",
+              "version_removed": "62"
             },
             "edge": {
               "version_added": "15"
@@ -3007,72 +3005,8 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "22"
-            },
-            "firefox_android": {
-              "version_added": "44"
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
-            "webview_android": {
-              "version_added": "56"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "removeStream": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/removeStream",
-          "support": {
-            "chrome": {
-              "version_added": "56"
-            },
-            "chrome_android": {
-              "version_added": "56"
-            },
-            "edge": {
-              "version_added": "15"
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": "22"
+              "version_added": "22",
+              "version_removed": "53"
             },
             "firefox_android": {
               "version_added": "44"
@@ -3102,7 +3036,75 @@
             ],
             "safari": {
               "version_added": "11",
-              "version_removed": "12"
+              "version_removed": "11"
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "56",
+              "version_removed": "62"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "removeStream": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/removeStream",
+          "support": {
+            "chrome": {
+              "version_added": "24"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "22",
+              "version_removed": "51"
+            },
+            "firefox_android": {
+              "version_added": "44"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": [
+              {
+                "version_added": "43",
+                "notes": "Promise based version."
+              },
+              {
+                "version_added": "37",
+                "version_removed": "43"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "43",
+                "notes": "Promise based version."
+              },
+              {
+                "version_added": "37",
+                "version_removed": "43"
+              }
+            ],
+            "safari": {
+              "version_added": "11",
+              "version_removed": "11"
             },
             "safari_ios": {
               "version_added": "11",
@@ -3154,7 +3156,7 @@
               "version_added": "51"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -3178,10 +3180,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/setConfiguration",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "58"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "58"
             },
             "edge": {
               "version_added": true
@@ -3219,7 +3221,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -3228,7 +3230,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "58"
             }
           },
           "status": {
@@ -3365,7 +3367,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -3405,10 +3407,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/setRemoteDescription",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -3446,7 +3448,7 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -3455,7 +3457,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -3586,10 +3588,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/close",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -3598,7 +3600,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -3613,7 +3615,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
@@ -3622,7 +3624,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -105,11 +105,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/RTCPeerConnection",
           "support": {
             "chrome": {
-              "version_added": "56",
+              "version_added": "23",
               "notes": "Before Chrome 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot</code>"
             },
             "chrome_android": {
-              "version_added": "56",
+              "version_added": "23",
               "notes": "Before Chrome 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot</code>"
             },
             "edge": {
@@ -157,7 +157,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56",
+              "version_added": true,
               "notes": "Before Chrome 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot</code>"
             }
           },
@@ -224,10 +224,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/connectionState",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "72"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "72"
             },
             "edge": {
               "version_added": false
@@ -260,7 +260,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "72"
             }
           },
           "status": {
@@ -275,10 +275,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/currentLocalDescription",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "70"
             },
             "edge": {
               "version_added": true
@@ -325,7 +325,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "70"
             }
           },
           "status": {
@@ -340,10 +340,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/currentRemoteDescription",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "70"
             },
             "edge": {
               "version_added": false
@@ -376,7 +376,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "70"
             }
           },
           "status": {
@@ -391,10 +391,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/defaultIceServers",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -441,7 +441,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -459,7 +459,7 @@
               "version_added": "26"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "edge": {
               "version_added": "15"
@@ -524,7 +524,7 @@
               "version_added": "25"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "15"
@@ -589,7 +589,7 @@
               "version_added": "24"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "24"
             },
             "edge": {
               "version_added": "15"
@@ -651,10 +651,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/peerIdentity",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -701,7 +701,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -716,10 +716,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/pendingLocalDescription",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "70"
             },
             "edge": {
               "version_added": true
@@ -766,7 +766,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "70"
             }
           },
           "status": {
@@ -781,10 +781,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/pendingRemoteDescription",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "70"
             },
             "edge": {
               "version_added": true
@@ -831,7 +831,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "70"
             }
           },
           "status": {
@@ -849,7 +849,7 @@
               "version_added": "24"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "24"
             },
             "edge": {
               "version_added": "15"
@@ -981,7 +981,7 @@
               "version_added": "26"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "edge": {
               "version_added": "15"
@@ -1046,7 +1046,7 @@
               "version_added": "24"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "24"
             },
             "edge": {
               "version_added": "15"
@@ -1109,10 +1109,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/onconnectionstatechange",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "72"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "72"
             },
             "edge": {
               "version_added": false
@@ -1145,7 +1145,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "72"
             }
           },
           "status": {
@@ -1163,7 +1163,7 @@
               "version_added": "25"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": true
@@ -1228,7 +1228,7 @@
               "version_added": "24"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "24"
             },
             "edge": {
               "version_added": "15"
@@ -1290,10 +1290,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/oniceconnectionstatechange",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "28"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "28"
             },
             "edge": {
               "version_added": "15"
@@ -1340,7 +1340,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -1420,10 +1420,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/onidentityresult",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -1470,7 +1470,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -1485,10 +1485,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/onidpassertionerror",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -1535,7 +1535,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -1550,10 +1550,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/onidpvalidationerror",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -1600,7 +1600,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -1615,10 +1615,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/onnegotiationneeded",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "edge": {
               "version_added": "15"
@@ -1665,7 +1665,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -1680,10 +1680,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/onpeeridentity",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -1730,7 +1730,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -1748,7 +1748,7 @@
               "version_added": "24"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "24"
             },
             "edge": {
               "version_added": "15"
@@ -1812,10 +1812,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/onsignalingstatechange",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "28"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "28"
             },
             "edge": {
               "version_added": "15"
@@ -1862,7 +1862,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -1943,20 +1943,20 @@
           "support": {
             "chrome": [
               {
-                "version_added": "24"
-              },
-              {
                 "version_added": "51",
                 "notes": "Promise based version."
+              },
+              {
+                "version_added": "24"
               }
             ],
             "chrome_android": [
               {
-                "version_added": true
-              },
-              {
                 "version_added": "51",
                 "notes": "Promise based version."
+              },
+              {
+                "version_added": "24"
               }
             ],
             "edge": {
@@ -2013,11 +2013,11 @@
             ],
             "webview_android": [
               {
-                "version_added": true
-              },
-              {
                 "version_added": "51",
                 "notes": "Promise based version."
+              },
+              {
+                "version_added": true
               }
             ]
           },
@@ -2033,10 +2033,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/addStream",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "edge": {
               "version_added": "15"
@@ -2084,7 +2084,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -2150,10 +2150,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/addTransceiver",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false
@@ -2186,7 +2186,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {
@@ -2202,24 +2202,20 @@
           "support": {
             "chrome": [
               {
-                "version_added": "56",
-                "notes": "Promise based version and unprefixed."
+                "version_added": "51",
+                "notes": "Promise based."
               },
               {
-                "version_added": "50",
-                "notes": "Promise based version.",
-                "version_removed": "56"
+                "version_added": "24"
               }
             ],
             "chrome_android": [
               {
-                "version_added": "56",
-                "notes": "Promise based version and unprefixed."
+                "version_added": "51",
+                "notes": "Promise based."
               },
               {
-                "version_added": "50",
-                "notes": "Promise based version.",
-                "version_removed": "56"
+                "version_added": "24"
               }
             ],
             "edge": {
@@ -2276,13 +2272,11 @@
             ],
             "webview_android": [
               {
-                "version_added": "56",
-                "notes": "Promise based version and unprefixed."
+                "version_added": "51",
+                "notes": "Promise based."
               },
               {
-                "version_added": "50",
-                "notes": "Promise based version.",
-                "version_removed": "56"
+                "version_added": true
               }
             ]
           },
@@ -2301,7 +2295,7 @@
               "version_added": "25"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": false
@@ -2364,24 +2358,20 @@
           "support": {
             "chrome": [
               {
-                "version_added": "56",
-                "notes": "Promise based version and unprefixed."
+                "version_added": "51",
+                "notes": "Promise based."
               },
               {
-                "version_added": "50",
-                "notes": "Promise based version.",
-                "version_removed": "56"
+                "version_added": "24"
               }
             ],
             "chrome_android": [
               {
-                "version_added": "56",
-                "notes": "Promise based version and unprefixed."
+                "version_added": "51",
+                "notes": "Promise based."
               },
               {
-                "version_added": "50",
-                "notes": "Promise based version.",
-                "version_removed": "56"
+                "version_added": "24"
               }
             ],
             "edge": {
@@ -2438,13 +2428,11 @@
             ],
             "webview_android": [
               {
-                "version_added": "56",
-                "notes": "Promise based version and unprefixed."
+                "version_added": "51",
+                "notes": "Promise based."
               },
               {
-                "version_added": "50",
-                "notes": "Promise based version.",
-                "version_removed": "56"
+                "version_added": "24"
               }
             ]
           },
@@ -2460,10 +2448,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/generateCertificate",
           "support": {
             "chrome": {
-              "version_added": "49"
+              "version_added": "48"
             },
             "chrome_android": {
-              "version_added": "49"
+              "version_added": "48"
             },
             "edge": {
               "version_added": true
@@ -2510,7 +2498,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "49"
+              "version_added": "48"
             }
           },
           "status": {
@@ -2525,10 +2513,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getConfiguration",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "15"
@@ -2575,7 +2563,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "70"
             }
           },
           "status": {
@@ -2590,10 +2578,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getIdentityAssertion",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -2640,7 +2628,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -2655,10 +2643,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getLocalStreams",
           "support": {
             "chrome": {
-              "version_added": "24"
+              "version_added": "27"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "edge": {
               "version_added": "15"
@@ -2772,10 +2760,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getRemoteStreams",
           "support": {
             "chrome": {
-              "version_added": "24"
+              "version_added": "27"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "edge": {
               "version_added": "15"
@@ -2888,12 +2876,32 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getStats",
           "support": {
-            "chrome": {
-              "version_added": "58"
-            },
-            "chrome_android": {
-              "version_added": "58"
-            },
+            "chrome": [
+              {
+                "version_added": "58",
+                "notes": "Promise resolves with <code>RTCStatsReport</code>."
+              },
+              {
+                "version_added": "54",
+                "notes": "Promise based version."
+              },
+              {
+                "version_added": "24"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "58",
+                "notes": "Promise resolves with <code>RTCStatsReport</code>."
+              },
+              {
+                "version_added": "54",
+                "notes": "Promise based version."
+              },
+              {
+                "version_added": "24"
+              }
+            ],
             "edge": {
               "version_added": "15"
             },
@@ -2924,9 +2932,19 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": {
-              "version_added": "58"
-            }
+            "webview_android": [
+              {
+                "version_added": "58",
+                "notes": "Promise resolves with <code>RTCStatsReport</code>."
+              },
+              {
+                "version_added": "54",
+                "notes": "Promise based version."
+              },
+              {
+                "version_added": true
+              }
+            ],
           },
           "status": {
             "experimental": false,
@@ -3064,7 +3082,7 @@
               "version_added": "24"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "24"
             },
             "edge": {
               "version_added": "15"
@@ -3114,7 +3132,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -3180,10 +3198,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/setConfiguration",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "48"
             },
             "chrome_android": {
-              "version_added": "58"
+              "version_added": "48"
             },
             "edge": {
               "version_added": true
@@ -3230,7 +3248,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "58"
+              "version_added": "48"
             }
           },
           "status": {
@@ -3245,10 +3263,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/setIdentityProvider",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -3295,7 +3313,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -3311,24 +3329,20 @@
           "support": {
             "chrome": [
               {
-                "version_added": "56",
-                "notes": "Promise based version and unprefixed."
+                "version_added": "51",
+                "notes": "Promise based version."
               },
               {
-                "version_added": "50",
-                "notes": "Promise based version.",
-                "version_removed": "56"
+                "version_added": "24"
               }
             ],
             "chrome_android": [
               {
-                "version_added": "56",
-                "notes": "Promise based version and unprefixed."
+                "version_added": "51",
+                "notes": "Promise based version."
               },
               {
-                "version_added": "50",
-                "notes": "Promise based version.",
-                "version_removed": "56"
+                "version_added": "24"
               }
             ],
             "edge": {
@@ -3385,13 +3399,11 @@
             ],
             "webview_android": [
               {
-                "version_added": "56",
-                "notes": "Promise based version and unprefixed."
+                "version_added": "51",
+                "notes": "Promise based version."
               },
               {
-                "version_added": "50",
-                "notes": "Promise based version.",
-                "version_removed": "56"
+                "version_added": "24"
               }
             ]
           },
@@ -3406,12 +3418,24 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/setRemoteDescription",
           "support": {
-            "chrome": {
-              "version_added": "24"
-            },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome": [
+              {
+                "version_added": "51",
+                "notes": "Promise based version."
+              },
+              {
+                "version_added": "24"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "51",
+                "notes": "Promise based version."
+              },
+              {
+                "version_added": "24"
+              }
+            ],
             "edge": {
               "version_added": "15"
             },
@@ -3456,9 +3480,15 @@
             "samsunginternet_android": {
               "version_added": "6.0"
             },
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "51",
+                "notes": "Promise based version."
+              },
+              {
+                "version_added": true
+              }
+            ]
           },
           "status": {
             "experimental": true,
@@ -3472,10 +3502,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/createDTMFSender",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "27"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "27"
             },
             "edge": {
               "version_added": true
@@ -3522,7 +3552,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": true
             }
           },
           "status": {
@@ -3537,10 +3567,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/onicecandidateerror",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -3573,7 +3603,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -3588,10 +3618,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/close",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "23"
             },
             "edge": {
               "version_added": "15"
@@ -3639,10 +3669,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getDefaultIceServers",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -3675,7 +3705,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
The non-Chrome changes came from Confluence. The Confluence data on this interface turned out to be really bad. You will wonder if some of these changes are correct. Here's the proof.

The webkit prefix was removed in Chrome 56. It appears that the prefix was only ever on the interface and not it’s individual members. I might have found this odd, but I’ve seen it before.
[constructor](https://chromium.googlesource.com/chromium/src/+/4426ed8c87c03f2c5d38aa75648154fc22cc564f)
Missing from IDL, not supported: [defaultIceServers, peerIdentity, sctp,onidentityresult, onidpassertionerror, onidpvalidationerror, onpeeridentity, getIdentityAssertion, setIdentityProvider, onicecandidateerror, getDefaultIceServers](https://cs.chromium.org/chromium/src/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.idl)
Promise-based [createAnswer, createOffer](https://storage.googleapis.com/chromium-find-releases-static/703.html#70302a3d99ed149d59acf592edf9d32d4fd0dbda) and [createAnswer added](https://chromium.googlesource.com/chromium/src/+/8f0a7f9dbbc977f76149b9e420b56bcaf5c81dc1), [createOffer added](https://chromium.googlesource.com/chromium/src/+/10646e4b58290fdc9942f3c0758de2c65649162d)
Promise-based [addIceCandidate, setLocalDescription, setRemoteDescription](https://chromium.googlesource.com/chromium/src/+/e16c96f5a5b517a64fdbc5be75f05e359e04b461)
[addTrack(), getSenders(), onTrack, removeTrack()](https://storage.googleapis.com/chromium-find-releases-static/fb2.html#fb265faa85701894a930a1024fba9c03c8f6a859)
[iceConnectionState, signalingState](https://chromium.googlesource.com/chromium/src/+/6c690b360cffb5f300f05382356d2fec3703f9dd)
[iceGatheringState](https://chromium.googlesource.com/chromium/src/+/b052a77a71916dfbd69029263ef437f98408df5f)
[localDescription, remoteDescription, setLocalDescription(), setRemoteDescription()](https://chromium.googlesource.com/chromium/src/+/d2df6ba6560e99f17cd900fdaa24f0ef4fafe203)
[localStreams, remoteStreams, addStream(), removeStream(), onaddstream, onremovestream](https://chromium.googlesource.com/chromium/src/+/07c9b773435da7f5bcc1bc0487a99b86b04a55ed)
[createDataChannel, ondatachannel](https://chromium.googlesource.com/chromium/src/+/ce4f330106a77d5f5c2a5b4d7b7abbb1bf7a299e)
[updateIce(), addIceCandidate(), iceState, onicecandidate](https://chromium.googlesource.com/chromium/src/+/17f2e5e5850823844c8d6127b1b8ec068a7cc736)
[oniceconnectionstatechange, onsignalingstatechange](https://chromium.googlesource.com/chromium/src/+/5876ff18ffca84b4147962ca5c874873dacbd864)
[onnegotationneeded](https://chromium.googlesource.com/chromium/src/+/6e58e62f39c2d21904b61d2f741d35f5c49eb271)
[connectionstate, onconnectionstatechagne](https://storage.googleapis.com/chromium-find-releases-static/930.html#93094c4962f94a897a6601a75724e4b2db329fae)
[currentLocalDescription, pendingLocalDescription, currentRemoteDescription, pendingRemoteDescription](https://storage.googleapis.com/chromium-find-releases-static/063.html#0637ce3f178c65389d0447bd71f3cc3868703784)
[connectionState, onconnectionstatechange](https://storage.googleapis.com/chromium-find-releases-static/930.html#93094c4962f94a897a6601a75724e4b2db329fae)
[onicegatheringstatechange](https://storage.googleapis.com/chromium-find-releases-static/0a7.html#0a734fd400a160bdc1ea1e2eaff4bc44299d523a)
[onnegotiationneeded](https://chromium.googlesource.com/chromium/src/+/6e58e62f39c2d21904b61d2f741d35f5c49eb271)
[addTransceiver](https://storage.googleapis.com/chromium-find-releases-static/ab1.html#ab1bc90d6ab7f52c22e56a181d7f5d3229df3859)
[generateCertificate](https://storage.googleapis.com/chromium-find-releases-static/ef4.html#ef4ab6012fddc80992b8848cfc6700e731dc39b1)
[getConfiguration](https://storage.googleapis.com/chromium-find-releases-static/7f9.html#7f9168f4e91b8848a33c0a970b490143a72e7b98)
[getLocalStreams, getRemoteStreams](https://chromium.googlesource.com/chromium/src/+/9adb9091c89dbd3acca8f74ed5ae3ddac2b16104)
[getReceivers](https://storage.googleapis.com/chromium-find-releases-static/107.html#1079a7037c61aa020728c6d0fd8fcced3d076d7d)
[getStats](https://chromium.googlesource.com/chromium/src/+/ad1e314ea85b8becfadf69a67513092e585bfee8), [Promise-based](https://storage.googleapis.com/chromium-find-releases-static/08f.html#08fa67b0f718b342b8c47725f2018c63ade8b699), [resolves to RTCStatsReport](https://www.chromestatus.com/features/5665052275245056), [MediaStreamTrack parameter](https://www.chromestatus.com/features/5647724393267200)
[Remove getStreamById](https://storage.googleapis.com/chromium-find-releases-static/48a.html#48a0ca6d697c2a43d8ff67069f016daa108458fd)
[setConfiguration](https://storage.googleapis.com/chromium-find-releases-static/c01.html#c0174a877b6c866a36eed6e2c8d8b6effef94eeb)
[createDTMFSender](https://chromium.googlesource.com/chromium/src/+/87a94142bbc06d32cba1b7c84192b165bed34854)
[close](https://chromium.googlesource.com/chromium/src/+/bdeb8e739290b102e45c76848ce40e3cec449671)