### PR TITLE
add full-size-kana to text-transform

### DIFF
--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -158,6 +158,57 @@
             }
           }
         },
+        "full-size-kana": {
+          "__compat": {
+            "description": "<code>full-size-kana</code>",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "65"
+              },
+              "firefox_android": {
+                "version_added": "65"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "dutch_ij_digraph": {
           "__compat": {
             "description": "Dutch <code>IJ</code> digraph",

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -152,7 +152,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -203,7 +203,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -175,10 +175,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "65"
+                "version_added": "64"
               },
               "firefox_android": {
-                "version_added": "65"
+                "version_added": "64"
               },
               "ie": {
                 "version_added": null

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -163,10 +163,10 @@
             "description": "<code>full-size-kana</code>",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION

https://drafts.csswg.org/css-text-3/#propdef-text-transform - adds the value
https://bugzilla.mozilla.org/show_bug.cgi?id=1498148 - FF 65 implemented it.
tested canary and safari tech preview. neither supports this value (or full-width for that matter)
