### PR TITLE
Add String matchAll

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1828,10 +1828,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "65"
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": "65"
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1810,6 +1810,61 @@
             }
           }
         },
+        "@@matchAll": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll",
+            "spec_url": "https://tc39.github.io/proposal-string-matchall/#sec-regexp-prototype-matchall",
+            "support": {
+              "chrome": {
+                "version_added": "73"
+              },
+              "chrome_android": {
+                "version_added": "73"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "65"
+              },
+              "firefox_android": {
+                "version_added": "65"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "60"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": "73"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "@@replace": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace",

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1613,6 +1613,61 @@
             }
           }
         },
+        "matchAll": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll",
+            "spec_url": "https://tc39.github.io/proposal-string-matchall/#sec-string-prototype-matchall",
+            "support": {
+              "chrome": {
+                "version_added": "73"
+              },
+              "chrome_android": {
+                "version_added": "73"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "65"
+              },
+              "firefox_android": {
+                "version_added": "65"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "60"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": "73"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "normalize": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/normalize",

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1631,10 +1631,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "65"
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": "65"
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -524,10 +524,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "65"
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": "65"
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -506,6 +506,61 @@
             }
           }
         },
+        "matchAll": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/matchAll",
+            "spec_url": "https://tc39.github.io/proposal-string-matchall/#Symbol.matchAll",
+            "support": {
+              "chrome": {
+                "version_added": "73"
+              },
+              "chrome_android": {
+                "version_added": "73"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "65"
+              },
+              "firefox_android": {
+                "version_added": "65"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "60"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": "73"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/prototype",


### PR DESCRIPTION
Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1435829
Chromiums: https://www.chromestatus.com/features/5520028858318848
Safari: https://bugs.webkit.org/show_bug.cgi?id=186694
Spec: https://github.com/tc39/proposal-string-matchall


Should pass once the other PR with the latest Chrome versions is merged.

(MDN pages do not yet exist, documenting these soon)