### PR TITLE
getDisplayMedia available in Firefox 66 + clarify Chrome/Edge versions

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -228,27 +228,70 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/getDisplayMedia",
           "description": "<code>getDisplayMedia()</code>",
           "support": {
-            "chrome": {
-              "version_added": "70",
-              "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code> in Chrome 70 and 71."
-            },
-            "chrome_android": {
-              "version_added": "70",
-              "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code> in Chrome 70 and 71."
-            },
+            "chrome": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "70",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform features",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code> in Chrome 70 and 71."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "70",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform features",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code> in Chrome 70 and 71."
+              }
+            ],
             "edge": {
-              "version_added": true
+              "version_added": "17",
+              "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code>."
             },
             "edge_mobile": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": false,
-              "notes": "Since Firefox 33 you can capture screen data using <code><a href='https://developer.mozilla.org/docs/Web/API/MediaDevices/getUserMedia'>getUserMedia()</a></code>, with a <code>video</code> constraint called <code>mediaSource</code>."
-            },
             "firefox_android": {
               "version_added": false
             },
+            "firefox": [
+              {
+                "version_added": "66"
+              },
+              {
+                "version_added": "33",
+                "version_removed": "66",
+                "notes": "Since Firefox 33 you can capture screen data using <code><a href='https://developer.mozilla.org/docs/Web/API/MediaDevices/getUserMedia'>getUserMedia()</a></code>, with a <code>video</code> constraint called <code>mediaSource</code>. Prior to 52 it relied on a client-configurable whitelist."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "66"
+              },
+              {
+                "version_added": "33",
+                "version_removed": "66",
+                "notes": "Since Firefox 33 you can capture screen data using <code><a href='https://developer.mozilla.org/docs/Web/API/MediaDevices/getUserMedia'>getUserMedia()</a></code>, with a <code>video</code> constraint called <code>mediaSource</code>. Prior to 52 it relied on a client-configurable whitelist."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -266,7 +266,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": false,
               "notes": "API is available, but will always fail with <code>NotAllowedError</code>."
             },
             "ie": {

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -288,7 +288,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false,
+              "notes": "API is available, but will always fail with <code>NotAllowedError</code>."
             }
           },
           "status": {

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -245,32 +245,15 @@
                 "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code> in Chrome 70 and 71."
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "72"
-              },
-              {
-                "version_added": "70",
-                "version_removed": "72",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code> in Chrome 70 and 71."
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17",
               "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code>."
             },
             "edge_mobile": {
               "version_added": true
-            },
-            "firefox_android": {
-              "version_added": false
             },
             "firefox": [
               {
@@ -282,16 +265,10 @@
                 "notes": "Since Firefox 33 you can capture screen data using <code><a href='https://developer.mozilla.org/docs/Web/API/MediaDevices/getUserMedia'>getUserMedia()</a></code>, with a <code>video</code> constraint called <code>mediaSource</code>. Prior to 52 it relied on a client-configurable whitelist."
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "66"
-              },
-              {
-                "version_added": "33",
-                "version_removed": "66",
-                "notes": "Since Firefox 33 you can capture screen data using <code><a href='https://developer.mozilla.org/docs/Web/API/MediaDevices/getUserMedia'>getUserMedia()</a></code>, with a <code>video</code> constraint called <code>mediaSource</code>. Prior to 52 it relied on a client-configurable whitelist."
-              }
-            ],
+            "firefox_android": {
+              "version_added": false
+              "notes": "API is available, but will always fail with <code>NotAllowedError</code>."
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
In [Firefox 66](https://bugzilla.mozilla.org/show_bug.cgi?id=1321221), [Edge 17](https://blogs.windows.com/msedgedev/2018/05/02/bringing-screen-capture-to-microsoft-edge-media-capture-api/), [Chrome 72](https://www.chromestatus.com/feature/6744724455030784). @a2sheppy PTAL.