### PR TITLE
[Chrome] Update document.idl from Git history.

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
             "version_added": true
@@ -101,7 +101,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/URL",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -149,7 +149,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/adoptNode",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -197,10 +197,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/alinkColor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "edge": {
               "version_added": null
@@ -230,7 +232,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             }
           },
           "status": {
@@ -244,10 +247,12 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "edge": {
               "version_added": null
@@ -277,7 +282,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             }
           },
           "status": {
@@ -292,7 +298,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/anchors",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -340,7 +346,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/applets",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -436,10 +442,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/bgColor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "edge": {
               "version_added": null
@@ -469,7 +477,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             }
           },
           "status": {
@@ -534,10 +543,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/captureEvents",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "edge": {
               "version_added": null
@@ -567,7 +578,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             }
           },
           "status": {
@@ -582,10 +594,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/caretRangeFromPoint",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -615,7 +627,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": true
             }
           },
           "status": {
@@ -631,16 +643,16 @@
           "support": {
             "chrome": [
               {
-                "version_added": "45"
+                "version_added": "1"
               },
               {
                 "alternative_name": "charset",
-                "version_added": true,
+                "version_added": "1",
                 "notes": "<code>charset</code> alias was made read-only in 45."
               },
               {
                 "alternative_name": "inputEncoding",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "chrome_android": [
@@ -649,7 +661,8 @@
               },
               {
                 "alternative_name": "charset",
-                "version_added": true
+                "version_added": true,
+                "notes": "<code>charset</code> alias was made read-only in 45."
               },
               {
                 "alternative_name": "inputEncoding",
@@ -779,7 +792,8 @@
               },
               {
                 "alternative_name": "charset",
-                "version_added": true
+                "version_added": true,
+                "notes": "<code>charset</code> alias was made read-only in 45."
               },
               {
                 "alternative_name": "inputEncoding",
@@ -799,10 +813,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/clear",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "edge": {
               "version_added": null
@@ -832,7 +848,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             }
           },
           "status": {
@@ -847,10 +864,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/close",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "edge": {
               "version_added": null
@@ -880,7 +899,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             }
           },
           "status": {
@@ -895,10 +915,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/compatMode",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": null
@@ -928,7 +948,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -991,10 +1011,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/contentType",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": null
@@ -1024,7 +1044,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -1039,7 +1059,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/cookie",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -1087,7 +1107,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createAttribute",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -1149,7 +1169,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createAttributeNS",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -1197,7 +1217,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createCDATASection",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -1245,7 +1265,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createComment",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -1293,7 +1313,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createDocumentFragment",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -1341,7 +1361,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createElement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -1445,7 +1465,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createElementNS",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -1597,7 +1617,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createEvent",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -1645,7 +1665,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createExpression",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -1693,7 +1713,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createNSResolver",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -1741,7 +1761,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createNodeIterator",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -1789,7 +1809,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createProcessingInstruction",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -1837,7 +1857,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createRange",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -1885,7 +1905,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createTextNode",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -2004,10 +2024,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createTouchList",
           "support": {
             "chrome": {
-              "version_added": "22"
+              "version_added": "22",
+              "version_removed": "69"
             },
             "chrome_android": {
-              "version_added": "25"
+              "version_added": "25",
+              "version_removed": "69"
             },
             "edge": {
               "version_added": true
@@ -2037,7 +2059,8 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "25",
+              "version_removed": "69"
             }
           },
           "status": {
@@ -2052,7 +2075,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createTreeWalker",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -2201,7 +2224,7 @@
               "version_added": "29"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "edge": {
               "version_added": true
@@ -2246,7 +2269,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/defaultView",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -2294,10 +2317,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/designMode",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "edge": {
               "version_added": true
@@ -2327,7 +2352,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             }
           },
           "status": {
@@ -2342,10 +2368,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/dir",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "edge": {
               "version_added": true
@@ -2377,7 +2405,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             }
           },
           "status": {
@@ -2392,7 +2421,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/doctype",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -2440,7 +2469,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/documentElement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -2488,7 +2517,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/documentURI",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -2684,7 +2713,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/domain",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -2734,10 +2763,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/embeds",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "edge": {
               "version_added": null
@@ -2767,7 +2798,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             }
           },
           "status": {
@@ -2878,7 +2910,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/execCommand",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -2973,10 +3005,10 @@
             "description": "<code>copy</code> command",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false
               },
               "edge": {
                 "version_added": true
@@ -3006,7 +3038,7 @@
                 "version_added": "10"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": false
               }
             },
             "status": {
@@ -3021,10 +3053,10 @@
             "description": "<code>cut</code> command",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false
               },
               "edge": {
                 "version_added": true
@@ -3054,7 +3086,7 @@
                 "version_added": "10"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": false
               }
             },
             "status": {
@@ -3069,10 +3101,10 @@
             "description": "<code>defaultParagraphSeparator</code> command",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false
               },
               "edge": {
                 "version_added": true
@@ -3102,7 +3134,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": true
+                "version_added": false
               }
             },
             "status": {
@@ -3373,16 +3405,16 @@
           "support": {
             "chrome": [
               {
-                "version_added": true
+                "version_added": "45"
               },
               {
-                "version_added": true,
+                "version_added": "22",
                 "prefix": "webkit"
               }
             ],
             "chrome_android": [
               {
-                "version_added": true
+                "version_added": "45"
               },
               {
                 "version_added": true,
@@ -3430,7 +3462,7 @@
             },
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "45"
               },
               {
                 "version_added": true,
@@ -3450,10 +3482,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fgColor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "edge": {
               "version_added": null
@@ -3483,7 +3517,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             }
           },
           "status": {
@@ -3611,7 +3646,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/forms",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -3660,11 +3695,11 @@
           "support": {
             "chrome": {
               "alternative_name": "webkitIsFullScreen",
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
               "alternative_name": "webkitIsFullScreen",
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -3727,7 +3762,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -3972,7 +4007,7 @@
               "version_added": "1"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -3987,7 +4022,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/getElementsByClassName",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -4035,7 +4070,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/getElementsByName",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -4086,7 +4121,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/getElementsByTagName",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -4134,7 +4169,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/getElementsByTagNameNS",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -4182,10 +4217,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/hasFocus",
           "support": {
             "chrome": {
-              "version_added": "30"
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": true
@@ -4215,7 +4250,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "45"
             }
           },
           "status": {
@@ -4294,7 +4329,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/head",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": {
               "version_added": true
@@ -4398,9 +4433,15 @@
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": [
+              {
+                "version_added": "33"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ],
             "edge": {
               "version_added": true
             },
@@ -4460,7 +4501,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/images",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -4508,7 +4549,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/implementation",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -4556,7 +4597,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/importNode",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -4652,7 +4693,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/lastModified",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -4748,10 +4789,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/linkColor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "edge": {
               "version_added": null
@@ -4781,7 +4824,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             }
           },
           "status": {
@@ -4796,7 +4840,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/links",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -4915,7 +4959,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/location",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -5852,10 +5896,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/open",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "edge": {
               "version_added": true
@@ -5885,7 +5931,8 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             }
           },
           "status": {
@@ -5900,10 +5947,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/origin",
           "support": {
             "chrome": {
-              "version_added": "41"
+              "version_added": "41",
+              "version_removed": "71"
             },
             "chrome_android": {
-              "version_added": "41"
+              "version_added": "41",
+              "version_removed": "71"
             },
             "edge": {
               "version_added": null
@@ -5933,7 +5982,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "41",
+              "version_removed": "71"
             }
           },
           "status": {
@@ -5948,10 +5998,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/plugins",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "edge": {
               "version_added": null
@@ -5981,7 +6033,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             }
           },
           "status": {
@@ -6128,7 +6181,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/preferredStyleSheetSet",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -6176,7 +6229,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/queryCommandEnabled",
           "support": {
             "chrome": {
-              "version_added": "17"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -6238,7 +6291,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/queryCommandIndeterm",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -6286,7 +6339,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/queryCommandState",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -6334,7 +6387,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/queryCommandSupported",
           "support": {
             "chrome": {
-              "version_added": "17"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -6450,7 +6503,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/queryCommandValue",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -6594,7 +6647,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/readyState",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -6651,7 +6704,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/referrer",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -6821,10 +6874,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/releaseEvents",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "edge": {
               "version_added": null
@@ -6854,7 +6909,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             }
           },
           "status": {
@@ -7089,7 +7145,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/selectedStyleSheetSet",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -7235,7 +7291,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/title",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -7388,9 +7444,15 @@
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": {
-              "version_added": "33"
-            },
+            "chrome_android": [
+              {
+                "version_added": "33"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -7498,10 +7560,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/vlinkColor",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "edge": {
               "version_added": null
@@ -7531,7 +7595,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "64",
+              "notes": "Moved from <code>HTMLDocument</code>."
             }
           },
           "status": {
@@ -7642,10 +7707,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/write",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "edge": {
               "version_added": null
@@ -7675,7 +7742,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             }
           },
           "status": {
@@ -7690,10 +7758,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/writeln",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             },
             "edge": {
               "version_added": null
@@ -7723,7 +7793,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "45",
+              "notes": "Moved from <code>HTMLDocument</code>."
             }
           },
           "status": {
@@ -7738,7 +7809,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/xmlEncoding",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -7783,9 +7854,10 @@
       },
       "xmlStandalone": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/xmlStandalone",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true
@@ -7833,7 +7905,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/xmlVersion",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true


### PR DESCRIPTION
Not perfect, but much improved.
* copy, cut, defaultParagraphSeparator, exitFullscreen, fileSize, fullscreen/webkitIsFulScreen, getAnimations, getBoxObjectFor, hasStorageAccess, height, lastStyleSheetSet, loadOverlay, normalizeDocument, onafterscriptexecute, onbeforescriptexecute, oncopy, popupNode, queryCommandText, releaseCapture, requestStorageAccess, routeEvent, styleSheetSets, timeline, tooltipNode, undoManager, and width are not in Document.idl. They may be in partials in other IDL files.
* Document [IDl state before Chrome 1](https://chromium.googlesource.com/chromium/src/+/669b92068f032979e649db30ba716b0f3e5af55b/third_party/WebKit/WebCore/dom/Document.idl) Included: doctype, implementation, documentElement, createElement, createDocumentFragment, createTextNode, createComment, createCDATASection, createProcessingInstruction, createAttribute, getElementsByTagName, importNode, createElementNS, createAttributeNS, getElementsByTagNameNS, inputEncoding, xmlEncoding, xmlVersion, xmlStandalone, adoptNode, documentURI, createEvent, createRange, createNodeIterator, createTreeWalker, defaultView, createExpression, createNSResolver, evaluate, execCommand, queryCommandEnabled, queryCommandIndeterm, queryCommandState, queryCommandSupported, title, domain, URL, cookie, body, images, links, forms, anchors, lastModified, getElementsByName, location, charset, readyState, preferredStylesheetSet, selectedStylesheetSet, getElementsByClassName, querySelector, and querySelectorAll.
* [fgColor, linkColor, vlinkColor, alinkColor, bgColor, Clear(), captureEvents(), releaseEvents(), all](https://storage.googleapis.com/chromium-find-releases-static/857.html#8574ecc06bdfcfad71ba4629174a785988996780)
* [caretRangeFromPoint](https://chromium.googlesource.com/chromium/src/+/b34bb56059ab5d888ed3678dd155de88d5ab8efb)
* [open(), close(), write(), writeLn()](https://storage.googleapis.com/chromium-find-releases-static/331.html#331fe69be9ccc88fe63c3e8f736b2fa1a75a4d14)
* [compatMode, contentType](https://chromium.googlesource.com/chromium/src/+/fbef713502f3c6490406cf0dae7fb34617536b9e%5E%21/#F0)
* [Remove createTouchList](https://chromiumdash.appspot.com/commit/b2c1f195b6e16986e3278cd5bd6410d0984589e8)
* [designMode](https://storage.googleapis.com/chromium-find-releases-static/240.html#2402569d4a7a764851741cdbb90ac3e663bcba1e)
* [dir](https://storage.googleapis.com/chromium-find-releases-static/538.html#5385e245ebbdf5dc69986e54f1b53c839e8950d2)
* [embeds, plugins](https://storage.googleapis.com/chromium-find-releases-static/d08.html#d085bd460067946c9317865dda3dca2075f7f6e7)
* [webkitExitPointerLock](https://chromium.googlesource.com/chromium/src/+/2edab9710e9ef603820397b096790fd098983d79%5E%21/#F12)
* [Unprefixed exitPointerLock() and pointerLockElement](https://storage.googleapis.com/chromium-find-releases-static/ea5.html#ea5cec42b1c0650b03c80de6fe2d9423623b67a1)
* [hasFocus](https://storage.googleapis.com/chromium-find-releases-static/d76.html#d767cf37bfb284acdd4c63a0b9a44698de8362ef)
* [head](https://chromium.googlesource.com/chromium/src/+/3121c9ccd70aa3c02c1745d661e4cd52bd84ddb7%5E%21/#F5)
* [hidden, visibilityStaate](https://chromium.googlesource.com/chromium/src/+/5c00fdf0c0d7b96068cb82edea1f384702320626%5E%21/#F14)
* [origin removed](https://www.chromestatus.com/features/5701042356355072)
