### PR TITLE
feat(JavaScript): Complete RegExp lookbehind assertions

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -733,19 +733,21 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1225665'>bug 1225665</a>."
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1225665'>bug 1225665</a>."
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": "49"
@@ -754,10 +756,10 @@
                 "version_added": "49"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": null


### PR DESCRIPTION
- Node.js added support in&nbsp;version&nbsp;8.10.0 (verified&nbsp;manually).
- Firefox is&nbsp;implementing this&nbsp;in&nbsp;[bug&nbsp;1225665](https://bugzilla.mozilla.org/show_bug.cgi?id=1225665).
- Safari doesn’t support this (verified&nbsp;manually).
- Microsoft&nbsp;Edge and IE don’t support this (verified&nbsp;manually).

review?(@Elchi3)