### PR TITLE
updating URL and URLSearchParams BCD

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -28,24 +28,20 @@
           "edge_mobile": {
             "version_added": "12"
           },
-          "firefox": [
-            {
-              "version_added": "19",
-              "notes": [
-                "Firefox had a bug whereby single quotes contained in URLs are escaped when accessed via URL APIs (see <a href='https://bugzil.la/1386683'>bug 1386683</a>). This has been fixed as of Firefox 57.",
-                "To use it from chrome code, JSM and Bootstrap scope, you have to import it with <code>Cu.importGlobalProperties(['URL']);</code>."
-              ]
-            }
-          ],
-          "firefox_android": [
-            {
-              "version_added": "19",
-              "notes": [
-                "Firefox had a bug whereby single quotes contained in URLs are escaped when accessed via URL APIs (see <a href='https://bugzil.la/1386683'>bug 1386683</a>). This has been fixed as of Firefox 57.",
-                "To use it from chrome code, JSM and Bootstrap scope, you have to import it with <code>Cu.importGlobalProperties(['URL']);</code>."
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "19",
+            "notes": [
+              "Firefox had a bug whereby single quotes contained in URLs are escaped when accessed via URL APIs (see <a href='https://bugzil.la/1386683'>bug 1386683</a>). This has been fixed as of Firefox 57.",
+              "To use it from chrome code, JSM and Bootstrap scope, you have to import it with <code>Cu.importGlobalProperties(['URL']);</code>."
+            ]
+          },
+          "firefox_android": {
+            "version_added": "19",
+            "notes": [
+              "Firefox had a bug whereby single quotes contained in URLs are escaped when accessed via URL APIs (see <a href='https://bugzil.la/1386683'>bug 1386683</a>). This has been fixed as of Firefox 57.",
+              "To use it from chrome code, JSM and Bootstrap scope, you have to import it with <code>Cu.importGlobalProperties(['URL']);</code>."
+            ]
+          },
           "ie": {
             "version_added": null
           },
@@ -482,10 +478,10 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "12",
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": "12",
+              "version_added": "12"
             },
             "firefox": [
               {

--- a/api/URL.json
+++ b/api/URL.json
@@ -924,10 +924,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/toJSON",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "71"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "71"
             },
             "edge": {
               "version_added": "17"
@@ -960,7 +960,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "71"
             }
           },
           "status": {
@@ -975,10 +975,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/toString",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "52"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "52"
             },
             "edge": {
               "version_added": "17"
@@ -1011,7 +1011,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "52"
             }
           },
           "status": {

--- a/api/URL.json
+++ b/api/URL.json
@@ -31,14 +31,14 @@
           "firefox": {
             "version_added": "19",
             "notes": [
-              "Firefox had a bug whereby single quotes contained in URLs are escaped when accessed via URL APIs (see <a href='https://bugzil.la/1386683'>bug 1386683</a>). This has been fixed as of Firefox 57.",
+              "Before version 57, Firefox had a bug whereby single quotes contained in URLs are escaped when accessed via URL APIs (see <a href='https://bugzil.la/1386683'>bug 1386683</a>).",
               "To use it from chrome code, JSM and Bootstrap scope, you have to import it with <code>Cu.importGlobalProperties(['URL']);</code>."
             ]
           },
           "firefox_android": {
             "version_added": "19",
             "notes": [
-              "Firefox had a bug whereby single quotes contained in URLs are escaped when accessed via URL APIs (see <a href='https://bugzil.la/1386683'>bug 1386683</a>). This has been fixed as of Firefox 57.",
+              "Before version 57, Firefox had a bug whereby single quotes contained in URLs are escaped when accessed via URL APIs (see <a href='https://bugzil.la/1386683'>bug 1386683</a>).",
               "To use it from chrome code, JSM and Bootstrap scope, you have to import it with <code>Cu.importGlobalProperties(['URL']);</code>."
             ]
           },

--- a/api/URL.json
+++ b/api/URL.json
@@ -35,11 +35,6 @@
                 "Firefox had a bug whereby single quotes contained in URLs are escaped when accessed via URL APIs (see <a href='https://bugzil.la/1386683'>bug 1386683</a>). This has been fixed as of Firefox 57.",
                 "To use it from chrome code, JSM and Bootstrap scope, you have to import it with <code>Cu.importGlobalProperties(['URL']);</code>."
               ]
-            },
-            {
-              "version_added": "4",
-              "version_removed": "18",
-              "notes": "This interface was supported with the non-standard <code>nsIDOMMozURLProperty</code> internal type. However this didn't make any difference in practice, as the only way to access such an object was through <code>window.URL</code>."
             }
           ],
           "firefox_android": [
@@ -49,11 +44,6 @@
                 "Firefox had a bug whereby single quotes contained in URLs are escaped when accessed via URL APIs (see <a href='https://bugzil.la/1386683'>bug 1386683</a>). This has been fixed as of Firefox 57.",
                 "To use it from chrome code, JSM and Bootstrap scope, you have to import it with <code>Cu.importGlobalProperties(['URL']);</code>."
               ]
-            },
-            {
-              "version_added": "14",
-              "version_removed": "18",
-              "notes": "This interface was supported with the non-standard <code>nsIDOMMozURLProperty</code> internal type. However this didn't make any difference in practice, as the only way to access such an object was through <code>window.URL</code>."
             }
           ],
           "ie": {
@@ -96,7 +86,7 @@
             }
           ],
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": [
             {
@@ -154,7 +144,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -207,10 +197,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -312,10 +302,10 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -357,16 +347,16 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -408,16 +398,16 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -459,16 +449,16 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -493,20 +483,13 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
             },
             "edge_mobile": {
               "version_added": "12",
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
             },
             "firefox": [
               {
                 "version_added": "26"
-              },
-              {
-                "version_added": "26",
-                "version_removed": "44",
-                "notes": "This property was on the <code>URLUtils</code> mixin. It has been moved either to the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
               },
               {
                 "version_added": "26",
@@ -520,11 +503,6 @@
               },
               {
                 "version_added": "26",
-                "version_removed": "44",
-                "notes": "This property was on the <code>URLUtils</code> mixin. It has been moved either to the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
-              },
-              {
-                "version_added": "26",
                 "version_removed": "49",
                 "notes": "Results for <code>URL</code> using the <code>blob</code> scheme incorrectly returned <code>null</code>."
               }
@@ -533,23 +511,19 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true,
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
+              "version_added": true
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
+              "version_added": true
             },
             "safari": {
-              "version_added": "10",
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true,
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "52"
@@ -573,12 +547,10 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "12",
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": "12",
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "26"
@@ -590,23 +562,19 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true,
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
+              "version_added": true
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
+              "version_added": true
             },
             "safari": {
-              "version_added": "10",
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true,
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "52"
@@ -662,16 +630,16 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -713,16 +681,16 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -764,16 +732,16 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -826,10 +794,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -888,10 +856,10 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -921,10 +889,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "52"
+              "version_added": "29"
             },
             "firefox_android": {
-              "version_added": "52"
+              "version_added": "29"
             },
             "ie": {
               "version_added": false
@@ -933,16 +901,16 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "51"
@@ -960,10 +928,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/toJSON",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "17"
@@ -978,25 +946,76 @@
               "version_added": "54"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toString": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/toString",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "edge_mobile": {
               "version_added": null
+            },
+            "firefox": {
+              "version_added": "54"
+            },
+            "firefox_android": {
+              "version_added": "54"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -1017,12 +1036,10 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "12",
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": "12",
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "26"
@@ -1034,23 +1051,19 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true,
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
+              "version_added": true
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
+              "version_added": true
             },
             "safari": {
-              "version_added": "10",
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true,
-              "notes": "Defined in another interface but available to use from <code>URL</code>."
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "52"

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -37,10 +37,10 @@
             "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "49"
@@ -91,7 +91,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -141,7 +141,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": "61"
@@ -193,7 +193,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -248,7 +248,7 @@
               "notes": "Removing a non-existent query parameter doesn't remove <code>?</code> from the URL. See <a href='https://bugs.webkit.org/show_bug.cgi?id=193022'>bug 193022</a>."
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -299,7 +299,58 @@
               "version_added": true
             },
             "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "49"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "forEach": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URLSearchParams/forEach",
+          "support": {
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": "49"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "edge_mobile": {
               "version_added": null
+            },
+            "firefox": {
+              "version_added": "44"
+            },
+            "firefox_android": {
+              "version_added": "44"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "36"
+            },
+            "opera_android": {
+              "version_added": "36"
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -350,7 +401,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -401,7 +452,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -452,7 +503,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -503,7 +554,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -554,7 +605,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -605,7 +656,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "61"
@@ -656,7 +707,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -707,7 +758,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"


### PR DESCRIPTION
This work was started due to the filing of https://bugzilla.mozilla.org/show_bug.cgi?id=1315191.

I ended up rabbit-holing on this rather a lot, and changed a lot of the data. I:

* added `URL.toString()` and `URLSearchParams.forEach()` — the first item is implied by 'stringifier' in the WebIDL and the second is implied by the presence of 'iterable' in the WebIDL. Both work and have been extensively tested.
* updated most of the `null` data to `true`; everything except for IE/Edge as I can't easily test those. I tested all the features on Safari/iOS/Samsung Internet/Opera Mobile/Chrome/Firefox/Firefox Android/Chrome Android. This stuff seems to work pretty much everywhere now.
* removed all the notes about proerties being available on different interfaces, as this was quite a while ago, and I think it is just confusing and not helpful.
* updated the Firefox support data for `URL.searchParams` to 29 (the original point of the bug that Marco filed, I think). I got this from the actual `URLSearchParams` interface support data — I don't see why this would be added in 29 if the `URL.searchParams` property was added 20 versions or more later.