### PR TITLE
adding step() with jump- keyterms.

### DIFF
--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -173,7 +173,7 @@
         },
         "jump": {
           "__compat": {
-            "description": "<code>jump-</code> keywords",
+            "description": "<code>jump-</code> keywords for <code>steps()</code>",
             "support": {
               "chrome": {
                 "version_added": null

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -170,6 +170,57 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "jump": {
+          "__compat": {
+            "description": "<code>jump-</code> keywords",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "65"
+              },
+              "firefox_android": {
+                "version_added": "65"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -154,7 +154,7 @@
         },
         "jump": {
           "__compat": {
-            "description": "<code>jump-</code> keywords",
+            "description": "<code>jump-</code> keywords for <code>steps()</code>",
             "support": {
               "chrome": {
                 "version_added": null

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -151,6 +151,57 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "jump": {
+          "__compat": {
+            "description": "<code>jump-</code> keywords",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "65"
+              },
+              "firefox_android": {
+                "version_added": "65"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/types/timing-function.json
+++ b/css/types/timing-function.json
@@ -152,56 +152,56 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "jump": {
-          "__compat": {
-            "description": "<code>jump-</code> keywords for <code>steps()</code>",
-            "support": {
-              "chrome": {
-                "version_added": null
+          },
+          "jump": {
+            "__compat": {
+              "description": "<code>jump-</code> keywords for <code>steps()</code>",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "65"
+                },
+                "firefox_android": {
+                  "version_added": "65"
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
               },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "65"
-              },
-              "firefox_android": {
-                "version_added": "65"
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              },
-              "webview_android": {
-                "version_added": null
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
             }
           }
         }

--- a/css/types/timing-function.json
+++ b/css/types/timing-function.json
@@ -4,7 +4,7 @@
       "timing-function": {
         "__compat": {
           "description": "<code>&lt;timing-function&gt;</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/single-transition-timing-function",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timing-function",
           "support": {
             "chrome": {
               "version_added": "4"
@@ -60,13 +60,13 @@
                 "version_added": "16"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": true
               },
               "firefox": {
                 "version_added": "4"
@@ -81,16 +81,16 @@
                 "version_added": "12.1"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -105,19 +105,19 @@
         },
         "steps": {
           "__compat": {
-            "description": "<code>steps()</code>",
+            "description": "<code>steps()</code> with <code>start</code>, <code>end</code> or no direction",
             "support": {
               "chrome": {
                 "version_added": "8"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": true
               },
               "firefox": {
                 "version_added": "4"
@@ -132,7 +132,7 @@
                 "version_added": "12.1"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": "5.1"
@@ -141,7 +141,7 @@
                 "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": "4"
@@ -149,6 +149,57 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "jump": {
+          "__compat": {
+            "description": "<code>jump-</code> keywords for <code>steps()</code>",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "65"
+              },
+              "firefox_android": {
+                "version_added": "65"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
adding step() with jump- keyterms.

updated a few missing browser supports. I've been playing with cubic-bzier outside of [0,1] for many years, so i know it's pretty well supported, 
Looked at caniuse.com animation to confirm the steps.
there is an issue with chrome bug if animation-fill-mode is backwards that step(start) is off - it jumps to the first step and stays there instead of the 0% keyframe. but that is more of a fill-mode issue than a steps issue, and not updating the fill-mode in this branch.

https://bugzilla.mozilla.org/show_bug.cgi?id=1496619 shows steps(jump-* ) supported in FF65. Tested canary and safari tech preview. No support in either on a feature added to the spec in November.

testing? see https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timing-function - the second codepen example.
