### PR TITLE
Updated browser support for document.adoptNode()

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -167,7 +167,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": 9
+              "version_added": "9"
             },
             "opera": {
               "version_added": true

--- a/api/Document.json
+++ b/api/Document.json
@@ -155,7 +155,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -167,16 +167,16 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": 9
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null


### PR DESCRIPTION
I tested in IE11 and Edge, and [this MSDN article](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/ff975548(v=vs.85)) says it was added in IE9.
