### PR TITLE
Fix the compat data fo subfeatures of Intl.RelativeTimeFormat

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -1651,7 +1651,7 @@
                   "version_added": "71"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": false
                 },
                 "edge_mobile": {
                   "version_added": false
@@ -1663,10 +1663,10 @@
                   "version_added": "65"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": null
@@ -1705,7 +1705,7 @@
                   "version_added": "71"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": false
                 },
                 "edge_mobile": {
                   "version_added": false
@@ -1717,10 +1717,10 @@
                   "version_added": "65"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": null


### PR DESCRIPTION
Browsers which don't support Intl.RelativeTimeFormat don't support the subfeatures either.

This implements the fixes for https://github.com/mdn/browser-compat-data/pull/3254#pullrequestreview-193280327