### PR TITLE
storage access api enabled in Fx65 desktop by default

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4242,14 +4242,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.storage_access.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "65"
             },
             "firefox_android": {
               "version_added": "65",
@@ -6895,14 +6888,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.storage_access.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "65"
             },
             "firefox_android": {
               "version_added": "65",


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1513021