### PR TITLE
Update Array.prototype.flat() support in Node.js

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -555,7 +555,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "11.0.0"
               },
               "opera": {
                 "version_added": "56"


### PR DESCRIPTION
Support for `Array.prototype.flat()` was added in Node.js 11.0.0.
node.green [link](https://node.green/#ESNEXT-candidate--stage-3--Array-prototype--flat--flatMap--Array-prototype-flat).