### PR TITLE
Compat data for WebExt OnClickData.button field.

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -296,6 +296,27 @@
               }
             }
           },
+          "button": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "64"
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
           "frameId": {
             "__compat": {
               "support": {


### PR DESCRIPTION
Added to Firefox in version 64 (bug 1469148). I'm not sure if that
applies to Firefox for Android, so I've left it out.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
