### PR TITLE
Add missing Edge 13 data based on Confluence

### DIFF
--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -373,7 +373,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -529,7 +529,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/AudioTrack.json
+++ b/api/AudioTrack.json
@@ -61,7 +61,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -112,7 +112,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -163,7 +163,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -214,7 +214,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -265,7 +265,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -316,7 +316,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -86,7 +86,7 @@
               }
             ],
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -160,7 +160,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -208,7 +208,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -256,7 +256,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -304,7 +304,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/CSSMediaRule.json
+++ b/api/CSSMediaRule.json
@@ -60,7 +60,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/CSSPageRule.json
+++ b/api/CSSPageRule.json
@@ -112,7 +112,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/CSSRule.json
+++ b/api/CSSRule.json
@@ -58,7 +58,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -106,7 +106,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -154,7 +154,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -202,7 +202,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/CSSRuleList.json
+++ b/api/CSSRuleList.json
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/CSSStyleDeclaration.json
+++ b/api/CSSStyleDeclaration.json
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -503,7 +503,7 @@
               "version_added": "46"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/CharacterData.json
+++ b/api/CharacterData.json
@@ -108,7 +108,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -156,7 +156,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -204,7 +204,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -252,7 +252,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -300,7 +300,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -348,7 +348,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -396,7 +396,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -159,7 +159,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -210,7 +210,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -261,7 +261,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -312,7 +312,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -363,7 +363,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -870,7 +870,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -972,7 +972,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/DeviceAcceleration.json
+++ b/api/DeviceAcceleration.json
@@ -61,7 +61,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -112,7 +112,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -163,7 +163,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Document.json
+++ b/api/Document.json
@@ -155,7 +155,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -203,7 +203,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -250,7 +250,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -298,7 +298,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -442,7 +442,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -540,7 +540,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -805,7 +805,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -853,7 +853,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -901,7 +901,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1155,7 +1155,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1203,7 +1203,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1251,7 +1251,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1603,7 +1603,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1651,7 +1651,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1699,7 +1699,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1747,7 +1747,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1795,7 +1795,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1843,7 +1843,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -2398,7 +2398,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -2446,7 +2446,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -2690,7 +2690,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -2740,7 +2740,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -3172,7 +3172,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": false
@@ -3456,7 +3456,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -3617,7 +3617,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -3760,7 +3760,7 @@
               }
             ],
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -4092,7 +4092,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -4140,7 +4140,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -4459,7 +4459,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -4507,7 +4507,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -4651,7 +4651,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -4747,7 +4747,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -5346,7 +5346,7 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -5419,7 +5419,7 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -5539,7 +5539,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -5587,7 +5587,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -5635,7 +5635,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -5947,7 +5947,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -6251,7 +6251,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -6409,7 +6409,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": false
@@ -6463,7 +6463,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -6664,7 +6664,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -6834,7 +6834,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -7241,7 +7241,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -7392,7 +7392,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -7504,7 +7504,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -7648,7 +7648,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -7696,7 +7696,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -7744,7 +7744,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -7791,7 +7791,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -7839,7 +7839,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/DocumentType.json
+++ b/api/DocumentType.json
@@ -58,7 +58,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": false
@@ -108,7 +108,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": false
@@ -204,7 +204,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": false

--- a/api/ErrorEvent.json
+++ b/api/ErrorEvent.json
@@ -107,7 +107,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -155,7 +155,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -203,7 +203,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -251,7 +251,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -299,7 +299,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Event.json
+++ b/api/Event.json
@@ -107,7 +107,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -210,7 +210,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -541,7 +541,7 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1299,7 +1299,7 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/File.json
+++ b/api/File.json
@@ -334,7 +334,7 @@
               "prefix": "webkit"
             },
             "edge": {
-              "version_added": false
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": false

--- a/api/FileList.json
+++ b/api/FileList.json
@@ -61,7 +61,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -112,7 +112,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/HTMLCollection.json
+++ b/api/HTMLCollection.json
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -61,7 +61,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -112,7 +112,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -214,7 +214,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -265,7 +265,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -316,7 +316,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -367,7 +367,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -418,7 +418,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -469,7 +469,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -520,7 +520,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -571,7 +571,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -724,7 +724,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -826,7 +826,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/HTMLFrameElement.json
+++ b/api/HTMLFrameElement.json
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -202,7 +202,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -250,7 +250,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -298,7 +298,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -346,7 +346,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -394,7 +394,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -442,7 +442,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -490,7 +490,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/HTMLFrameSetElement.json
+++ b/api/HTMLFrameSetElement.json
@@ -152,7 +152,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -199,7 +199,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -246,7 +246,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -104,7 +104,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -149,7 +149,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -194,7 +194,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -494,7 +494,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -539,7 +539,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -584,7 +584,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -629,7 +629,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -719,7 +719,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1099,7 +1099,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1147,7 +1147,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1195,7 +1195,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1243,7 +1243,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/HTMLMenuElement.json
+++ b/api/HTMLMenuElement.json
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -154,7 +154,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/HTMLOptionsCollection.json
+++ b/api/HTMLOptionsCollection.json
@@ -112,7 +112,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -214,7 +214,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -251,7 +251,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -299,7 +299,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -347,7 +347,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -395,7 +395,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -443,7 +443,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -491,7 +491,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -587,7 +587,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -779,7 +779,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/HTMLTableSectionElement.json
+++ b/api/HTMLTableSectionElement.json
@@ -106,7 +106,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": false
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": false
@@ -154,7 +154,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": false
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": false

--- a/api/HashChangeEvent.json
+++ b/api/HashChangeEvent.json
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -109,7 +109,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/History.json
+++ b/api/History.json
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -202,7 +202,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -396,7 +396,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -834,7 +834,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": false
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": false

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -61,7 +61,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -183,7 +183,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/MediaStreamTrackEvent.json
+++ b/api/MediaStreamTrackEvent.json
@@ -113,7 +113,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -265,7 +265,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -418,7 +418,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/MimeTypeArray.json
+++ b/api/MimeTypeArray.json
@@ -63,7 +63,7 @@
               "notes": "Prior to version 59, method parameters were optional"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -168,7 +168,7 @@
               "notes": "Prior to version 59, method parameters were optional"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -61,7 +61,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -112,7 +112,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -163,7 +163,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -214,7 +214,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -265,7 +265,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/NamedNodeMap.json
+++ b/api/NamedNodeMap.json
@@ -80,7 +80,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -128,7 +128,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -176,7 +176,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -224,7 +224,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -272,7 +272,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -320,7 +320,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -368,7 +368,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -416,7 +416,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1131,7 +1131,7 @@
               "version_added": "35"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1569,7 +1569,7 @@
               "notes": "Always returns <code>20030107</code>."
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -2080,7 +2080,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -2211,7 +2211,7 @@
               "version_added": "63"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Node.json
+++ b/api/Node.json
@@ -684,7 +684,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -879,7 +879,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -975,7 +975,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1195,7 +1195,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1243,7 +1243,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1611,7 +1611,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1988,7 +1988,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/PageTransitionEvent.json
+++ b/api/PageTransitionEvent.json
@@ -61,7 +61,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/PerformanceNavigation.json
+++ b/api/PerformanceNavigation.json
@@ -165,7 +165,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Plugin.json
+++ b/api/Plugin.json
@@ -61,7 +61,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -112,7 +112,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -165,7 +165,7 @@
               "notes": "Starting with version 59, method parameters are required instead of optional."
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -217,7 +217,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -270,7 +270,7 @@
               "notes": "Starting with version 59, method parameters are required instead of optional."
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -322,7 +322,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/PluginArray.json
+++ b/api/PluginArray.json
@@ -63,7 +63,7 @@
               "notes": "Starting with version 59, method parameters are required instead of optional."
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -168,7 +168,7 @@
               "notes": "Starting with version 59, method parameters are required instead of optional."
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -222,7 +222,7 @@
               "notes": "Starting with version 59, method parameters are required instead of optional."
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/PopStateEvent.json
+++ b/api/PopStateEvent.json
@@ -58,7 +58,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/ProcessingInstruction.json
+++ b/api/ProcessingInstruction.json
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Range.json
+++ b/api/Range.json
@@ -543,7 +543,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SVGCircleElement.json
+++ b/api/SVGCircleElement.json
@@ -58,7 +58,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -105,7 +105,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -152,7 +152,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SVGClipPathElement.json
+++ b/api/SVGClipPathElement.json
@@ -57,7 +57,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SVGEllipseElement.json
+++ b/api/SVGEllipseElement.json
@@ -57,7 +57,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -104,7 +104,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -151,7 +151,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -198,7 +198,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -202,7 +202,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -250,7 +250,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -298,7 +298,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -346,7 +346,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -394,7 +394,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -442,7 +442,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SVGMaskElement.json
+++ b/api/SVGMaskElement.json
@@ -57,7 +57,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -104,7 +104,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -151,7 +151,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -198,7 +198,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -245,7 +245,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -292,7 +292,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SVGPathElement.json
+++ b/api/SVGPathElement.json
@@ -112,7 +112,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -164,7 +164,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -216,7 +216,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -268,7 +268,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -320,7 +320,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -372,7 +372,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -424,7 +424,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -476,7 +476,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -528,7 +528,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -580,7 +580,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -632,7 +632,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -684,7 +684,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -736,7 +736,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -788,7 +788,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -840,7 +840,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -892,7 +892,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -944,7 +944,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -996,7 +996,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1048,7 +1048,7 @@
               "version_removed": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1099,7 +1099,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1149,7 +1149,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1200,7 +1200,7 @@
               "version_removed": "62"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SVGPatternElement.json
+++ b/api/SVGPatternElement.json
@@ -57,7 +57,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -104,7 +104,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -151,7 +151,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -198,7 +198,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -245,7 +245,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -292,7 +292,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -339,7 +339,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SVGPoint.json
+++ b/api/SVGPoint.json
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SVGRect.json
+++ b/api/SVGRect.json
@@ -57,7 +57,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -104,7 +104,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -151,7 +151,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -198,7 +198,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SVGRectElement.json
+++ b/api/SVGRectElement.json
@@ -60,7 +60,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -107,7 +107,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -154,7 +154,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -201,7 +201,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -248,7 +248,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -295,7 +295,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -104,7 +104,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -151,7 +151,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -294,7 +294,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -341,7 +341,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -388,7 +388,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -435,7 +435,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -482,7 +482,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -529,7 +529,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -576,7 +576,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -623,7 +623,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -670,7 +670,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -717,7 +717,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -816,7 +816,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -863,7 +863,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -910,7 +910,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1004,7 +1004,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1051,7 +1051,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1098,7 +1098,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1145,7 +1145,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1408,7 +1408,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1455,7 +1455,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1502,7 +1502,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1549,7 +1549,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1596,7 +1596,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1695,7 +1695,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1742,7 +1742,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1789,7 +1789,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1836,7 +1836,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SVGTextContentElement.json
+++ b/api/SVGTextContentElement.json
@@ -57,7 +57,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -104,7 +104,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -151,7 +151,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -198,7 +198,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -245,7 +245,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -292,7 +292,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -339,7 +339,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -386,7 +386,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -433,7 +433,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -480,7 +480,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -527,7 +527,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SVGTextPathElement.json
+++ b/api/SVGTextPathElement.json
@@ -57,7 +57,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -104,7 +104,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -151,7 +151,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SVGTextPositioningElement.json
+++ b/api/SVGTextPositioningElement.json
@@ -57,7 +57,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -104,7 +104,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -151,7 +151,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -198,7 +198,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -245,7 +245,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SVGUseElement.json
+++ b/api/SVGUseElement.json
@@ -57,7 +57,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -104,7 +104,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -151,7 +151,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -198,7 +198,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -245,7 +245,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -292,7 +292,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Screen.json
+++ b/api/Screen.json
@@ -269,7 +269,7 @@
               "notes": "Starting with version 59 this property is no longer required to always return 24."
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -726,7 +726,7 @@
               "notes": "Starting with version 59 this property is no longer required to always return 24."
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -495,7 +495,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1167,7 +1167,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/StorageEvent.json
+++ b/api/StorageEvent.json
@@ -107,7 +107,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -155,7 +155,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -203,7 +203,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -251,7 +251,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -299,7 +299,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -347,7 +347,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/StyleSheet.json
+++ b/api/StyleSheet.json
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -202,7 +202,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -250,7 +250,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -298,7 +298,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -346,7 +346,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/StyleSheetList.json
+++ b/api/StyleSheetList.json
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -155,7 +155,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/ValidityState.json
+++ b/api/ValidityState.json
@@ -58,7 +58,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/VideoTrack.json
+++ b/api/VideoTrack.json
@@ -61,7 +61,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -112,7 +112,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -163,7 +163,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -214,7 +214,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -265,7 +265,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -316,7 +316,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -137,7 +137,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -185,7 +185,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -233,7 +233,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -288,7 +288,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -336,7 +336,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -384,7 +384,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -432,7 +432,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -480,7 +480,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -528,7 +528,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -576,7 +576,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -624,7 +624,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -690,7 +690,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Window.json
+++ b/api/Window.json
@@ -371,7 +371,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -475,7 +475,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -2470,7 +2470,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -2805,7 +2805,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -3011,7 +3011,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -3164,7 +3164,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -3266,7 +3266,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -3317,7 +3317,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -3572,7 +3572,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -3623,7 +3623,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -3790,7 +3790,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -3841,7 +3841,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -4045,7 +4045,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -4402,7 +4402,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -4504,7 +4504,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -4744,7 +4744,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -4796,7 +4796,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -4848,7 +4848,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -5173,7 +5173,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -5225,7 +5225,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -5430,7 +5430,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -5791,7 +5791,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -7083,7 +7083,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -7134,7 +7134,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -7236,7 +7236,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -7455,7 +7455,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/XPathExpression.json
+++ b/api/XPathExpression.json
@@ -61,7 +61,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/XPathResult.json
+++ b/api/XPathResult.json
@@ -61,7 +61,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -112,7 +112,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -214,7 +214,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null


### PR DESCRIPTION
Produced by `npm run confluence -- --fill-only --browsers=edge` with
local changes applied to only include changes where the new version
was 13. Since Edge 12 was the first version of Edge and we don't have
data for Edge 12, this means we can't know if these APIs were first in
Edge 12 or Edge 13, so it can only say true.