### PR TITLE
Add missing Edge 14 data based on Confluence

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -363,7 +363,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -669,7 +669,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2355,7 +2355,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/CustomEvent.json
+++ b/api/CustomEvent.json
@@ -157,7 +157,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -219,7 +219,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -250,7 +250,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": false

--- a/api/HTMLAllCollection.json
+++ b/api/HTMLAllCollection.json
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/HTMLDataElement.json
+++ b/api/HTMLDataElement.json
@@ -61,7 +61,7 @@
               "version_added": "62"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -250,7 +250,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/HTMLOutputElement.json
+++ b/api/HTMLOutputElement.json
@@ -61,7 +61,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -112,7 +112,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -165,7 +165,7 @@
               "notes": "Before Chrome 50, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -258,7 +258,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -309,7 +309,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -360,7 +360,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -411,7 +411,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -462,7 +462,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -513,7 +513,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -564,7 +564,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -615,7 +615,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -666,7 +666,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -151,7 +151,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/HTMLTimeElement.json
+++ b/api/HTMLTimeElement.json
@@ -70,7 +70,7 @@
               "version_added": "62"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -318,7 +318,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -435,7 +435,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -603,7 +603,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -792,7 +792,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -960,7 +960,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/IIRFilterNode.json
+++ b/api/IIRFilterNode.json
@@ -116,7 +116,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/MimeType.json
+++ b/api/MimeType.json
@@ -61,7 +61,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -214,7 +214,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1861,7 +1861,7 @@
               "notes": "Starting in Chrome 59, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information see <a href='https://crbug.com/720283'>Chrome bug 720283</a>."
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -354,7 +354,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -456,7 +456,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -513,7 +513,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -627,7 +627,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -729,7 +729,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -780,7 +780,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -831,7 +831,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -882,7 +882,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -933,7 +933,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -1137,7 +1137,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -1239,7 +1239,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -1341,7 +1341,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null
@@ -1392,7 +1392,7 @@
               "version_added": "46"
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -167,7 +167,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/Request.json
+++ b/api/Request.json
@@ -434,7 +434,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -547,7 +547,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -689,7 +689,7 @@
               "version_removed": "46"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -876,7 +876,7 @@
               "version_removed": "46"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -949,7 +949,7 @@
               "version_added": "46"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -1063,7 +1063,7 @@
               "version_removed": "46"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -1136,7 +1136,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -1238,7 +1238,7 @@
               "version_added": "46"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -1300,7 +1300,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -1362,7 +1362,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": false
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": false
@@ -1466,7 +1466,7 @@
               "notes": "Fragment support added in Chrome 59."
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/Response.json
+++ b/api/Response.json
@@ -325,7 +325,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -409,7 +409,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -544,7 +544,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -628,7 +628,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -712,7 +712,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -796,7 +796,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -975,7 +975,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -1216,7 +1216,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SpeechSynthesis.json
+++ b/api/SpeechSynthesis.json
@@ -71,7 +71,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -132,7 +132,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -193,7 +193,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -254,7 +254,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -315,7 +315,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -376,7 +376,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -437,7 +437,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -498,7 +498,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -559,7 +559,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/SpeechSynthesisEvent.json
+++ b/api/SpeechSynthesisEvent.json
@@ -71,7 +71,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -132,7 +132,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -193,7 +193,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -254,7 +254,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/SpeechSynthesisUtterance.json
+++ b/api/SpeechSynthesisUtterance.json
@@ -133,7 +133,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -194,7 +194,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -255,7 +255,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -316,7 +316,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -377,7 +377,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -438,7 +438,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -499,7 +499,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -560,7 +560,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -621,7 +621,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -682,7 +682,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -743,7 +743,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -804,7 +804,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -865,7 +865,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/SpeechSynthesisVoice.json
+++ b/api/SpeechSynthesisVoice.json
@@ -71,7 +71,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -132,7 +132,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -193,7 +193,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -254,7 +254,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -315,7 +315,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/Window.json
+++ b/api/Window.json
@@ -7032,7 +7032,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": true
@@ -7185,7 +7185,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": null


### PR DESCRIPTION
Produced by `npm run confluence -- --fill-only --browsers=edge` with
local changes applied to only include changes where the new version
was 14.