### PR TITLE
Add missing Edge 15 data based on Confluence

### DIFF
--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -244,7 +244,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -63,7 +63,7 @@
               "notes": "Currently supported only by Google Daydream."
             },
             "edge": {
-              "version_added": true
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": false
@@ -971,7 +971,7 @@
               "notes": "Currently supported only by Google Daydream."
             },
             "edge": {
-              "version_added": true
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": false

--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -1076,7 +1076,7 @@
               ]
             },
             "edge": {
-              "version_added": null
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -862,7 +862,7 @@
               }
             ],
             "edge": {
-              "version_added": null
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Range.json
+++ b/api/Range.json
@@ -1078,7 +1078,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -57,7 +57,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": null
@@ -104,7 +104,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": null
@@ -159,7 +159,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": null
@@ -206,7 +206,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Window.json
+++ b/api/Window.json
@@ -1095,7 +1095,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": false
@@ -1153,7 +1153,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": false
@@ -1215,7 +1215,7 @@
               ]
             },
             "edge": {
-              "version_added": null
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": null
@@ -1274,7 +1274,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": false
@@ -1343,7 +1343,7 @@
               ]
             },
             "edge": {
-              "version_added": null
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": null
@@ -1402,7 +1402,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": false
@@ -1464,7 +1464,7 @@
               ]
             },
             "edge": {
-              "version_added": null
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": null
@@ -2703,7 +2703,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": true


### PR DESCRIPTION
Produced by `npm run confluence -- --fill-only --browsers=edge` with
local changes applied to only include changes where the new version
was 15.