### PR TITLE
Add missing Edge 16 data based on Confluence

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -698,7 +698,7 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": false
+              "version_added": "16"
             },
             "firefox": {
               "version_added": "50"

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -346,7 +346,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "16"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/MediaKeyStatusMap.json
+++ b/api/MediaKeyStatusMap.json
@@ -112,7 +112,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "16"
             },
             "edge_mobile": {
               "version_added": true
@@ -316,7 +316,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "16"
             },
             "edge_mobile": {
               "version_added": true
@@ -418,7 +418,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "16"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -405,7 +405,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "16"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -330,7 +330,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": null
+              "version_added": "16"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -333,7 +333,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "16"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Response.json
+++ b/api/Response.json
@@ -1048,7 +1048,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "16"
             },
             "edge_mobile": {
               "version_added": null
@@ -1099,7 +1099,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "16"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/WritableStreamDefaultController.json
+++ b/api/WritableStreamDefaultController.json
@@ -113,7 +113,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "16"
             },
             "edge_mobile": {
               "version_added": null


### PR DESCRIPTION
Produced by `npm run confluence -- --fill-only --browsers=edge` with
local changes applied to only include changes where the new version
was 16.