### PR TITLE
Add missing Edge 17 data based on Confluence

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -997,7 +997,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": null
@@ -2494,7 +2494,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": null
@@ -5202,7 +5202,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": null
@@ -5250,7 +5250,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": null
@@ -5492,7 +5492,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": true
@@ -298,7 +298,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": false

--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -394,7 +394,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": false

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -853,7 +853,7 @@
               "version_added": "62"
             },
             "edge": {
-              "version_added": false
+              "version_added": "17"
             },
             "firefox": {
               "version_added": false

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -214,7 +214,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -610,7 +610,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false,
+              "version_added": "17",
               "notes": "Use <code>window.doNotTrack</code> instead."
             },
             "edge_mobile": {

--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -321,7 +321,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -61,7 +61,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": null
@@ -112,7 +112,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Range.json
+++ b/api/Range.json
@@ -495,7 +495,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": null
@@ -1030,7 +1030,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -577,7 +577,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -207,7 +207,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": false
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": true
@@ -269,7 +269,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": false
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": true

--- a/javascript/builtins/Proxy.json
+++ b/javascript/builtins/Proxy.json
@@ -67,7 +67,7 @@
                 "version_added": "63"
               },
               "edge": {
-                "version_added": true
+                "version_added": "17"
               },
               "edge_mobile": {
                 "version_added": true


### PR DESCRIPTION
Produced by `npm run confluence -- --fill-only --browsers=edge` with
local changes applied to only include changes where the new version
was 17.