### PR TITLE
updating web components-related firefox support information, to make …

### DIFF
--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -24,7 +24,7 @@
             },
             {
               "version_added": "59",
-              "version_removed": "62",
+              "version_removed": "63",
               "flags": [
                 {
                   "type": "preference",
@@ -40,7 +40,7 @@
             },
             {
               "version_added": "59",
-              "version_removed": "62",
+              "version_removed": "63",
               "flags": [
                 {
                   "type": "preference",
@@ -100,7 +100,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -116,7 +116,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -193,7 +193,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -209,7 +209,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -310,7 +310,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -326,7 +326,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -478,7 +478,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -494,7 +494,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -32,6 +32,22 @@
                   "value_to_set": "true"
                 }
               ]
+            },
+            {
+              "version_added": true,
+              "version_removed": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.customelements.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             }
           ],
           "firefox_android": [
@@ -42,6 +58,22 @@
               "version_added": "59",
               "version_removed": "63",
               "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.customelements.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
+              "version_added": true,
+              "version_removed": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                },
                 {
                   "type": "preference",
                   "name": "dom.webcomponents.customelements.enabled",
@@ -108,6 +140,22 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.customelements.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -118,6 +166,22 @@
                 "version_added": "59",
                 "version_removed": "63",
                 "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.customelements.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",
@@ -201,6 +265,22 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.customelements.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -211,6 +291,22 @@
                 "version_added": "59",
                 "version_removed": "63",
                 "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.customelements.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",
@@ -318,6 +414,22 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.customelements.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -328,6 +440,22 @@
                 "version_added": "59",
                 "version_removed": "63",
                 "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.customelements.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",
@@ -486,6 +614,22 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.customelements.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -496,6 +640,22 @@
                 "version_added": "59",
                 "version_removed": "63",
                 "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.customelements.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -24,24 +24,8 @@
             },
             {
               "version_added": "59",
-              "version_removed": "65",
+              "version_removed": "62",
               "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.customelements.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            {
-              "version_added": true,
-              "version_removed": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.enabled",
-                  "value_to_set": "true"
-                },
                 {
                   "type": "preference",
                   "name": "dom.webcomponents.customelements.enabled",
@@ -56,24 +40,8 @@
             },
             {
               "version_added": "59",
-              "version_removed": "65",
+              "version_removed": "62",
               "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.customelements.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            {
-              "version_added": true,
-              "version_removed": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.enabled",
-                  "value_to_set": "true"
-                },
                 {
                   "type": "preference",
                   "name": "dom.webcomponents.customelements.enabled",
@@ -132,24 +100,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.customelements.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",
@@ -164,24 +116,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.customelements.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",
@@ -257,24 +193,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.customelements.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",
@@ -289,24 +209,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.customelements.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",
@@ -406,24 +310,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.customelements.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",
@@ -438,24 +326,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.customelements.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",
@@ -534,10 +406,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "ie": {
               "version_added": null
@@ -606,24 +478,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.customelements.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",
@@ -638,24 +494,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.customelements.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",

--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -67,10 +67,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "63"
             },
             "ie": {
               "version_added": true
@@ -118,10 +118,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "63"
             },
             "ie": {
               "version_added": true
@@ -169,10 +169,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "63"
             },
             "ie": {
               "version_added": true
@@ -220,10 +220,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "63"
             },
             "ie": {
               "version_added": true
@@ -271,10 +271,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "63"
             },
             "ie": {
               "version_added": true
@@ -416,10 +416,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "63"
             },
             "ie": {
               "version_added": true
@@ -467,10 +467,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "63"
             },
             "ie": {
               "version_added": true
@@ -518,10 +518,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "63"
             },
             "ie": {
               "version_added": true

--- a/api/Element.json
+++ b/api/Element.json
@@ -283,7 +283,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -299,7 +299,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -4872,7 +4872,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -4888,7 +4888,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/Element.json
+++ b/api/Element.json
@@ -283,7 +283,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
@@ -299,7 +299,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
@@ -4872,7 +4872,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
@@ -4888,7 +4888,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
@@ -4944,10 +4944,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "ie": {
               "version_added": null

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -32,6 +32,22 @@
                   "value_to_set": "true"
                 }
               ]
+            },
+            {
+              "version_added": true,
+              "version_removed": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             }
           ],
           "firefox_android": [
@@ -42,6 +58,22 @@
               "version_added": "59",
               "version_removed": "63",
               "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
+              "version_added": true,
+              "version_removed": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                },
                 {
                   "type": "preference",
                   "name": "dom.webcomponents.shadowdom.enabled",
@@ -110,6 +142,22 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -120,6 +168,22 @@
                 "version_added": "59",
                 "version_removed": "63",
                 "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",
@@ -189,6 +253,22 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -199,6 +279,22 @@
                 "version_added": "59",
                 "version_removed": "63",
                 "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -24,24 +24,8 @@
             },
             {
               "version_added": "59",
-              "version_removed": "65",
+              "version_removed": "62",
               "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            {
-              "version_added": true,
-              "version_removed": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.enabled",
-                  "value_to_set": "true"
-                },
                 {
                   "type": "preference",
                   "name": "dom.webcomponents.shadowdom.enabled",
@@ -56,24 +40,8 @@
             },
             {
               "version_added": "59",
-              "version_removed": "65",
+              "version_removed": "62",
               "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            {
-              "version_added": true,
-              "version_removed": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.enabled",
-                  "value_to_set": "true"
-                },
                 {
                   "type": "preference",
                   "name": "dom.webcomponents.shadowdom.enabled",
@@ -134,24 +102,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.shadowdom.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",
@@ -166,24 +118,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.shadowdom.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",
@@ -245,24 +181,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.shadowdom.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",
@@ -277,24 +197,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.shadowdom.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -24,7 +24,7 @@
             },
             {
               "version_added": "59",
-              "version_removed": "62",
+              "version_removed": "63",
               "flags": [
                 {
                   "type": "preference",
@@ -40,7 +40,7 @@
             },
             {
               "version_added": "59",
-              "version_removed": "62",
+              "version_removed": "63",
               "flags": [
                 {
                   "type": "preference",
@@ -102,7 +102,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -118,7 +118,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -181,7 +181,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -197,7 +197,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -24,7 +24,7 @@
             },
             {
               "version_added": "59",
-              "version_removed": "65",
+              "version_removed": "62",
               "flags": [
                 {
                   "type": "preference",
@@ -40,7 +40,7 @@
             },
             {
               "version_added": "59",
-              "version_removed": "65",
+              "version_removed": "62",
               "flags": [
                 {
                   "type": "preference",
@@ -148,18 +148,10 @@
               "notes": "Features still implemented on the <a href='https://developer.mozilla.org/docs/Web/API/Document'>Document</a> interface"
             },
             "firefox": {
-              "version_added": false,
-              "notes": [
-                "Features still implemented on the <a href='https://developer.mozilla.org/docs/Web/API/Document'>Document</a> interface",
-                "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-              ]
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": [
-                "Features still implemented on the <a href='https://developer.mozilla.org/docs/Web/API/Document'>Document</a> interface",
-                "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
-              ]
+              "version_added": "63"
             },
             "ie": {
               "version_added": false
@@ -216,15 +208,14 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+                ]
               }
             ],
             "firefox_android": [
@@ -233,15 +224,14 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+                ]
               }
             ],
             "ie": {
@@ -297,15 +287,14 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+                ]
               }
             ],
             "firefox_android": [
@@ -314,15 +303,14 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+                ]
               }
             ],
             "ie": {
@@ -378,15 +366,14 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+                ]
               }
             ],
             "firefox_android": [
@@ -395,15 +382,14 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "See <a href='https://bugzil.la/1205323'>bug 1205323</a>"
+                ]
               }
             ],
             "ie": {

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -24,7 +24,7 @@
             },
             {
               "version_added": "59",
-              "version_removed": "62",
+              "version_removed": "63",
               "flags": [
                 {
                   "type": "preference",
@@ -40,7 +40,7 @@
             },
             {
               "version_added": "59",
-              "version_removed": "62",
+              "version_removed": "63",
               "flags": [
                 {
                   "type": "preference",
@@ -208,7 +208,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -224,7 +224,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -287,7 +287,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -303,7 +303,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -366,7 +366,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -382,7 +382,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/Slotable.json
+++ b/api/Slotable.json
@@ -32,6 +32,22 @@
                   "value_to_set": "true"
                 }
               ]
+            },
+            {
+              "version_added": true,
+              "version_removed": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             }
           ],
           "firefox_android": [
@@ -42,6 +58,22 @@
               "version_added": "59",
               "version_removed": "63",
               "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.shadowdom.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
+              "version_added": true,
+              "version_removed": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.enabled",
+                  "value_to_set": "true"
+                },
                 {
                   "type": "preference",
                   "name": "dom.webcomponents.shadowdom.enabled",
@@ -110,6 +142,22 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -120,6 +168,22 @@
                 "version_added": "59",
                 "version_removed": "63",
                 "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",

--- a/api/Slotable.json
+++ b/api/Slotable.json
@@ -24,24 +24,8 @@
             },
             {
               "version_added": "59",
-              "version_removed": "65",
+              "version_removed": "62",
               "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            {
-              "version_added": true,
-              "version_removed": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.enabled",
-                  "value_to_set": "true"
-                },
                 {
                   "type": "preference",
                   "name": "dom.webcomponents.shadowdom.enabled",
@@ -56,24 +40,8 @@
             },
             {
               "version_added": "59",
-              "version_removed": "65",
+              "version_removed": "62",
               "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.shadowdom.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            {
-              "version_added": true,
-              "version_removed": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.enabled",
-                  "value_to_set": "true"
-                },
                 {
                   "type": "preference",
                   "name": "dom.webcomponents.shadowdom.enabled",
@@ -134,24 +102,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.shadowdom.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",
@@ -166,24 +118,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.shadowdom.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",

--- a/api/Slotable.json
+++ b/api/Slotable.json
@@ -24,7 +24,7 @@
             },
             {
               "version_added": "59",
-              "version_removed": "62",
+              "version_removed": "63",
               "flags": [
                 {
                   "type": "preference",
@@ -40,7 +40,7 @@
             },
             {
               "version_added": "59",
-              "version_removed": "62",
+              "version_removed": "63",
               "flags": [
                 {
                   "type": "preference",
@@ -102,7 +102,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -118,7 +118,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/Window.json
+++ b/api/Window.json
@@ -1588,24 +1588,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.customelements.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",
@@ -1620,24 +1604,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.customelements.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",

--- a/api/Window.json
+++ b/api/Window.json
@@ -1596,6 +1596,22 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.customelements.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -1606,6 +1622,22 @@
                 "version_added": "59",
                 "version_removed": "63",
                 "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.customelements.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",

--- a/api/Window.json
+++ b/api/Window.json
@@ -1588,7 +1588,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -1604,7 +1604,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/selectors/host.json
+++ b/css/selectors/host.json
@@ -26,7 +26,7 @@
               },
               {
                 "version_added": "61",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -41,8 +41,8 @@
                 "version_added": "63"
               },
               {
-                "version_added": "59",
-                "version_removed": "62",
+                "version_added": "61",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/selectors/host.json
+++ b/css/selectors/host.json
@@ -26,7 +26,7 @@
               },
               {
                 "version_added": "61",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
@@ -41,8 +41,8 @@
                 "version_added": "63"
               },
               {
-                "version_added": "61",
-                "version_removed": "65",
+                "version_added": "59",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/selectors/hostfunction.json
+++ b/css/selectors/hostfunction.json
@@ -26,7 +26,7 @@
               },
               {
                 "version_added": "61",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,7 +42,7 @@
               },
               {
                 "version_added": "61",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/selectors/hostfunction.json
+++ b/css/selectors/hostfunction.json
@@ -26,7 +26,7 @@
               },
               {
                 "version_added": "61",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,7 +42,7 @@
               },
               {
                 "version_added": "61",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/selectors/slotted.json
+++ b/css/selectors/slotted.json
@@ -24,7 +24,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -40,7 +40,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/selectors/slotted.json
+++ b/css/selectors/slotted.json
@@ -24,6 +24,7 @@
               },
               {
                 "version_added": "59",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
@@ -39,6 +40,7 @@
               },
               {
                 "version_added": "59",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",

--- a/html/elements/slot.json
+++ b/html/elements/slot.json
@@ -23,7 +23,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -39,7 +39,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -98,7 +98,7 @@
                 },
                 {
                   "version_added": "59",
-                  "version_removed": "62",
+                  "version_removed": "63",
                   "flags": [
                     {
                       "type": "preference",
@@ -114,7 +114,7 @@
                 },
                 {
                   "version_added": "59",
-                  "version_removed": "62",
+                  "version_removed": "63",
                   "flags": [
                     {
                       "type": "preference",

--- a/html/elements/slot.json
+++ b/html/elements/slot.json
@@ -31,6 +31,22 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -41,6 +57,22 @@
                 "version_added": "59",
                 "version_removed": "63",
                 "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",
@@ -106,6 +138,22 @@
                       "value_to_set": "true"
                     }
                   ]
+                },
+                {
+                  "version_added": true,
+                  "version_removed": "59",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.webcomponents.enabled",
+                      "value_to_set": "true"
+                    },
+                    {
+                      "type": "preference",
+                      "name": "dom.webcomponents.shadowdom.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 }
               ],
               "firefox_android": [
@@ -116,6 +164,22 @@
                   "version_added": "59",
                   "version_removed": "63",
                   "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.webcomponents.shadowdom.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": true,
+                  "version_removed": "59",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.webcomponents.enabled",
+                      "value_to_set": "true"
+                    },
                     {
                       "type": "preference",
                       "name": "dom.webcomponents.shadowdom.enabled",

--- a/html/elements/slot.json
+++ b/html/elements/slot.json
@@ -23,24 +23,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.shadowdom.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",
@@ -55,24 +39,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.shadowdom.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",
@@ -130,24 +98,8 @@
                 },
                 {
                   "version_added": "59",
-                  "version_removed": "65",
+                  "version_removed": "62",
                   "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.webcomponents.shadowdom.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "version_added": true,
-                  "version_removed": "59",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.webcomponents.enabled",
-                      "value_to_set": "true"
-                    },
                     {
                       "type": "preference",
                       "name": "dom.webcomponents.shadowdom.enabled",
@@ -162,24 +114,8 @@
                 },
                 {
                   "version_added": "59",
-                  "version_removed": "65",
+                  "version_removed": "62",
                   "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.webcomponents.shadowdom.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "version_added": true,
-                  "version_removed": "59",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.webcomponents.enabled",
-                      "value_to_set": "true"
-                    },
                     {
                       "type": "preference",
                       "name": "dom.webcomponents.shadowdom.enabled",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -906,7 +906,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -922,7 +922,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -1289,7 +1289,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",
@@ -1305,7 +1305,7 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "62",
+                "version_removed": "63",
                 "flags": [
                   {
                     "type": "preference",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -906,24 +906,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.customelements.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",
@@ -938,24 +922,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.customelements.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",
@@ -1321,24 +1289,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.shadowdom.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",
@@ -1353,24 +1305,8 @@
               },
               {
                 "version_added": "59",
-                "version_removed": "65",
+                "version_removed": "62",
                 "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.shadowdom.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -914,6 +914,22 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.customelements.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -924,6 +940,22 @@
                 "version_added": "59",
                 "version_removed": "63",
                 "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.customelements.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.customelements.enabled",
@@ -1297,6 +1329,22 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
@@ -1307,6 +1355,22 @@
                 "version_added": "59",
                 "version_removed": "63",
                 "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
                   {
                     "type": "preference",
                     "name": "dom.webcomponents.shadowdom.enabled",


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1503019#c16

Basically, I have removed a bunch of data about prefs that I thought was just making things confusing, and changed support versions for the latest pref info so that it no longer looks like it is supported behind a pref later than it is enabled by default (was really confusing)