### PR TITLE
Splitting up break-inside support

### DIFF
--- a/css/properties/break-inside.json
+++ b/css/properties/break-inside.json
@@ -2,104 +2,55 @@
   "css": {
     "properties": {
       "break-inside": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-inside",
-          "support": {
-            "chrome": {
-              "version_added": "50"
-            },
-            "chrome_android": {
-              "version_added": "50"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": "10"
-            },
-            "opera": [
-              {
-                "version_added": "37"
-              },
-              {
-                "version_added": "11.1",
-                "version_removed": "12.1"
-              }
-            ],
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": "10"
-            },
-            "safari_ios": {
-              "version_added": "10"
-            },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": "50"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        },
-        "column": {
+        "multicol_context": {
           "__compat": {
-            "description": "<code>column</code> and <code>avoid-column</code>",
+            "description": "Supported in Multi-column Layout",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-inside",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "50"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "50"
               },
               "edge": {
-                "version_added": false
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": false
+                "version_added": true
               },
               "firefox": {
-                "version_added": false
+                "version_added": "65"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "65"
               },
               "ie": {
                 "version_added": "10"
               },
-              "opera": {
-                "version_added": "11.1",
-                "version_removed": "12.1"
-              },
+              "opera": [
+                {
+                  "version_added": "37"
+                },
+                {
+                  "version_added": "11.1",
+                  "version_removed": "12.1"
+                }
+              ],
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": false
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "50"
               }
             },
             "status": {
@@ -107,107 +58,218 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "recto": {
-          "__compat": {
-            "description": "<code>recto</code> and <code>verso</code>",
-            "support": {
-              "chrome": {
-                "version_added": false
+          },
+          "column": {
+            "__compat": {
+              "description": "<code>column</code> and <code>avoid-column</code>",
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "edge_mobile": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "11.1",
+                  "version_removed": "12.1"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
               },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
             }
           }
         },
-        "region": {
+        "paged_context": {
           "__compat": {
-            "description": "<code>region</code> and <code>avoid-region</code>",
+            "description": "Supported in Paged Media",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-inside",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "50"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "50"
               },
               "edge": {
-                "version_added": false
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": false
+                "version_added": true
               },
               "firefox": {
-                "version_added": false
+                "version_added": "65"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "65"
               },
               "ie": {
-                "version_added": false
+                "version_added": "10"
               },
-              "opera": {
-                "version_added": false
-              },
+              "opera": [
+                {
+                  "version_added": "37"
+                },
+                {
+                  "version_added": "11.1",
+                  "version_removed": "12.1"
+                }
+              ],
               "opera_android": {
-                "version_added": false
+                "version_added": true
               },
               "safari": {
-                "version_added": false
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "50"
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "page": {
+            "__compat": {
+              "description": "<code>page</code> and <code>avoid-page</code>",
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "edge_mobile": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "11.1",
+                  "version_removed": "12.1"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "region": {
+            "__compat": {
+              "description": "<code>region</code> and <code>avoid-region</code>",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }


### PR DESCRIPTION
As support is different depending on being in a multicol or paged context, splitting these up as we did for box alignment.

MDN Issue where this is discussed: https://github.com/mdn/sprints/issues/734

Also updating the browser support for Firefox 65: https://bugzilla.mozilla.org/show_bug.cgi?id=775618

Have updated some support for Chrome, Edge and IE based on my testing in those browsers.
