### PR TITLE
only repeating linear gradient was missing url

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -475,6 +475,7 @@
           "repeating-linear-gradient": {
             "__compat": {
               "description": "<code>repeating-linear-gradient()</code>",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeating-linear-gradient",
               "support": {
                 "chrome": [
                   {


### PR DESCRIPTION
all the gradient image types linked to the page describing that gradient type, except for repeating-linear-gradient, so added that in.

No ticket or anything. Just an issue i found.
https://developer.mozilla.org/en-US/docs/Web/CSS/gradient 