### PR TITLE
updated rotate bcd

### DIFF
--- a/css/properties/rotate.json
+++ b/css/properties/rotate.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/rotate",
           "support": {
             "chrome": {
-              "version_added": "73"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "73"
+              "version_added": true
             },
             "edge": {
               "version_added": false
@@ -70,10 +70,10 @@
             "description": "x, y, or z axis name plus angle value",
             "support": {
               "chrome": {
-                "version_added": "73"
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": "73"
+                "version_added": true
               },
               "edge": {
                 "version_added": false

--- a/css/properties/rotate.json
+++ b/css/properties/rotate.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/rotate",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "73"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "73"
             },
             "edge": {
               "version_added": false
@@ -53,7 +53,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": true
@@ -70,10 +70,10 @@
             "description": "x, y, or z axis name plus angle value",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "73"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "73"
               },
               "edge": {
                 "version_added": false
@@ -82,10 +82,24 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.individual-transform.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.individual-transform.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "ie": {
                 "version_added": false
@@ -103,7 +117,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": false
               },
               "webview_android": {
                 "version_added": true


### PR DESCRIPTION
Updated the BCD for the rotate property (not the value, but the property)

the 3-digit axis + angle is now supported behind a flag in FF, and generally in chrome canary (73) but not in chrome (71). I tested Safari tech preview, FF, chrome, canary, opera samsung internet 7 and 8.2. On FF 65 behind a flag and canary 73 support the rotate property at all. I did not test edge.

https://bugzilla.mozilla.org/show_bug.cgi?id=1504327 - for FF - yes, it's in there, but behind a flag
Chrome: https://www.chromestatus.com/features#rotate
it's in neither 56 nor 57 for Blink - https://dev.opera.com/blog/opera-57/

tested the example code from codepen in all the browsers - both the value rotate: 1 -0.5 1 180deg; and rotate: 180deg;
