### PR TITLE
Updated support for Samsung internet

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -1672,7 +1672,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true


### PR DESCRIPTION
Updated support for Samsung internet with GlobalEventHandlers.oninput

A checklist to help your pull request get merged faster:
- [x] I tried GlobalEventHandlers.oninput on my Samsung Note 4 using Samsung internet and it worked  properly.
- [x] Tested using Samsung internet version 8.2.01.2

