### PR TITLE
Mark Proxy.revocable as available since Edge 12

### DIFF
--- a/javascript/builtins/Proxy.json
+++ b/javascript/builtins/Proxy.json
@@ -67,7 +67,7 @@
                 "version_added": "63"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true


### PR DESCRIPTION
This is per kangax and testing in Edge 13:
https://github.com/mdn/browser-compat-data/pull/3313#discussion_r249448771