### PR TITLE
Complete Intl.RelativeTimeFormat

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -1590,6 +1590,7 @@
         "RelativeTimeFormat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat",
+            "spec_url": "https://tc39.github.io/proposal-intl-relative-time/#relativetimeformat-objects",
             "support": {
               "chrome": {
                 "version_added": "71"
@@ -1643,6 +1644,7 @@
           "format": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/format",
+              "spec_url": "https://tc39.github.io/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.prototype.format",
               "support": {
                 "chrome": {
                   "version_added": "71"
@@ -1697,6 +1699,7 @@
           "formatToParts": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/formatToParts",
+              "spec_url": "https://tc39.github.io/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.prototype.formatToParts",
               "support": {
                 "chrome": {
                   "version_added": "71"
@@ -1751,6 +1754,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/prototype",
+              "spec_url": "https://tc39.github.io/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.prototype",
               "support": {
                 "chrome": {
                   "version_added": "71"
@@ -1805,6 +1809,7 @@
           "resolvedOptions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/resolvedOptions",
+              "spec_url": "https://tc39.github.io/proposal-intl-relative-time/#sec-intl.relativetimeformat.prototype.resolvedoptions",
               "support": {
                 "chrome": {
                   "version_added": "71"
@@ -1859,6 +1864,7 @@
           "supportedLocalesOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/supportedLocalesOf",
+              "spec_url": "https://tc39.github.io/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.supportedLocalesOf",
               "support": {
                 "chrome": {
                   "version_added": "71"

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -1640,6 +1640,114 @@
               "deprecated": false
             }
           },
+          "format": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/format",
+              "support": {
+                "chrome": {
+                  "version_added": "71"
+                },
+                "chrome_android": {
+                  "version_added": "71"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "65"
+                },
+                "firefox_android": {
+                  "version_added": "65"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": "71"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "formatToParts": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/formatToParts",
+              "support": {
+                "chrome": {
+                  "version_added": "71"
+                },
+                "chrome_android": {
+                  "version_added": "71"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": "71"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/prototype",
@@ -1694,9 +1802,63 @@
               }
             }
           },
-          "format": {
+          "resolvedOptions": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/format",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/resolvedOptions",
+              "support": {
+                "chrome": {
+                  "version_added": "71"
+                },
+                "chrome_android": {
+                  "version_added": "71"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "65"
+                },
+                "firefox_android": {
+                  "version_added": "65"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": "71"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "supportedLocalesOf": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/supportedLocalesOf",
               "support": {
                 "chrome": {
                   "version_added": "71"


### PR DESCRIPTION
`formatToParts` is not yet in Firefox, see https://bugzilla.mozilla.org/show_bug.cgi?id=1473229
Otherwise I've used the values we already had for the bare bones of `Intl.RelativeTimeFormat` (added in https://github.com/mdn/browser-compat-data/pull/3254/ and updated in https://github.com/mdn/browser-compat-data/pull/3302). Also sorted the features alphabetically.

Fixes the compat data to-dos on https://github.com/tc39/proposal-intl-relative-time/issues/102