### PR TITLE
Mark Notification API as added in Edge 14

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -18,7 +18,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "14"
           },
           "edge_mobile": {
             "version_added": null


### PR DESCRIPTION
Evidence:
https://blogs.windows.com/msedgedev/2016/05/16/web-notifications-microsoft-edge/#GWchcgkUJOUWuuEB.97
https://jsbin.com/nabeneq/edit?js,console run in Edge 13 and 14