### PR TITLE
Splitting up break-before

### DIFF
--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -2,104 +2,55 @@
   "css": {
     "properties": {
       "break-before": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-before",
-          "support": {
-            "chrome": {
-              "version_added": "50"
-            },
-            "chrome_android": {
-              "version_added": "50"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": "10"
-            },
-            "opera": [
-              {
-                "version_added": "37"
-              },
-              {
-                "version_added": "11.1",
-                "version_removed": "12.1"
-              }
-            ],
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": "10"
-            },
-            "safari_ios": {
-              "version_added": "10"
-            },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": "50"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        },
-        "column": {
+        "multicol_context": {
           "__compat": {
-            "description": "<code>column</code> and <code>avoid-column</code>",
+            "description": "Supported in Multi-column Layout",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-before",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "50"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "50"
               },
               "edge": {
-                "version_added": false
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": false
+                "version_added": true
               },
               "firefox": {
-                "version_added": false
+                "version_added": "65"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "65"
               },
               "ie": {
                 "version_added": "10"
               },
-              "opera": {
-                "version_added": "11.1",
-                "version_removed": "12.1"
-              },
+              "opera": [
+                {
+                  "version_added": "37"
+                },
+                {
+                  "version_added": "11.1",
+                  "version_removed": "12.1"
+                }
+              ],
               "opera_android": {
                 "version_added": null
               },
               "safari": {
-                "version_added": false
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "50"
               }
             },
             "status": {
@@ -107,68 +58,334 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "recto": {
-          "__compat": {
-            "description": "<code>recto</code> and <code>verso</code>",
-            "support": {
-              "chrome": {
-                "version_added": false
+          },
+          "column": {
+            "__compat": {
+              "description": "<code>column</code> and <code>avoid-column</code>",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "11.1",
+                  "version_removed": "12.1"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
               },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            }
+          },
+          "always": {
+            "__compat": {
+              "description": "<code>always</code>",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         },
-        "region": {
+        "paged_context": {
           "__compat": {
-            "description": "<code>region</code> and <code>avoid-region</code>",
+            "description": "Supported in Paged Media",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-before",
+            "support": {
+              "chrome": {
+                "version_added": "50"
+              },
+              "chrome_android": {
+                "version_added": "50"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "65"
+              },
+              "firefox_android": {
+                "version_added": "65"
+              },
+              "ie": {
+                "version_added": "10"
+              },
+              "opera": [
+                {
+                  "version_added": "37"
+                },
+                {
+                  "version_added": "11.1",
+                  "version_removed": "12.1"
+                }
+              ],
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "10"
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "50"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "page": {
+            "__compat": {
+              "description": "<code>page</code> and <code>avoid-page</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "50"
+                },
+                "chrome_android": {
+                  "version_added": "50"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "edge_mobile": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "65"
+                },
+                "firefox_android": {
+                  "version_added": "65"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "11.1",
+                  "version_removed": "12.1"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": "50"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "always": {
+            "__compat": {
+              "description": "<code>always</code>",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "edge_mobile": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "65"
+                },
+                "firefox_android": {
+                  "version_added": "65"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "11.1",
+                  "version_removed": "12.1"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": "50"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "recto": {
+            "__compat": {
+              "description": "<code>recto</code> and <code>verso</code>",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        },
+        "region_context": {
+          "__compat": {
+            "description": "Supported in CSS Regions",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-before",
             "support": {
               "chrome": {
                 "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": false


### PR DESCRIPTION
Separating out the support data for break-before into the three places it can be implemented as support is mostly in paged media.

Relates to this issue: https://github.com/mdn/sprints/issues/734
