### PR TITLE
Splitting up compat data for break-after

### DIFF
--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -2,76 +2,22 @@
   "css": {
     "properties": {
       "break-after": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-after",
-          "support": {
-            "chrome": {
-              "version_added": "50"
-            },
-            "chrome_android": {
-              "version_added": "50"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": "10"
-            },
-            "opera": [
-              {
-                "version_added": "37"
-              },
-              {
-                "version_added": "11.1",
-                "version_removed": "12.1"
-              }
-            ],
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": "10"
-            },
-            "safari_ios": {
-              "version_added": "10"
-            },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": "50"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        },
-        "column": {
+        "multicol_context": {
           "__compat": {
-            "description": "<code>column</code> and <code>avoid-column</code>",
+            "description": "Supported in Multi-column Layout",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-after",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "50"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "50"
               },
               "edge": {
-                "version_added": false
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": false
+                "version_added": true
               },
               "firefox": {
                 "version_added": false
@@ -82,24 +28,29 @@
               "ie": {
                 "version_added": "10"
               },
-              "opera": {
-                "version_added": "11.1",
-                "version_removed": "12.1"
-              },
+              "opera": [
+                {
+                  "version_added": "37"
+                },
+                {
+                  "version_added": "11.1",
+                  "version_removed": "12.1"
+                }
+              ],
               "opera_android": {
                 "version_added": null
               },
               "safari": {
-                "version_added": false
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "50"
               }
             },
             "status": {
@@ -107,68 +58,335 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "recto": {
-          "__compat": {
-            "description": "<code>recto</code> and <code>verso</code>",
-            "support": {
-              "chrome": {
-                "version_added": false
+          },
+          "column": {
+            "__compat": {
+              "description": "<code>column</code> and <code>avoid-column</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "50",
+                  "notes": "Supports <code>column</code> but not <code>avoid-column</code>."
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": "10",
+                  "notes": "Supports <code>column</code> but not <code>avoid-column</code>."
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": true
+                }
               },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            }
+          },
+          "always": {
+            "__compat": {
+              "description": "<code>always</code>",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         },
-        "region": {
+        "paged_context": {
           "__compat": {
-            "description": "<code>region</code> and <code>avoid-region</code>",
+            "description": "Supported in Paged Media",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-after",
+            "support": {
+              "chrome": {
+                "version_added": "50"
+              },
+              "chrome_android": {
+                "version_added": "50"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "65"
+              },
+              "firefox_android": {
+                "version_added": "65"
+              },
+              "ie": {
+                "version_added": "10"
+              },
+              "opera": [
+                {
+                  "version_added": "37"
+                },
+                {
+                  "version_added": "11.1",
+                  "version_removed": "12.1"
+                }
+              ],
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "10"
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "50"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "page": {
+            "__compat": {
+              "description": "<code>page</code> and <code>avoid-page</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "50"
+                },
+                "chrome_android": {
+                  "version_added": "50"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "edge_mobile": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "65"
+                },
+                "firefox_android": {
+                  "version_added": "65"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "11.1",
+                  "version_removed": "12.1"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": "50"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "always": {
+            "__compat": {
+              "description": "<code>always</code>",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "edge_mobile": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "11.1",
+                  "version_removed": "12.1"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": "50"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "recto": {
+            "__compat": {
+              "description": "<code>recto</code> and <code>verso</code>",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        },
+        "region_context": {
+          "__compat": {
+            "description": "Supported in CSS Regions",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-after",
             "support": {
               "chrome": {
                 "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": false

--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -61,11 +61,10 @@
           },
           "column": {
             "__compat": {
-              "description": "<code>column</code> and <code>avoid-column</code>",
+              "description": "<code>column</code>",
               "support": {
                 "chrome": {
-                  "version_added": "50",
-                  "notes": "Supports <code>column</code> but not <code>avoid-column</code>."
+                  "version_added": "50"
                 },
                 "chrome_android": {
                   "version_added": true
@@ -83,8 +82,7 @@
                   "version_added": false
                 },
                 "ie": {
-                  "version_added": "10",
-                  "notes": "Supports <code>column</code> but not <code>avoid-column</code>."
+                  "version_added": "10"
                 },
                 "opera": {
                   "version_added": null
@@ -103,6 +101,57 @@
                 },
                 "webview_android": {
                   "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "avoid-column": {
+            "__compat": {
+              "description": "<code>avoid-column</code>",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": false
                 }
               },
               "status": {


### PR DESCRIPTION
To match other updated compat data. I am splitting up the data into multicol, paged media and regions i order to better show support in these different contexts.

Related to MDN issue: https://github.com/mdn/sprints/issues/734

Also compat data PRs:

* https://github.com/mdn/browser-compat-data/pull/3327
* https://github.com/mdn/browser-compat-data/pull/3315

