### PR TITLE
Firefox support for image.decode()

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -396,6 +396,7 @@
       "decode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/decode",
+          "description": "<code>decode()</code>",
           "support": {
             "chrome": {
               "version_added": "64"
@@ -410,10 +411,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "65"
             },
             "ie": {
               "version_added": null

--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -98,6 +98,7 @@
       "decode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/decode",
+          "description": "<code>decode()</code>",
           "support": {
             "chrome": {
               "version_added": "65"
@@ -112,10 +113,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "65"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
Add to both HTMLImageElement and SVGImageElement the
fact that Firefox 65 adds support.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1501794
Spec: https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decode