### PR TITLE
pointer-events  support versions

### DIFF
--- a/css/properties/pointer-events.json
+++ b/css/properties/pointer-events.json
@@ -86,7 +86,7 @@
                 "version_added": "4"
               },
               "safari_ios": {
-                "version_added": "12"
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": null

--- a/css/properties/pointer-events.json
+++ b/css/properties/pointer-events.json
@@ -9,19 +9,19 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "71"
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "42"
             },
             "firefox": {
               "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "64"
             },
             "ie": {
               "version_added": "11"
@@ -30,13 +30,13 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "safari": {
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -59,19 +59,19 @@
                 "version_added": "2"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "71"
               },
               "edge": {
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "42"
               },
               "firefox": {
                 "version_added": "3.6"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "64"
               },
               "ie": {
                 "version_added": "11"
@@ -80,13 +80,13 @@
                 "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "49"
               },
               "safari": {
                 "version_added": "4"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "12"
               },
               "samsunginternet_android": {
                 "version_added": null

--- a/css/properties/pointer-events.json
+++ b/css/properties/pointer-events.json
@@ -9,19 +9,19 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "71"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": "42"
+              "version_added": true
             },
             "firefox": {
               "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": "64"
+              "version_added": true
             },
             "ie": {
               "version_added": "11"
@@ -30,13 +30,13 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": "49"
+              "version_added": true
             },
             "safari": {
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "12"
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -59,19 +59,19 @@
                 "version_added": "2"
               },
               "chrome_android": {
-                "version_added": "71"
+                "version_added": true
               },
               "edge": {
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": "42"
+                "version_added": true
               },
               "firefox": {
                 "version_added": "3.6"
               },
               "firefox_android": {
-                "version_added": "64"
+                "version_added": true
               },
               "ie": {
                 "version_added": "11"
@@ -80,7 +80,7 @@
                 "version_added": "15"
               },
               "opera_android": {
-                "version_added": "49"
+                "version_added": true
               },
               "safari": {
                 "version_added": "4"


### PR DESCRIPTION
I tested pointer-events on following browsers and it worked with me
chrome_android: 71
edge_mobile: 42
firefox_android: 64
opera_android: 49
safari_ios : 12