### PR TITLE
Fix compat info for onpause/onresume in Firefox

### DIFF
--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -945,10 +945,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": "25"
+              "version_added": "65"
             },
             "ie": {
               "version_added": null
@@ -1004,10 +1004,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": "25"
+              "version_added": "65"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
MediaRecorder in Firefox had onpause and onresume listed
as supported in Firefox 25. These were not added until
Firefox 65.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1458538