### PR TITLE
Update Number.prototype.toLocaleString to match Intl.NumberFormat

### DIFF
--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -1122,7 +1122,7 @@
                   "version_added": "29"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "ie": {
                   "version_added": "11"
@@ -1134,7 +1134,7 @@
                   "version_added": "15"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "37"
                 },
                 "safari": {
                   "version_added": "10"
@@ -1146,7 +1146,7 @@
                   "version_added": true
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "4.4"
                 }
               },
               "status": {
@@ -1175,7 +1175,7 @@
                   "version_added": "29"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "ie": {
                   "version_added": "11"
@@ -1187,7 +1187,7 @@
                   "version_added": "15"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "37"
                 },
                 "safari": {
                   "version_added": "10"
@@ -1199,7 +1199,7 @@
                   "version_added": true
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "4.4"
                 }
               },
               "status": {


### PR DESCRIPTION
Since "**locale**" and "**options**" arguments depends on Intl API, the compatibility should match the [Intl.NumberFormat compatibility table](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat#Browser_compatibility).
