### PR TITLE
Update compat data for HTML translate attribute

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1669,10 +1669,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/translate",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": true
             },
             "edge": {
               "version_added": false
@@ -1690,22 +1690,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates the compat data for the [`translate`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate#) global attribute.

The old data had it as unsupported across the board. This bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1482896 says that the attribute is in fact supported by Chrome and Safari, and points to this helpful chart: https://w3c.github.io/i18n-tests/results/the-translate-attribute.

I've updated the data to `true` for Chrome, Safari, and Opera. I've assumed that this carries across to the mobile versions, although this is a guess. I've left Firefox, Edge, and IE as `false` as per the w3c chart, and changed the rest to `null` which seems like a better reflection of my understanding.

<img width="1209" alt="screen shot 2019-01-24 at 4 07 05 pm" src="https://user-images.githubusercontent.com/432915/51716753-fd13f100-1ff2-11e9-8636-63243894cb53.png">

I'd be happy to fill this in with data for the other browsers, and browser versions too, if you know where I can get this info from.
