### PR TITLE
Safari: Added HTMLImageElement.decode() and HTMLImageElement.decoding.

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -423,10 +423,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "64"
@@ -468,10 +468,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "65"


### PR DESCRIPTION
Both methods are supported since Safari 11.1 on macOS and 11.3 on iOS.

Source: https://webkit.org/blog/8216/new-webkit-features-in-safari-11-1/