### PR TITLE
Update browser versions for unprefixed element.requestFullScreen()

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3385,14 +3385,24 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/requestFullscreen",
           "support": {
-            "chrome": {
-              "version_added": "15",
-              "prefix": "webkit"
-            },
-            "chrome_android": {
-              "version_added": true,
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ],
             "edge": {
               "version_added": true,
               "prefix": "webkit",
@@ -3448,6 +3458,9 @@
             },
             "opera": [
               {
+                "version_added": "58"
+              },
+              {
                 "version_added": "15",
                 "prefix": "webkit"
               },
@@ -3458,6 +3471,9 @@
               }
             ],
             "opera_android": [
+              {
+                "version_added": "58"
+              },
               {
                 "version_added": "14",
                 "prefix": "webkit"


### PR DESCRIPTION
I want to update the compatibility table on https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen and specify that Blink browsers doesn't need a prefix anymore. See https://www.chromestatus.com/feature/6596356319739904.