### PR TITLE
Add "New Window" WebDriver command

### DIFF
--- a/webdriver/commands/NewWindow.json
+++ b/webdriver/commands/NewWindow.json
@@ -1,0 +1,67 @@
+{
+  "webdriver": {
+    "commands": {
+      "NewWindow": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/NewWindow",
+          "support": {
+            "chrome": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
+            },
+            "edge": {
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
+            },
+            "edge_mobile": {
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
+            },
+            "firefox": {
+              "version_added": "66"
+            },
+            "firefox_android": {
+              "version_added": "66"
+            },
+            "ie": {
+              "version_added": "7"
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Safari is non spec-conforming and incompatible."
+            },
+            "samsunginternet_android": {
+              "version_added": false,
+              "notes": "The vendor-supported implementation for Samsung Internet is non-spec-conforming and incompatible."
+            },
+            "webview_android": {
+              "version_added": false,
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
For the WebDriver project a new command called "New Window" has been added:
https://w3c.github.io/webdriver/#new-window

Feature support has been landed in Firefox/Fennec 66:
https://bugzilla.mozilla.org/show_bug.cgi?id=1504756

On MDN this command is documented at:
https://developer.mozilla.org/en-US/docs/Web/WebDriver/Commands/New_Window

Tests for the new command are run as part of the Webdriver tests in the WPT test suite.