### PR TITLE
update support for overflow block and inline

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1047,44 +1047,42 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1422235'>bug 1422235</a>."
+                "version_added": "66"
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1422235'>bug 1422235</a>."
+                "version_added": "66"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {
               "experimental": true,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }
@@ -1101,44 +1099,42 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1422235'>bug 1422235</a>."
+                "version_added": "66"
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1422235'>bug 1422235</a>."
+                "version_added": "66"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {
               "experimental": true,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }


### PR DESCRIPTION
Firefox 66 has implementation of the media queries overflow-block and overflow-inline. 

Confirmed support and also lack of support in other browsers by testing, so have updated to show Firefox 66 support, and set other browsers to false.

https://bugzilla.mozilla.org/show_bug.cgi?id=1422235

