### PR TITLE
dynamic_import is enabled by default on FF67

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1882,28 +1882,40 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66",
-                "flags": [
-                  {
-                    "name": "javascript.options.dynamicImport",
-                    "type": "preference",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "See <a href='https://bugzil.la/1517546'>bug 1517546</a>."
-              },
-              "firefox_android": {
-                "version_added": "66",
-                "flags": [
-                  {
-                    "name": "javascript.options.dynamicImport",
-                    "type": "preference",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "See <a href='https://bugzil.la/1517546'>bug 1517546</a>."
-              },
+              "firefox": [
+                {
+                  "version_added": "67"
+                },
+                {
+                  "version_added": "66",
+                  "version_removed": "67",
+                  "flags": [
+                    {
+                      "name": "javascript.options.dynamicImport",
+                      "type": "preference",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": "See <a href='https://bugzil.la/1517546'>bug 1517546</a>."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "67"
+                },
+                {
+                  "version_added": "66",
+                  "version_removed": "67",
+                  "flags": [
+                    {
+                      "name": "javascript.options.dynamicImport",
+                      "type": "preference",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": "See <a href='https://bugzil.la/1517546'>bug 1517546</a>."
+                }
+              ],
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
JavaScript Dynamic Imports are now activated by default in Firefox Nightly 67.0a1
https://bugzilla.mozilla.org/show_bug.cgi?id=1522491

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
