### PR TITLE
[Chrome] Add missing webview for requestFullscreen().

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3496,10 +3496,15 @@
               "version_added": true,
               "prefix": "webkit"
             },
-            "webview_android": {
-              "version_added": true,
-              "prefix": "webkit"
-            }
+            "webview_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ],
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
To not be in Android webview a feature has to be listed in [this file](https://cs.chromium.org/chromium/src/android_webview/tools/system_webview_shell/test/data/webexposed/not-webview-exposed.txt). The `requestFullscreen()` function is not.