### PR TITLE
Prefixed Fullscreen API removed in Firefox 65

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3249,6 +3249,7 @@
               },
               {
                 "version_added": "49",
+                "version_removed": "65",
                 "flags": [
                   {
                     "type": "preference",
@@ -3269,6 +3270,7 @@
               },
               {
                 "version_added": "49",
+                "version_removed": "65",
                 "flags": [
                   {
                     "type": "preference",
@@ -3680,6 +3682,7 @@
               },
               {
                 "version_added": "49",
+                "version_removed": "65",
                 "flags": [
                   {
                     "type": "preference",
@@ -3700,6 +3703,7 @@
               },
               {
                 "version_added": "49",
+                "version_removed": "65",
                 "flags": [
                   {
                     "type": "preference",
@@ -3775,6 +3779,7 @@
               },
               {
                 "version_added": "47",
+                "version_removed": "65",
                 "flags": [
                   {
                     "type": "preference",
@@ -3795,6 +3800,7 @@
               },
               {
                 "version_added": "47",
+                "version_removed": "65",
                 "flags": [
                   {
                     "type": "preference",
@@ -5363,6 +5369,7 @@
               },
               {
                 "version_added": "47",
+                "version_removed": "65",
                 "flags": [
                   {
                     "type": "preference",
@@ -5383,6 +5390,7 @@
               },
               {
                 "version_added": "47",
+                "version_removed": "65",
                 "flags": [
                   {
                     "type": "preference",
@@ -5446,6 +5454,7 @@
               },
               {
                 "version_added": "47",
+                "version_removed": "65",
                 "flags": [
                   {
                     "type": "preference",
@@ -5466,6 +5475,7 @@
               },
               {
                 "version_added": "47",
+                "version_removed": "65",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/Document.json
+++ b/api/Document.json
@@ -3259,6 +3259,7 @@
               },
               {
                 "version_added": "9",
+                "version_removed": "65",
                 "alternative_name": "mozCancelFullScreen"
               }
             ],
@@ -3278,6 +3279,7 @@
               },
               {
                 "version_added": "9",
+                "version_removed": "65",
                 "alternative_name": "mozCancelFullScreen"
               }
             ],
@@ -3688,6 +3690,7 @@
               },
               {
                 "version_added": "9",
+                "version_removed": "65",
                 "alternative_name": "mozFullScreen"
               }
             ],
@@ -3707,6 +3710,7 @@
               },
               {
                 "version_added": "9",
+                "version_removed": "65",
                 "alternative_name": "mozFullScreen"
               }
             ],
@@ -3781,6 +3785,7 @@
               },
               {
                 "version_added": "10",
+                "version_removed": "65",
                 "alternative_name": "mozFullScreenEnabled"
               }
             ],
@@ -3800,6 +3805,7 @@
               },
               {
                 "version_added": "10",
+                "version_removed": "65",
                 "alternative_name": "mozFullScreenEnabled"
               }
             ],
@@ -5364,6 +5370,11 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": "10",
+                "version_removed": "65",
+                "alternative_name": "onmozfullscreenchange"
               }
             ],
             "firefox_android": [
@@ -5379,6 +5390,11 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": "10",
+                "version_removed": "65",
+                "alternative_name": "onmozfullscreenchange"
               }
             ],
             "ie": {
@@ -5437,6 +5453,11 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": "10",
+                "version_removed": "65",
+                "alternative_name": "onmozfullscreenerror"
               }
             ],
             "firefox_android": [
@@ -5452,6 +5473,11 @@
                     "value_to_set": "true"
                   }
                 ]
+              },
+              {
+                "version_added": "10",
+                "version_removed": "65",
+                "alternative_name": "onmozfullscreenerror"
               }
             ],
             "ie": {

--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -341,6 +341,7 @@
               },
               {
                 "version_added": "9",
+                "version_removed": "65",
                 "alternative_name": "mozFullScreenElement"
               }
             ],
@@ -360,6 +361,7 @@
               },
               {
                 "version_added": "9",
+                "version_removed": "65",
                 "alternative_name": "mozFullScreenElement"
               }
             ],

--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -331,6 +331,7 @@
               },
               {
                 "version_added": "47",
+                "version_removed": "65",
                 "flags": [
                   {
                     "type": "preference",
@@ -351,6 +352,7 @@
               },
               {
                 "version_added": "47",
+                "version_removed": "65",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/Element.json
+++ b/api/Element.json
@@ -2842,12 +2842,26 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "64"
-            },
-            "firefox_android": {
-              "version_added": "64"
-            },
+            "firefox": [
+              {
+                "version_added": "64"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "65",
+                "alternative_name": "onmozfullscreenchange"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "64"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "65",
+                "alternative_name": "onmozfullscreenchange"
+              }
+            ],
             "ie": {
               "version_added": null
             },
@@ -2890,12 +2904,26 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "64"
-            },
-            "firefox_android": {
-              "version_added": "64"
-            },
+            "firefox": [
+              {
+                "version_added": "64"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "65",
+                "alternative_name": "onmozfullscreenerror"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "64"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "65",
+                "alternative_name": "onmozfullscreenerror"
+              }
+            ],
             "ie": {
               "version_added": null
             },
@@ -3428,6 +3456,7 @@
               },
               {
                 "version_added": "9",
+                "version_removed": "65",
                 "alternative_name": "mozRequestFullScreen",
                 "notes": "Before Firefox 44, Firefox incorrectly allowed elements inside a <code>&lt;frame&gt;</code> or an <code>&lt;object&gt;</code> to request, and to be granted, fullscreen. In Firefox 44 and onwards this has been fixed: only elements in the top-level document or in an <code><code>&lt;iframe&gt;</code></code> with the <code>allowfullscreen</code> attribute can be displayed fullscreen."
               }
@@ -3448,6 +3477,7 @@
               },
               {
                 "version_added": "9",
+                "version_removed": "65",
                 "alternative_name": "mozRequestFullScreen",
                 "notes": "Before Firefox 44, Firefox incorrectly allowed elements inside a <code>&lt;frame&gt;</code> or an <code>&lt;object&gt;</code> to request, and to be granted, fullscreen. In Firefox 44 and onwards this has been fixed: only elements in the top-level document or in an <code><code>&lt;iframe&gt;</code></code> with the <code>allowfullscreen</code> attribute can be displayed fullscreen."
               }

--- a/api/Element.json
+++ b/api/Element.json
@@ -2888,7 +2888,7 @@
           }
         }
       },
-      "onfullscreenerror": {
+      "onerror": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/onfullscreenerror",
           "support": {
@@ -3446,6 +3446,7 @@
               },
               {
                 "version_added": "47",
+                "version_removed": "65",
                 "flags": [
                   {
                     "type": "preference",
@@ -3458,7 +3459,7 @@
                 "version_added": "9",
                 "version_removed": "65",
                 "alternative_name": "mozRequestFullScreen",
-                "notes": "Before Firefox 44, Firefox incorrectly allowed elements inside a <code>&lt;frame&gt;</code> or an <code>&lt;object&gt;</code> to request, and to be granted, fullscreen. In Firefox 44 and onwards this has been fixed: only elements in the top-level document or in an <code><code>&lt;iframe&gt;</code></code> with the <code>allowfullscreen</code> attribute can be displayed fullscreen."
+                "notes": "Before Firefox 44, Firefox incorrectly allowed elements inside a <code>&lt;frame&gt;</code> or <code>&lt;object&gt;</code> element to request, and to be granted, fullscreen. In Firefox 44 and onwards this has been fixed: only elements in the top-level document or in an <code>&lt;iframe&gt;</code> element with the <code>allowfullscreen</code> attribute can be displayed fullscreen."
               }
             ],
             "firefox_android": [
@@ -3467,6 +3468,7 @@
               },
               {
                 "version_added": "47",
+                "version_removed": "65",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -35,6 +35,7 @@
               },
               {
                 "version_added": "9",
+                "version_removed": "65",
                 "alternative_name": ":-moz-full-screen"
               }
             ],
@@ -54,6 +55,7 @@
               },
               {
                 "version_added": "9",
+                "version_removed": "65",
                 "alternative_name": ":-moz-full-screen"
               }
             ],

--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -25,6 +25,7 @@
               },
               {
                 "version_added": "47",
+                "version_removed": "65",
                 "flags": [
                   {
                     "type": "preference",
@@ -45,6 +46,7 @@
               },
               {
                 "version_added": "47",
+                "version_removed": "65",
                 "flags": [
                   {
                     "type": "preference",


### PR DESCRIPTION
Updates the interfaces and CSS selector that are involved
in the Fullscreen API to note that the `moz` prefix is
gone in Firefox 65.

See bug 1504946.

Linting passed cleanly and visually things look good.