### PR TITLE
Add Safari support for DOMPoint

### DIFF
--- a/api/DOMPoint.json
+++ b/api/DOMPoint.json
@@ -32,10 +32,10 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": "12"
+            "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "12"
+            "version_added": "10.1"
           },
           "webview_android": {
             "version_added": "58"

--- a/api/DOMPoint.json
+++ b/api/DOMPoint.json
@@ -80,10 +80,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "webview_android": {
               "version_added": "58"

--- a/api/DOMPointReadOnly.json
+++ b/api/DOMPointReadOnly.json
@@ -32,10 +32,10 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": "12"
+            "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "12"
+            "version_added": "10.1"
           },
           "webview_android": {
             "version_added": "61"
@@ -80,10 +80,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "12"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "12"
+              "version_added": "10.1"
             },
             "webview_android": {
               "version_added": "61"
@@ -128,10 +128,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "12"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "12"
+              "version_added": "10.1"
             },
             "webview_android": {
               "version_added": "61"
@@ -176,10 +176,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "12"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "12"
+              "version_added": "10.1"
             },
             "webview_android": {
               "version_added": "61"
@@ -224,10 +224,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "12"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "12"
+              "version_added": "10.1"
             },
             "webview_android": {
               "version_added": "61"
@@ -272,10 +272,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "12"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "12"
+              "version_added": "10.1"
             },
             "webview_android": {
               "version_added": "61"
@@ -320,10 +320,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "12"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "12"
+              "version_added": "10.1"
             },
             "webview_android": {
               "version_added": "61"
@@ -368,10 +368,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "12"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "12"
+              "version_added": "10.1"
             },
             "webview_android": {
               "version_added": "61"
@@ -416,10 +416,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "12"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "12"
+              "version_added": "10.1"
             },
             "webview_android": {
               "version_added": "61"

--- a/api/DOMPointReadOnly.json
+++ b/api/DOMPointReadOnly.json
@@ -32,10 +32,10 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": false
+            "version_added": "12"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "12"
           },
           "webview_android": {
             "version_added": "61"
@@ -80,10 +80,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12"
             },
             "webview_android": {
               "version_added": "61"
@@ -128,10 +128,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12"
             },
             "webview_android": {
               "version_added": "61"
@@ -176,10 +176,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12"
             },
             "webview_android": {
               "version_added": "61"
@@ -224,10 +224,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12"
             },
             "webview_android": {
               "version_added": "61"
@@ -272,10 +272,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12"
             },
             "webview_android": {
               "version_added": "61"
@@ -320,10 +320,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12"
             },
             "webview_android": {
               "version_added": "61"
@@ -368,10 +368,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12"
             },
             "webview_android": {
               "version_added": "61"
@@ -416,10 +416,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12"
             },
             "webview_android": {
               "version_added": "61"


### PR DESCRIPTION
Add support for DOMPointReadOnly and DOMPoint in Safari and iOS Safari.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests):
https://developer.apple.com/documentation/webkitjs/dompointreadonly

- [x] Data: if you tested something, describe how you tested with details like browser and version
Tested in Safari 12

- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any