### PR TITLE
Update zoom: reset

### DIFF
--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -59,10 +59,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/zoom#Values",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": false
@@ -80,10 +80,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": true

--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -60,13 +60,11 @@
             "support": {
               "chrome": {
                 "version_added": true,
-                "version_removed": "59",
-                "notes": "See <a href='https://chromium.googlesource.com/chromium/src/+/30a210d86eaf8ca5bf2941a6bbee44b867300c6b'>this commit</a>."
+                "version_removed": "59"
               },
               "chrome_android": {
                 "version_added": true,
-                "version_removed": "59",
-                "notes": "See <a href='https://chromium.googlesource.com/chromium/src/+/30a210d86eaf8ca5bf2941a6bbee44b867300c6b'>this commit</a>."
+                "version_removed": "59"
               },
               "edge": {
                 "version_added": false
@@ -100,8 +98,7 @@
               },
               "webview_android": {
                 "version_added": true,
-                "version_removed": "59",
-                "notes": "Refer to <a href='https://chromium.googlesource.com/chromium/src/+/30a210d86eaf8ca5bf2941a6bbee44b867300c6b'>this commit</a>."
+                "version_removed": "59"
               }
             },
             "status": {

--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -59,10 +59,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/zoom#Values",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": true,
+                "version_removed": "59",
+                "notes": "See <a href='https://chromium.googlesource.com/chromium/src/+/30a210d86eaf8ca5bf2941a6bbee44b867300c6b'>this commit</a>."
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": true,
+                "version_removed": "59",
+                "notes": "See <a href='https://chromium.googlesource.com/chromium/src/+/30a210d86eaf8ca5bf2941a6bbee44b867300c6b'>this commit</a>."
               },
               "edge": {
                 "version_added": false
@@ -95,7 +99,9 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": null
+                "version_added": true,
+                "version_removed": "59",
+                "notes": "Refer to <a href='https://chromium.googlesource.com/chromium/src/+/30a210d86eaf8ca5bf2941a6bbee44b867300c6b'>this commit</a>."
               }
             },
             "status": {


### PR DESCRIPTION
Data from Chromium 69.0.3497.100.

Test:
![invalid](https://user-images.githubusercontent.com/16851802/51970595-3f17b980-246f-11e9-876e-4a8e93f67168.png)

https://css-tricks.com/almanac/properties/z/zoom/
CSS-Tricks treat `zoom: reset;` as a Safari only stuff, though https://developer.mozilla.org/zh-CN/docs/Web/CSS/zoom#Values says:
> possibly Blink

My own idea is, it's Apple Webkit only. 

<!--
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
-->