### PR TITLE
Fix compatibility tables for caretRangeFromPoint and caretPositionFromPoint

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -606,10 +606,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "20"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "20"
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -163,10 +163,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": {
               "version_added": "63"

--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -169,7 +169,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "63"
+              "version_added": "20"
             },
             "firefox_android": {
               "version_added": "63"

--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -172,7 +172,7 @@
               "version_added": "20"
             },
             "firefox_android": {
-              "version_added": "63"
+              "version_added": "20"
             },
             "ie": {
               "version_added": false

--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -175,7 +175,7 @@
               "version_added": "63"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
If you try using caretRangeFromPoint and caretPositionFromPoint on document in Firefox or IE you will see that caretRangeFromPoint is undefined in Firefox and caretPositionFromPoint is undefined in IE, contrary to what compatibility tables says in MDN.
