### PR TITLE
Update createTouch/createTouchList 

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2050,7 +2050,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": true,
               "version_removed": "56"
             },
             "safari": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -1973,7 +1973,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": true
@@ -2032,7 +2032,7 @@
               "version_removed": "69"
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": true
@@ -2051,6 +2051,7 @@
             },
             "opera_android": {
               "version_added": true
+              "version_removed": "56"
             },
             "safari": {
               "version_added": false

--- a/api/Document.json
+++ b/api/Document.json
@@ -2047,7 +2047,8 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true,
+              "version_removed": "56"
             },
             "opera_android": {
               "version_added": true,


### PR DESCRIPTION
Per https://www.chromestatus.com/feature/5185332291043328.

Edge desktop hasn't exposed touch event support by default, so changed them to `false`.