### PR TITLE
updating firefox support info for window.event, and event.returnValue

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -1009,13 +1009,11 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "63",
-              "version_removed": "64",
+              "version_added": false,
               "notes": "Temporarily added in 63, removed in 64, briefly added in 65, then removed again while related compatibility issues are sorted out (see <a href='https://bugzil.la/1520756'>bug 1520756</a>)."
             },
             "firefox_android": {
-              "version_added": "63",
-              "version_removed": "64",
+              "version_added": false,
               "notes": "Temporarily added in 63, removed in 64, briefly added in 65, then removed again while related compatibility issues are sorted out (see <a href='https://bugzil.la/1520756'>bug 1520756</a>)."
             },
             "ie": {

--- a/api/Event.json
+++ b/api/Event.json
@@ -1009,10 +1009,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "63"
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": "63"
+              "version_added": "65"
             },
             "ie": {
               "version_added": "6"

--- a/api/Event.json
+++ b/api/Event.json
@@ -1009,10 +1009,14 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "65"
+              "version_added": "63",
+              "version_removed": "64",
+              "notes": "Temporarily added in 63, removed in 64, briefly added in 65, then removed again while related compatibility issues are sorted out (see <a href='https://bugzil.la/1520756'>bug 1520756</a>)."
             },
             "firefox_android": {
-              "version_added": "65"
+              "version_added": "63",
+              "version_removed": "64",
+              "notes": "Temporarily added in 63, removed in 64, briefly added in 65, then removed again while related compatibility issues are sorted out (see <a href='https://bugzil.la/1520756'>bug 1520756</a>)."
             },
             "ie": {
               "version_added": "6"

--- a/api/Window.json
+++ b/api/Window.json
@@ -1844,26 +1844,38 @@
             "edge_mobile": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.window.event.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.window.event.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "65"
+              },
+              {
+                "version_added": "63",
+                "version_removed": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.window.event.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "65"
+              },
+              {
+                "version_added": "63",
+                "version_removed": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.window.event.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": true
             },

--- a/api/Window.json
+++ b/api/Window.json
@@ -1844,38 +1844,28 @@
             "edge_mobile": {
               "version_added": true
             },
-            "firefox": [
-              {
-                "version_added": "65"
-              },
-              {
-                "version_added": "63",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.window.event.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "65"
-              },
-              {
-                "version_added": "63",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.window.event.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63",
+              "notes": "This was briefly enabled by default in 65, then removed again while related compatibility issues are sorted out (see <a href='https://bugzil.la/1520756'>bug 1520756</a>).",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.window.event.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "63",
+              "notes": "This was briefly enabled by default in 65, then removed again while related compatibility issues are sorted out (see <a href='https://bugzil.la/1520756'>bug 1520756</a>).",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.window.event.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "ie": {
               "version_added": true
             },


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1496288

See also https://www.fxsitecompat.com/en-CA/docs/2018/support-for-window-event-and-event-returnvalue-has-been-added-again/ for more useful details. the first paragraph basically applies to this PR.