### PR TITLE
Nest conic-gradient correctly; sort alphabetically

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -106,6 +106,146 @@
               "deprecated": false
             }
           },
+          "conic-gradient": {
+            "__compat": {
+              "description": "<code>conic-gradient()</code>",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/conic-gradient",
+              "support": {
+                "chrome": [
+                  {
+                    "version_added": "69"
+                  },
+                  {
+                    "version_added": "59",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "Enable Experimental Web Platform Features"
+                      }
+                    ]
+                  }
+                ],
+                "chrome_android": [
+                  {
+                    "version_added": "69"
+                  },
+                  {
+                    "version_added": "59",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "Enable Experimental Web Platform Features"
+                      }
+                    ]
+                  }
+                ],
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "56"
+                },
+                "opera_android": {
+                  "version_added": "56"
+                },
+                "safari": {
+                  "version_added": null,
+                  "notes": "In Safari Technology Preview Release 66"
+                },
+                "safari_ios": {
+                  "version_added": null,
+                  "notes": "In Safari Technology Preview Release 66"
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": [
+                  {
+                    "version_added": "69"
+                  },
+                  {
+                    "version_added": "59",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "Enable Experimental Web Platform Features"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            },
+            "doubleposition": {
+              "__compat": {
+                "description": "Double-position color stops",
+                "support": {
+                  "chrome": {
+                    "version_added": "72"
+                  },
+                  "chrome_android": {
+                    "version_added": "72"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "edge_mobile": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": null,
+                    "notes": "In Safari Technology Preview Release 66"
+                  },
+                  "safari_ios": {
+                    "version_added": null,
+                    "notes": "In Safari Technology Preview Release 66"
+                  },
+                  "samsunginternet_android": {
+                    "version_added": false
+                  },
+                  "webview_android": {
+                    "version_added": "72"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
           "linear-gradient": {
             "__compat": {
               "description": "<code>linear-gradient()</code>",
@@ -440,378 +580,6 @@
                       "version_added": "46",
                       "partial_implementation": true,
                       "notes": "Accepted only in <code>-webkit-linear-gradient()</code> and <code>-moz-linear-gradient()</code>, not <code>linear-gradient()</code>."
-                    }
-                  ],
-                  "ie": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "16"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "6.1"
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  },
-                  "samsunginternet_android": {
-                    "version_added": true
-                  },
-                  "webview_android": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            }
-          },
-          "repeating-linear-gradient": {
-            "__compat": {
-              "description": "<code>repeating-linear-gradient()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeating-linear-gradient",
-              "support": {
-                "chrome": [
-                  {
-                    "version_added": "26"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "10"
-                  }
-                ],
-                "chrome_android": [
-                  {
-                    "version_added": true
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": true
-                  }
-                ],
-                "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": [
-                  {
-                    "version_added": "16",
-                    "notes": "Before Firefox 36, gradients weren't applied on the pre-multiplied color space, leading to shades of grey unexpectedly appearing when used with transparency."
-                  },
-                  {
-                    "prefix": "-moz-",
-                    "version_added": "3.6",
-                    "notes": [
-                      "Since Firefox 42, the prefixed version of gradients can be disabled by setting <code>layout.css.prefixes.gradients</code> to <code>false</code>.",
-                      "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
-                    ]
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "49"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "44",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.prefixes.webkit",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  }
-                ],
-                "firefox_android": [
-                  {
-                    "version_added": "16",
-                    "notes": "Before Firefox 36, gradients weren't applied on the pre-multiplied color space, leading to shades of grey unexpectedly appearing when used with transparency."
-                  },
-                  {
-                    "prefix": "-moz-",
-                    "version_added": "4",
-                    "notes": [
-                      "Since Firefox 42, the prefixed version of gradients can be disabled by setting <code>layout.css.prefixes.gradients</code> to <code>false</code>.",
-                      "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
-                    ]
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "49"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "44",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.prefixes.webkit",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  }
-                ],
-                "ie": {
-                  "version_added": "10",
-                  "notes": "Internet Explorer 5.5 through 9.0 supported gradients via a proprietary filter: <code><a href='https://developer.mozilla.org/docs/Web/CSS/-ms-filter#Gradient'>-ms-filter: progid:DXImageTransform.Microsoft.Gradient()</a></code>."
-                },
-                "opera": [
-                  {
-                    "version_added": "12.1"
-                  },
-                  {
-                    "prefix": "-o-",
-                    "version_added": "11",
-                    "version_removed": "15",
-                    "notes": "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "15",
-                    "notes": "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
-                  }
-                ],
-                "opera_android": [
-                  {
-                    "version_added": true
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "14"
-                  }
-                ],
-                "safari": [
-                  {
-                    "version_added": "6.1"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "5.1",
-                    "notes": [
-                      "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(linear,…)</a></code> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>repeating-linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
-                      "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
-                    ]
-                  }
-                ],
-                "safari_ios": {
-                  "version_added": true
-                },
-                "samsunginternet_android": {
-                  "version_added": true
-                },
-                "webview_android": [
-                  {
-                    "version_added": true
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": true
-                  }
-                ]
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            },
-            "to": {
-              "__compat": {
-                "description": "<code>to</code> keyword",
-                "support": {
-                  "chrome": {
-                    "version_added": "26"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "12"
-                  },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
-                  "firefox": {
-                    "version_added": "10"
-                  },
-                  "firefox_android": {
-                    "version_added": "10"
-                  },
-                  "ie": {
-                    "version_added": "10"
-                  },
-                  "opera": {
-                    "version_added": "12.1"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "6.1"
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  },
-                  "samsunginternet_android": {
-                    "version_added": true
-                  },
-                  "webview_android": {
-                    "version_added": true
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            },
-            "doubleposition": {
-              "__compat": {
-                "description": "Double-position color stops",
-                "support": {
-                  "chrome": {
-                    "version_added": "71"
-                  },
-                  "chrome_android": {
-                    "version_added": "71"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "64"
-                  },
-                  "firefox_android": {
-                    "version_added": "64"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "58"
-                  },
-                  "opera_android": {
-                    "version_added": "58"
-                  },
-                  "safari": {
-                    "version_added": null,
-                    "notes": "In Safari Technology Preview Release 66"
-                  },
-                  "safari_ios": {
-                    "version_added": null,
-                    "notes": "In Safari Technology Preview Release 66"
-                  },
-                  "samsunginternet_android": {
-                    "version_added": true
-                  },
-                  "webview_android": {
-                    "version_added": "71"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            },
-            "interpolation_hints": {
-              "__compat": {
-                "description": "Interpolation Hints / Gradient Midpoints",
-                "support": {
-                  "chrome": {
-                    "version_added": "40"
-                  },
-                  "chrome_android": {
-                    "version_added": "40"
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "36"
-                  },
-                  "firefox_android": {
-                    "version_added": "36"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": "27"
-                  },
-                  "opera_android": {
-                    "version_added": true
-                  },
-                  "safari": {
-                    "version_added": "6.1"
-                  },
-                  "safari_ios": {
-                    "version_added": true
-                  },
-                  "samsunginternet_android": {
-                    "version_added": true
-                  },
-                  "webview_android": {
-                    "version_added": "40"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            },
-            "unitless_0_angle": {
-              "__compat": {
-                "description": "Unitless <code>0</code> for &lt;angle&gt;",
-                "support": {
-                  "chrome": {
-                    "version_added": "26"
-                  },
-                  "chrome_android": {
-                    "version_added": true
-                  },
-                  "edge": {
-                    "version_added": "12"
-                  },
-                  "edge_mobile": {
-                    "version_added": "12"
-                  },
-                  "firefox": [
-                    {
-                      "version_added": "55"
-                    },
-                    {
-                      "version_added": "46",
-                      "partial_implementation": true,
-                      "notes": "Accepted only in <code>-webkit-repeating-linear-gradient()</code> and <code>-moz-repeating-linear-gradient()</code>, not <code>repeating-linear-gradient()</code>."
-                    }
-                  ],
-                  "firefox_android": [
-                    {
-                      "version_added": "55"
-                    },
-                    {
-                      "version_added": "46",
-                      "partial_implementation": true,
-                      "notes": "Accepted only in <code>-webkit-repeating-linear-gradient()</code> and <code>-moz-repeating-linear-gradient()<code>, not <code>repeating-linear-gradient()</code>."
                     }
                   ],
                   "ie": {
@@ -1181,6 +949,378 @@
               }
             }
           },
+          "repeating-linear-gradient": {
+            "__compat": {
+              "description": "<code>repeating-linear-gradient()</code>",
+              "support": {
+                "chrome": [
+                  {
+                    "version_added": "26"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "10"
+                  }
+                ],
+                "chrome_android": [
+                  {
+                    "version_added": true
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": true
+                  }
+                ],
+                "edge": {
+                  "version_added": "12"
+                },
+                "edge_mobile": {
+                  "version_added": true
+                },
+                "firefox": [
+                  {
+                    "version_added": "16",
+                    "notes": "Before Firefox 36, gradients weren't applied on the pre-multiplied color space, leading to shades of grey unexpectedly appearing when used with transparency."
+                  },
+                  {
+                    "prefix": "-moz-",
+                    "version_added": "3.6",
+                    "notes": [
+                      "Since Firefox 42, the prefixed version of gradients can be disabled by setting <code>layout.css.prefixes.gradients</code> to <code>false</code>.",
+                      "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
+                    ]
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "49"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "44",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "layout.css.prefixes.webkit",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
+                "firefox_android": [
+                  {
+                    "version_added": "16",
+                    "notes": "Before Firefox 36, gradients weren't applied on the pre-multiplied color space, leading to shades of grey unexpectedly appearing when used with transparency."
+                  },
+                  {
+                    "prefix": "-moz-",
+                    "version_added": "4",
+                    "notes": [
+                      "Since Firefox 42, the prefixed version of gradients can be disabled by setting <code>layout.css.prefixes.gradients</code> to <code>false</code>.",
+                      "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
+                    ]
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "49"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "44",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "layout.css.prefixes.webkit",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
+                "ie": {
+                  "version_added": "10",
+                  "notes": "Internet Explorer 5.5 through 9.0 supported gradients via a proprietary filter: <code><a href='https://developer.mozilla.org/docs/Web/CSS/-ms-filter#Gradient'>-ms-filter: progid:DXImageTransform.Microsoft.Gradient()</a></code>."
+                },
+                "opera": [
+                  {
+                    "version_added": "12.1"
+                  },
+                  {
+                    "prefix": "-o-",
+                    "version_added": "11",
+                    "version_removed": "15",
+                    "notes": "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "15",
+                    "notes": "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
+                  }
+                ],
+                "opera_android": [
+                  {
+                    "version_added": true
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "14"
+                  }
+                ],
+                "safari": [
+                  {
+                    "version_added": "6.1"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "5.1",
+                    "notes": [
+                      "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(linear,…)</a></code> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>repeating-linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
+                      "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
+                    ]
+                  }
+                ],
+                "safari_ios": {
+                  "version_added": true
+                },
+                "samsunginternet_android": {
+                  "version_added": true
+                },
+                "webview_android": [
+                  {
+                    "version_added": true
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": true
+                  }
+                ]
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeating-linear-gradient"
+            },
+            "to": {
+              "__compat": {
+                "description": "<code>to</code> keyword",
+                "support": {
+                  "chrome": {
+                    "version_added": "26"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": "12"
+                  },
+                  "edge_mobile": {
+                    "version_added": true
+                  },
+                  "firefox": {
+                    "version_added": "10"
+                  },
+                  "firefox_android": {
+                    "version_added": "10"
+                  },
+                  "ie": {
+                    "version_added": "10"
+                  },
+                  "opera": {
+                    "version_added": "12.1"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "6.1"
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  },
+                  "samsunginternet_android": {
+                    "version_added": true
+                  },
+                  "webview_android": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "doubleposition": {
+              "__compat": {
+                "description": "Double-position color stops",
+                "support": {
+                  "chrome": {
+                    "version_added": "71"
+                  },
+                  "chrome_android": {
+                    "version_added": "71"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "edge_mobile": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "64"
+                  },
+                  "firefox_android": {
+                    "version_added": "64"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "58"
+                  },
+                  "opera_android": {
+                    "version_added": "58"
+                  },
+                  "safari": {
+                    "version_added": null,
+                    "notes": "In Safari Technology Preview Release 66"
+                  },
+                  "safari_ios": {
+                    "version_added": null,
+                    "notes": "In Safari Technology Preview Release 66"
+                  },
+                  "samsunginternet_android": {
+                    "version_added": true
+                  },
+                  "webview_android": {
+                    "version_added": "71"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "interpolation_hints": {
+              "__compat": {
+                "description": "Interpolation Hints / Gradient Midpoints",
+                "support": {
+                  "chrome": {
+                    "version_added": "40"
+                  },
+                  "chrome_android": {
+                    "version_added": "40"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "edge_mobile": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "36"
+                  },
+                  "firefox_android": {
+                    "version_added": "36"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "27"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "6.1"
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  },
+                  "samsunginternet_android": {
+                    "version_added": true
+                  },
+                  "webview_android": {
+                    "version_added": "40"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "unitless_0_angle": {
+              "__compat": {
+                "description": "Unitless <code>0</code> for &lt;angle&gt;",
+                "support": {
+                  "chrome": {
+                    "version_added": "26"
+                  },
+                  "chrome_android": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": "12"
+                  },
+                  "edge_mobile": {
+                    "version_added": "12"
+                  },
+                  "firefox": [
+                    {
+                      "version_added": "55"
+                    },
+                    {
+                      "version_added": "46",
+                      "partial_implementation": true,
+                      "notes": "Accepted only in <code>-webkit-repeating-linear-gradient()</code> and <code>-moz-repeating-linear-gradient()</code>, not <code>repeating-linear-gradient()</code>."
+                    }
+                  ],
+                  "firefox_android": [
+                    {
+                      "version_added": "55"
+                    },
+                    {
+                      "version_added": "46",
+                      "partial_implementation": true,
+                      "notes": "Accepted only in <code>-webkit-repeating-linear-gradient()</code> and <code>-moz-repeating-linear-gradient()<code>, not <code>repeating-linear-gradient()</code>."
+                    }
+                  ],
+                  "ie": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": "16"
+                  },
+                  "opera_android": {
+                    "version_added": true
+                  },
+                  "safari": {
+                    "version_added": "6.1"
+                  },
+                  "safari_ios": {
+                    "version_added": true
+                  },
+                  "samsunginternet_android": {
+                    "version_added": true
+                  },
+                  "webview_android": {
+                    "version_added": true
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
           "repeating-radial-gradient": {
             "__compat": {
               "description": "<code>repeating-radial-gradient()</code>",
@@ -1486,146 +1626,6 @@
                   "standard_track": true,
                   "deprecated": false
                 }
-              }
-            }
-          }
-        },
-        "conic-gradient": {
-          "__compat": {
-            "description": "<code>conic-gradient()</code>",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/conic-gradient",
-            "support": {
-              "chrome": [
-                {
-                  "version_added": "69"
-                },
-                {
-                  "version_added": "59",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable Experimental Web Platform Features"
-                    }
-                  ]
-                }
-              ],
-              "chrome_android": [
-                {
-                  "version_added": "69"
-                },
-                {
-                  "version_added": "59",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable Experimental Web Platform Features"
-                    }
-                  ]
-                }
-              ],
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "56"
-              },
-              "opera_android": {
-                "version_added": "56"
-              },
-              "safari": {
-                "version_added": null,
-                "notes": "In Safari Technology Preview Release 66"
-              },
-              "safari_ios": {
-                "version_added": null,
-                "notes": "In Safari Technology Preview Release 66"
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": [
-                {
-                  "version_added": "69"
-                },
-                {
-                  "version_added": "59",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable Experimental Web Platform Features"
-                    }
-                  ]
-                }
-              ]
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          },
-          "doubleposition": {
-            "__compat": {
-              "description": "Double-position color stops",
-              "support": {
-                "chrome": {
-                  "version_added": "72"
-                },
-                "chrome_android": {
-                  "version_added": "72"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": null,
-                  "notes": "In Safari Technology Preview Release 66"
-                },
-                "safari_ios": {
-                  "version_added": null,
-                  "notes": "In Safari Technology Preview Release 66"
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "72"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
               }
             }
           }


### PR DESCRIPTION
Follow-up on https://github.com/mdn/browser-compat-data/pull/3135

conic-gradient wasn't nesting under gradients, so this won't work: https://developer.mozilla.org/en-US/docs/Web/CSS/conic-gradient#Browser_compatibility

Also sorted the gradients alphabetically while I was in there.

No data updates, just moving features around. Horrible diff :(