### PR TITLE
Fix URL.hash data for IE

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -286,7 +286,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": true
+              "version_added": null
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
IE doesn't support the `URL()` constructor, so it can't support the `hash` property of `URL` instances. All the other instance properties are listed as `null` for IE, but `hash` is listed with support.

![image](https://user-images.githubusercontent.com/159415/52102348-1856b000-2634-11e9-8525-49e88bf9f553.png)

This PR makes the `hash` property consistent with the other `URL` instance properties.
