### PR TITLE
Update Safari (macOS/iOS) AudioContext support

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -64,7 +64,8 @@
             "prefix": "webkit"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true,
+            "prefix": "webkit"
           },
           "samsunginternet_android": [
             {
@@ -131,7 +132,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true,
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -230,10 +232,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -384,10 +386,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -438,7 +440,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -489,7 +491,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -540,7 +542,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -684,16 +686,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -741,10 +743,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -338,7 +338,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
Safari for both macOS and iOS support the `AudioContext` API with the `webkit` prefix.  While developing a visualizer for my website and testing it out on iOS, I found that all it simply needed was a `context.resume()` as a part of compliance for [Chrome's autoplay policy](https://developers.google.com/web/updates/2017/09/autoplay-policy-changes).  This compatibility table has been updated to include supported functions, as tested with the latest Safari versions.  (This also sneaks in a quick fix to an Opera compatibility statement that was set to `false` when it should be `true`, as proven by my own use of the function.)
