### PR TITLE
More updates to fragmentation properties

### DIFF
--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -38,13 +38,13 @@
                 }
               ],
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": "10"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "10"
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -85,16 +85,16 @@
                   "version_added": "10"
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": null
@@ -136,19 +136,19 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "webview_android": {
                   "version_added": false
@@ -190,7 +190,7 @@
                   "version_added": false
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari": {
                   "version_added": false

--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -38,13 +38,13 @@
                 }
               ],
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": "10"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "10"
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -61,13 +61,13 @@
           },
           "column": {
             "__compat": {
-              "description": "<code>column</code> and <code>avoid-column</code>",
+              "description": "<code>column</code>",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "edge": {
                   "version_added": "12"
@@ -85,11 +85,61 @@
                   "version_added": "10"
                 },
                 "opera": {
-                  "version_added": "11.1",
-                  "version_removed": "12.1"
+                  "version_added": true
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": true
+                },
+                "safari_ios": {
+                  "version_added": true
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "avoid-column": {
+            "__compat": {
+              "description": "<code>avoid-column</code>",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
                 },
                 "safari": {
                   "version_added": false
@@ -332,7 +382,7 @@
                   "version_added": false
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge": {
                   "version_added": false

--- a/css/properties/break-inside.json
+++ b/css/properties/break-inside.json
@@ -85,23 +85,22 @@
                   "version_added": "10"
                 },
                 "opera": {
-                  "version_added": "11.1",
-                  "version_removed": "12.1"
+                  "version_added": true
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "samsunginternet_android": {
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": true
                 }
               },
               "status": {
@@ -220,56 +219,57 @@
                 "deprecated": false
               }
             }
-          },
-          "region": {
-            "__compat": {
-              "description": "<code>region</code> and <code>avoid-region</code>",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                }
+          }
+        },
+        "region_context": {
+          "__compat": {
+            "description": "Supported in CSS Regions",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-inside",
+            "support": {
+              "chrome": {
+                "version_added": false
               },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }


### PR DESCRIPTION
I have done some more cleaning up and testing of the `break-before`, `break-after` and `break-inside` data.

1. Tested in Opera and Safari for Multicol, and updated all three files.
2. Split up `column` and `avoid-column` support in `break-before` so that it would match work done in PR for `break-after`.
3. Moved the section for regions in `break-inside` to match other properties.

Previous PRs:

- `break-after`: https://github.com/mdn/browser-compat-data/pull/3330
- `break-before`: https://github.com/mdn/browser-compat-data/pull/3327
- `break-inside`: https://github.com/mdn/browser-compat-data/pull/3315