### PR TITLE
adding removal data for the moz-none value of user-select

### DIFF
--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -245,6 +245,7 @@
                 },
                 {
                   "version_added": true,
+                  "version_removed": "65",
                   "prefix": "-moz-"
                 }
               ],
@@ -254,6 +255,7 @@
                 },
                 {
                   "version_added": true,
+                  "version_removed": "65",
                   "prefix": "-moz-"
                 }
               ],


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1506547

One of the things done in this bug weas the removal of the -moz-none value.