### PR TITLE
URLSearchParams: Add Edge version that supports it

### DIFF
--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -64,7 +64,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": null


### PR DESCRIPTION
As per

    https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8993198/

this is supported with EdgeHTML 17, build 17133.

https://caniuse.com/#feat=urlsearchparams also mentions 17 as supported version.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
