### PR TITLE
Add BCD for Web Crypto "Param" objects

### DIFF
--- a/api/AesCbcParams.json
+++ b/api/AesCbcParams.json
@@ -1,0 +1,93 @@
+{
+  "api": {
+    "AesCbcParams": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/AesCbcParams",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": "11"
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "24"
+          },
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/AesCtrParams.json
+++ b/api/AesCtrParams.json
@@ -1,0 +1,93 @@
+{
+  "api": {
+    "AesCtrParams": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/AesCtrParams",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": "11"
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "24"
+          },
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/AesGcmParams.json
+++ b/api/AesGcmParams.json
@@ -1,0 +1,93 @@
+{
+  "api": {
+    "AesGcmParams": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/AesGcmParams",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": "11"
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "24"
+          },
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/AesKeyGenParams.json
+++ b/api/AesKeyGenParams.json
@@ -1,0 +1,93 @@
+{
+  "api": {
+    "AesKeyGenParams": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/AesKeyGenParams",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": "11"
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "24"
+          },
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/EcKeyGenParams.json
+++ b/api/EcKeyGenParams.json
@@ -1,0 +1,93 @@
+{
+  "api": {
+    "EcKeyGenParams": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/EcKeyGenParams",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": "11"
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "24"
+          },
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/EcKeyImportParams.json
+++ b/api/EcKeyImportParams.json
@@ -1,0 +1,93 @@
+{
+  "api": {
+    "EcKeyImportParams": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/EcKeyImportParams",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": "11"
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "24"
+          },
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/EcdhKeyDeriveParams.json
+++ b/api/EcdhKeyDeriveParams.json
@@ -1,0 +1,93 @@
+{
+  "api": {
+    "EcdhKeyDeriveParams": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/EcdhKeyDeriveParams",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "24"
+          },
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/EcdsaParams.json
+++ b/api/EcdsaParams.json
@@ -1,0 +1,93 @@
+{
+  "api": {
+    "EcdsaParams": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/EcdsaParams",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": "11"
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "24"
+          },
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/HkdfParams.json
+++ b/api/HkdfParams.json
@@ -1,0 +1,93 @@
+{
+  "api": {
+    "HkdfParams": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HkdfParams",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "24"
+          },
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/HmacImportParams.json
+++ b/api/HmacImportParams.json
@@ -1,0 +1,93 @@
+{
+  "api": {
+    "HmacImportParams": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HmacImportParams",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": "11"
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "24"
+          },
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/HmacKeyGenParams.json
+++ b/api/HmacKeyGenParams.json
@@ -1,0 +1,93 @@
+{
+  "api": {
+    "HmacKeyGenParams": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HmacKeyGenParams",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": "11"
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "24"
+          },
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/Pbkdf2Params.json
+++ b/api/Pbkdf2Params.json
@@ -1,0 +1,93 @@
+{
+  "api": {
+    "Pbkdf2Params": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Pbkdf2Params",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "24"
+          },
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/RsaHashedImportParams.json
+++ b/api/RsaHashedImportParams.json
@@ -1,0 +1,93 @@
+{
+  "api": {
+    "RsaHashedImportParams": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/RsaHashedImportParams",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": "11"
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "24"
+          },
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/RsaHashedKeyGenParams.json
+++ b/api/RsaHashedKeyGenParams.json
@@ -1,0 +1,93 @@
+{
+  "api": {
+    "RsaHashedKeyGenParams": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/RsaHashedKeyGenParams",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": "11"
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "24"
+          },
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/RsaOaepParams.json
+++ b/api/RsaOaepParams.json
@@ -1,0 +1,93 @@
+{
+  "api": {
+    "RsaOaepParams": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/RsaOaepParams",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": "11"
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "24"
+          },
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/RsaPssParams.json
+++ b/api/RsaPssParams.json
@@ -1,0 +1,93 @@
+{
+  "api": {
+    "RsaPssParams": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/RsaPssParams",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": "12"
+          },
+          "firefox": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "34"
+            },
+            {
+              "version_added": "32",
+              "version_removed": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcrypto.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": "11"
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "24"
+          },
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "version_added": "7",
+              "prefix": "WebKit"
+            }
+          ],
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a PR to add compat data for the `Param` objects that I've documented as part of https://github.com/mdn/sprints/issues/664:

https://developer.mozilla.org/en-US/docs/Web/API/AesCbcParams
https://developer.mozilla.org/en-US/docs/Web/API/AesCtrParams
https://developer.mozilla.org/en-US/docs/Web/API/AesGcmParams
https://developer.mozilla.org/en-US/docs/Web/API/AesKeyGenParams
https://developer.mozilla.org/en-US/docs/Web/API/EcdhKeyDeriveParams
https://developer.mozilla.org/en-US/docs/Web/API/EcdsaParams
https://developer.mozilla.org/en-US/docs/Web/API/EcKeyGenParams
https://developer.mozilla.org/en-US/docs/Web/API/EcKeyImportParams
https://developer.mozilla.org/en-US/docs/Web/API/HkdfParams
https://developer.mozilla.org/en-US/docs/Web/API/HmacImportParams
https://developer.mozilla.org/en-US/docs/Web/API/HmacKeyGenParams
https://developer.mozilla.org/en-US/docs/Web/API/Pbkdf2Params
https://developer.mozilla.org/en-US/docs/Web/API/RsaHashedImportParams
https://developer.mozilla.org/en-US/docs/Web/API/RsaHashedKeyGenParams
https://developer.mozilla.org/en-US/docs/Web/API/RsaOaepParams
https://developer.mozilla.org/en-US/docs/Web/API/RsaPssParams

These things are dictionaries holding algorithm-specific parameters that are passed into crypto functions like `SubtleCrypto.sign()`, `SubtleCrypto.encrypt()` and so on.

So in general I've copied the browser support data from the [compat data for `SubtleCrypto`](https://github.com/mdn/browser-compat-data/blob/master/api/SubtleCrypto.json). 

Basically, if a browser supports a given algorithm for a given `SubtleCrypto` function, then it will support the associated `Param` object, and if it doesn't, it won't.

As far as I can tell:

* all algorithms are supported by all browsers except Edge which does not support RSA-PSS, ECDSA, ECDH, AES-CTR, SHA-1, HKDF, PBKDF2 (see also https://github.com/mdn/browser-compat-data/pull/2738 for some more stuff on this)

* all functions are supported by all browsers except IE, which does not support `deriveKey` or `deriveBits`. The associated algorithms there are ECDH, HKDF, PBKDF2.

That would give us a support table like this:

```
AesCbcParams          (all)
AesCtrParams          (all except edge)
AesGcmParams          (all)
AesKeyGenParams       (all)
EcdhKeyDeriveParams   (all except edge and ie)
EcdsaParams           (all except edge)
EcKeyGenParams        (all except edge)
EcKeyImportParams     (all except edge)
HkdfParams            (all except edge and ie)
HmacImportParams      (all)
HmacKeyGenParams      (all)
Pbkdf2Params          (all except edge and ie)
RsaHashedImportParams (all)
RsaHashedKeyGenParams (all)
RsaOaepParams         (all)
RsaPssParams          (all except edge)
```

...and that's what I've tried to do in this PR. I have tested it a bit, but tbh it's very frustrating trying to do this for so many tables using a local Kuma.
