### PR TITLE
Add BCD for CryptoKeyPair

### DIFF
--- a/api/CryptoKeyPair.json
+++ b/api/CryptoKeyPair.json
@@ -1,0 +1,55 @@
+{
+  "api": {
+    "CryptoKeyPair": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CryptoKeyPair",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "edge": {
+            "version_added": true
+          },
+          "edge_mobile": {
+            "version_added": true
+          },
+          "firefox": {
+            "version_added": "34"
+          },
+          "firefox_android": {
+            "version_added": "34"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds BCD for the [`CryptoKeyPair`](https://developer.mozilla.org/en-US/docs/Web/API/CryptoKeyPair) object, docs for which were added as part of https://github.com/mdn/sprints/issues/664.

It's the same data as for [`CryptoKey`](https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey), except I didn't include any subfeatures.
