### PR TITLE
Mention Firefox Android camera bug on FileReader.readAsDataURL()

### DIFF
--- a/api/FileReader.json
+++ b/api/FileReader.json
@@ -608,7 +608,8 @@
               "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": "32"
+              "version_added": "32",
+              "notes": "Using the camera in Android 8.x raises an exception."
             },
             "ie": {
               "version_added": "10"

--- a/api/FileReader.json
+++ b/api/FileReader.json
@@ -609,7 +609,7 @@
             },
             "firefox_android": {
               "version_added": "32",
-              "notes": "Using the camera in Android 8.x raises an exception."
+              "notes": "Using the camera in Android 8.x raises an exception. See <a href='https://bugzil.la/1511083'>bug 1511083</a>."
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
Fixes #3342.