### PR TITLE
updating all CSS value

### DIFF
--- a/css/properties/all.json
+++ b/css/properties/all.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "27"
@@ -59,13 +59,13 @@
                 "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false


### PR DESCRIPTION
I'm working on a learn document about values and units, spotted there were null values in the compat data for `all`. Confirmed by testing there is no support in those browsers and have updated the data.

https://developer.mozilla.org/en-US/docs/Web/CSS/all