### PR TITLE
Updates to document.all.

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -256,7 +256,7 @@
             "chrome_android": {
               "version_added": "64",
               "notes": [
-                "Staring in Chrome 65, this property is readonly.",
+                "Starting in Chrome 65, this property is readonly.",
                 "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
               ]
             },

--- a/api/Document.json
+++ b/api/Document.json
@@ -249,7 +249,7 @@
             "chrome": {
               "version_added": "64",
               "notes": [
-                "Staring in Chrome 65, this property is readonly.",
+                "Starting in Chrome 65, this property is readonly.",
                 "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
               ]
             },

--- a/api/Document.json
+++ b/api/Document.json
@@ -290,7 +290,7 @@
             "webview_android": {
               "version_added": "64",
               "notes": [
-                "Staring in Chrome 65, this property is readonly.",
+                "Starting in Chrome 65, this property is readonly.",
                 "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
               ]
             }

--- a/api/Document.json
+++ b/api/Document.json
@@ -248,11 +248,17 @@
           "support": {
             "chrome": {
               "version_added": "64",
-              "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
+              "notes": [
+                "Staring in Chrome 65, this property is readonly.",
+                "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
+              ]
             },
             "chrome_android": {
               "version_added": "64",
-              "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
+              "notes": [
+                "Staring in Chrome 65, this property is readonly.",
+                "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
+              ]
             },
             "edge": {
               "version_added": null
@@ -283,13 +289,16 @@
             },
             "webview_android": {
               "version_added": "64",
-              "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
+              "notes": [
+                "Staring in Chrome 65, this property is readonly.",
+                "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
+              ]
             }
           },
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -387,8 +387,7 @@
     "compare-versions": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
-      "integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg==",
-      "dev": true
+      "integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg=="
     },
     "compressible": {
       "version": "2.0.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -387,7 +387,8 @@
     "compare-versions": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
-      "integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg=="
+      "integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg==",
+      "dev": true
     },
     "compressible": {
       "version": "2.0.14",


### PR DESCRIPTION
* Chrome made this [read only in Chrome 65](https://storage.googleapis.com/chromium-find-releases-static/74c.html#74c78412e6d3839adb217ce05556f4f3c681dbf3). This is a bit confusing since it was previously marked 'readonly', but was also 'replaceable', which overrode. 
* Document.all is [not deprecated in the current spec](https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-all). I can change it back if anyone knows something I don't.
