### PR TITLE
Mark document.applets as available from Edge 12

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -352,7 +352,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "18"
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": null


### PR DESCRIPTION
`document.applets` is an ancient API and was available in the first release of
Edge, confirmed by its presence in web-apis:
https://github.com/mdittmer/web-apis/blob/be545389cb029a53b6a75bd6416dce012d961a4d/data/og/window_Edge_12.10240_Windows_10.0.json