### PR TITLE
Remove fault chrome values.

### DIFF
--- a/api/ValidityState.json
+++ b/api/ValidityState.json
@@ -8,7 +8,7 @@
             "version_added": "15"
           },
           "chrome_android": {
-            "version_added": "71"
+            "version_added": true
           },
           "edge": {
             "version_added": "12"
@@ -58,7 +58,7 @@
               "version_added": "25"
             },
             "chrome_android": {
-              "version_added": "71"
+              "version_added": true
             },
             "edge": {
               "version_added": "14"
@@ -109,7 +109,7 @@
               "version_added": "15"
             },
             "chrome_android": {
-              "version_added": "71"
+              "version_added": true
             },
             "edge": {
               "version_added": "12",
@@ -162,7 +162,7 @@
               "version_added": "40"
             },
             "chrome_android": {
-              "version_added": "71"
+              "version_added": true
             },
             "edge": {
               "version_added": "17"


### PR DESCRIPTION
I forgot to hit submit on a review of [another pull request](https://github.com/mdn/browser-compat-data/pull/3367). Having "71" as the Chrome version number on something that's been around for years gives a more faulty impression of its support than simply listing 'true'.