### PR TITLE
feat(browsers): Add `pref_url` for feature flags page

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -2,6 +2,7 @@
   "browsers": {
     "chrome": {
       "name": "Chrome",
+      "pref_url": "chrome://flags",
       "releases": {
         "1": {
           "release_date": "2008-12-11",

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -2,6 +2,7 @@
   "browsers": {
     "chrome_android": {
       "name": "Chrome Android",
+      "pref_url": "chrome://flags",
       "releases": {
         "18": {
           "release_date": "2012-06-27",

--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -2,6 +2,7 @@
   "browsers": {
     "edge": {
       "name": "Edge",
+      "pref_url": "about:flags",
       "releases": {
         "12": {
           "release_date": "2015-07-28",

--- a/browsers/edge_mobile.json
+++ b/browsers/edge_mobile.json
@@ -2,6 +2,7 @@
   "browsers": {
     "edge_mobile": {
       "name": "Edge Mobile",
+      "pref_url": "about:flags",
       "releases": {
         "12": {
           "release_date": "2015-07-15",

--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -2,6 +2,7 @@
   "browsers": {
     "firefox": {
       "name": "Firefox",
+      "pref_url": "about:config",
       "releases": {
         "1": {
           "release_date": "2004-11-09",

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -2,6 +2,7 @@
   "browsers": {
     "firefox_android": {
       "name": "Firefox Android",
+      "pref_url": "about:config",
       "releases": {
         "4": {
           "release_date": "2011-03-29",

--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -17,6 +17,7 @@ The file `firefox.json` is structured like this:
   "browsers": {
     "firefox": {
       "name": "Firefox",
+      "pref_url": "about:config",
       "releases": {
         "1.5": {
           "release_date": "2005-11-29",
@@ -35,7 +36,11 @@ Underneath, there is a `releases` object which will hold the various releases of
 
 ### `name`
 
-The `name` string is an optional property which should use the browser brand name and avoid English words if possible, for example `"Firefox"`, `"Firefox Android"`, `"Safari"`, `"iOS Safari"`, etc.
+The `name` string is a required property which should use the browser brand name and avoid English words if possible, for example `"Firefox"`, `"Firefox Android"`, `"Safari"`, `"iOS Safari"`, etc.
+
+### `pref_url`
+
+An optional string containg the URL of the page where feature flags can be changed (e.g. `"about:config"` for Firefox or `"chrome://flags"` for Chrome).
 
 ### Release objects
 The release objects consist of the following properties:

--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -40,7 +40,7 @@ The `name` string is a required property which should use the browser brand name
 
 ### `pref_url`
 
-An optional string containg the URL of the page where feature flags can be changed (e.g. `"about:config"` for Firefox or `"chrome://flags"` for Chrome).
+An optional string containing the URL of the page where feature flags can be changed (e.g. `"about:config"` for Firefox or `"chrome://flags"` for Chrome).
 
 ### Release objects
 The release objects consist of the following properties:

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -34,6 +34,10 @@
           "type": "string",
           "description": "Browser name, avoid using unnecessary English (e.g. prefer 'Chrome Android' over 'Chrome for Android')."
         },
+        "pref_url": {
+          "type": "string",
+          "description": "URL of the page where feature flags can be changed (e.g. 'about:config' or 'chrome://flags')"
+        },
         "releases": {
           "type": "object",
           "additionalProperties": { "$ref": "#/definitions/release_statement" }

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -36,7 +36,7 @@
         },
         "pref_url": {
           "type": "string",
-          "description": "URL of the page where feature flags can be changed (e.g. 'about:config' or 'chrome://flags')"
+          "description": "URL of the page where feature flags can be changed (e.g. 'about:config' or 'chrome://flags')."
         },
         "releases": {
           "type": "object",


### PR DESCRIPTION
This adds a&nbsp;field called `pref_url` to&nbsp;the&nbsp:browser schema to&nbsp;document where feature flags can&nbsp;be&nbsp;changed, so&nbsp;that it&nbsp;can be&nbsp;unhard&#x2011;coded from the&nbsp;`{{Compat}}`&nbsp;macro (see&nbsp;also&nbsp;https://github.com/mdn/kumascript/pull/1010).

review?(@Elchi3, @wbamberg)