### PR TITLE
Updates to NetworkInformation interface.

### DIFF
--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -275,10 +275,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NetworkInformation/ontypechange",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -305,7 +305,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -270,6 +270,51 @@
           }
         }
       },
+      "ontypechange": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NetworkInformation/ontypechange",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "rtt": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NetworkInformation/rtt",
@@ -306,6 +351,51 @@
             },
             "webview_android": {
               "version_added": "50"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "saveData": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NetworkInformation/saveData",
+          "support": {
+            "chrome": {
+              "version_added": "65"
+            },
+            "chrome_android": {
+              "version_added": "65"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "65"
             }
           },
           "status": {


### PR DESCRIPTION
[Confluence shows the break from 64 to 65](http://web-confluence.appspot.com/#!/catalog?releases=%5B%22Chrome_60.0.3112.78_Windows_10.0%22,%22Chrome_61.0.3163.79_Windows_10.0%22,%22Chrome_64.0.3282.119_Windows_10.0%22,%22Chrome_65.0.3325.146_Windows_10.0%22%5D&q=%22NetworkInformation%22). 