### PR TITLE
Make desktop browser required in lint and add them where missing

### DIFF
--- a/api/AbsoluteOrientationSensor.json
+++ b/api/AbsoluteOrientationSensor.json
@@ -28,6 +28,9 @@
           "opera_android": {
             "version_added": "56"
           },
+          "safari": {
+            "version_added": null
+          },
           "samsunginternet_android": {
             "version_added": null
           },
@@ -69,6 +72,9 @@
             },
             "opera_android": {
               "version_added": "56"
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -22,6 +22,9 @@
               "notes": "Based on Generic Sensor API."
             }
           ],
+          "edge": {
+            "version_added": null
+          },
           "firefox": {
             "version_added": null
           },
@@ -82,6 +85,9 @@
                 "notes": "Based on Generic Sensor API."
               }
             ],
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": null
             },
@@ -142,6 +148,9 @@
                 "notes": "Based on Generic Sensor API."
               }
             ],
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": null
             },

--- a/api/Attr.json
+++ b/api/Attr.json
@@ -60,6 +60,9 @@
               "version_added": "46",
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": "48",
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
@@ -101,6 +104,9 @@
             "chrome": {
               "version_added": "46",
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": "48",

--- a/api/AudioNodeOptions.json
+++ b/api/AudioNodeOptions.json
@@ -10,6 +10,9 @@
           "chrome_android": {
             "version_added": "55"
           },
+          "edge": {
+            "version_added": null
+          },
           "firefox": {
             "version_added": "53"
           },

--- a/api/BatteryManager.json
+++ b/api/BatteryManager.json
@@ -11,6 +11,9 @@
             "version_added": "38",
             "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
           },
+          "edge": {
+            "version_added": null
+          },
           "edge_mobile": {
             "version_added": false
           },
@@ -100,6 +103,9 @@
             "chrome_android": {
               "version_added": "38",
               "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+            },
+            "edge": {
+              "version_added": null
             },
             "edge_mobile": {
               "version_added": false
@@ -192,6 +198,9 @@
               "version_added": "38",
               "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
+            "edge": {
+              "version_added": null
+            },
             "edge_mobile": {
               "version_added": false
             },
@@ -282,6 +291,9 @@
             "chrome_android": {
               "version_added": "38",
               "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+            },
+            "edge": {
+              "version_added": null
             },
             "edge_mobile": {
               "version_added": false
@@ -374,6 +386,9 @@
               "version_added": "38",
               "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
+            "edge": {
+              "version_added": null
+            },
             "edge_mobile": {
               "version_added": false
             },
@@ -464,6 +479,9 @@
             "chrome_android": {
               "version_added": "38",
               "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+            },
+            "edge": {
+              "version_added": null
             },
             "edge_mobile": {
               "version_added": false
@@ -556,6 +574,9 @@
               "version_added": "38",
               "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
+            "edge": {
+              "version_added": null
+            },
             "edge_mobile": {
               "version_added": false
             },
@@ -647,6 +668,9 @@
               "version_added": "38",
               "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
+            "edge": {
+              "version_added": null
+            },
             "edge_mobile": {
               "version_added": false
             },
@@ -737,6 +761,9 @@
             "chrome_android": {
               "version_added": "38",
               "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+            },
+            "edge": {
+              "version_added": null
             },
             "edge_mobile": {
               "version_added": false

--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -10,6 +10,9 @@
           "chrome_android": {
             "version_added": true
           },
+          "edge": {
+            "version_added": null
+          },
           "firefox": {
             "version_added": true
           },
@@ -50,6 +53,9 @@
             },
             "chrome_android": {
               "version_added": "60"
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": null

--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -117,6 +117,9 @@
             "chrome_android": {
               "version_added": false
             },
+            "edge": {
+              "version_added": null
+            },
             "edge_mobile": {
               "version_added": null
             },

--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -10,6 +10,9 @@
           "chrome_android": {
             "version_added": "54"
           },
+          "edge": {
+            "version_added": null
+          },
           "firefox": {
             "version_added": "38"
           },
@@ -51,6 +54,9 @@
             },
             "chrome_android": {
               "version_added": "54"
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": "38"
@@ -94,6 +100,9 @@
             "chrome_android": {
               "version_added": "54"
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": "38"
             },
@@ -135,6 +144,9 @@
             },
             "chrome_android": {
               "version_added": "54"
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": "38"
@@ -178,6 +190,9 @@
             "chrome_android": {
               "version_added": "60"
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": "57"
             },
@@ -220,6 +235,9 @@
             "chrome_android": {
               "version_added": "54"
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": "38"
             },
@@ -261,6 +279,9 @@
             },
             "chrome_android": {
               "version_added": "54"
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": "38"

--- a/api/BudgetService.json
+++ b/api/BudgetService.json
@@ -10,11 +10,23 @@
           "chrome_android": {
             "version_added": "55"
           },
+          "edge": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
           "opera": {
             "version_added": "42"
           },
           "opera_android": {
             "version_added": "42"
+          },
+          "safari": {
+            "version_added": null
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -39,11 +51,23 @@
             "chrome_android": {
               "version_added": "55"
             },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
             "opera": {
               "version_added": "42"
             },
             "opera_android": {
               "version_added": "42"
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -69,11 +93,23 @@
             "chrome_android": {
               "version_added": "55"
             },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
             "opera": {
               "version_added": "42"
             },
             "opera_android": {
               "version_added": "42"
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -99,11 +135,23 @@
             "chrome_android": {
               "version_added": "55"
             },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
             "opera": {
               "version_added": "42"
             },
             "opera_android": {
               "version_added": "42"
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/BudgetState.json
+++ b/api/BudgetState.json
@@ -10,11 +10,23 @@
           "chrome_android": {
             "version_added": "60"
           },
+          "edge": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
           "opera": {
             "version_added": false
           },
           "opera_android": {
             "version_added": false
+          },
+          "safari": {
+            "version_added": null
           },
           "samsunginternet_android": {
             "version_added": false
@@ -39,11 +51,23 @@
             "chrome_android": {
               "version_added": "60"
             },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
             "opera": {
               "version_added": false
             },
             "opera_android": {
               "version_added": false
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": false
@@ -69,11 +93,23 @@
             "chrome_android": {
               "version_added": "60"
             },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
             "opera": {
               "version_added": false
             },
             "opera_android": {
               "version_added": false
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/Client.json
+++ b/api/Client.json
@@ -165,6 +165,9 @@
             "chrome_android": {
               "version_added": "45"
             },
+            "edge": {
+              "version_added": null
+            },
             "edge_mobile": {
               "version_added": false
             },

--- a/api/Credential.json
+++ b/api/Credential.json
@@ -167,6 +167,9 @@
               "version_removed": "52",
               "notes": "See <a href='https://crbug.com/602980'>Bug 602980</a>."
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -167,6 +167,9 @@
                 "version_removed": "60"
               }
             ],
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": null
             },
@@ -215,6 +218,9 @@
             },
             "chrome_android": {
               "version_added": "51"
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": null

--- a/api/DOMError.json
+++ b/api/DOMError.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMError",
         "support": {
+          "chrome": {
+            "version_added": null
+          },
           "edge": {
             "version_added": true
           },
@@ -17,6 +20,15 @@
           "firefox_android": {
             "version_added": true,
             "version_removed": "58"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
           }
         },
         "status": {
@@ -29,6 +41,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMError/name",
           "support": {
+            "chrome": {
+              "version_added": null
+            },
             "edge": {
               "version_added": true
             },
@@ -42,6 +57,15 @@
             "firefox_android": {
               "version_added": true,
               "version_removed": "58"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             }
           },
           "status": {
@@ -55,6 +79,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMError/message",
           "support": {
+            "chrome": {
+              "version_added": null
+            },
             "edge": {
               "version_added": true
             },
@@ -68,6 +95,15 @@
             "firefox_android": {
               "version_added": true,
               "version_removed": "58"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             }
           },
           "status": {

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -316,6 +316,9 @@
               "version_added": "50",
               "notes": "Before Chrome 50, this property was part of the deprecated child <code>DOMSettableTokenList</code> interface."
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": true
             },
@@ -652,6 +655,9 @@
             "chrome_android": {
               "version_added": "45"
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": "50"
             },
@@ -745,6 +751,9 @@
             "chrome_android": {
               "version_added": "45"
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": "50"
             },
@@ -789,6 +798,9 @@
             },
             "chrome_android": {
               "version_added": "45"
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": "50"

--- a/api/External.json
+++ b/api/External.json
@@ -25,6 +25,12 @@
           "ie": {
             "version_added": null
           },
+          "opera": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
           "samsunginternet_android": {
             "version_added": null
           },
@@ -61,6 +67,12 @@
               "version_added": true
             },
             "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
               "version_added": null
             },
             "samsunginternet_android": {
@@ -100,6 +112,12 @@
               "version_added": true
             },
             "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
               "version_added": null
             },
             "samsunginternet_android": {

--- a/api/FederatedCredential.json
+++ b/api/FederatedCredential.json
@@ -10,6 +10,9 @@
           "chrome_android": {
             "version_added": "51"
           },
+          "edge": {
+            "version_added": null
+          },
           "firefox": {
             "version_added": null
           },
@@ -50,6 +53,9 @@
             },
             "chrome_android": {
               "version_added": "51"
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": null
@@ -92,6 +98,9 @@
             },
             "chrome_android": {
               "version_added": "51"
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": null

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -472,6 +472,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": true
             },

--- a/api/HTMLFontElement.json
+++ b/api/HTMLFontElement.json
@@ -4,11 +4,26 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFontElement",
         "support": {
+          "chrome": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": null
+          },
           "firefox": {
             "version_added": "22"
           },
           "firefox_android": {
             "version_added": "22"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
           }
         },
         "status": {
@@ -21,11 +36,26 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFontElement/color",
           "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": "22"
             },
             "firefox_android": {
               "version_added": "22"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             }
           },
           "status": {
@@ -39,11 +69,26 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFontElement/face",
           "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": "22"
             },
             "firefox_android": {
               "version_added": "22"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             }
           },
           "status": {
@@ -57,11 +102,26 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFontElement/size",
           "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": "22"
             },
             "firefox_android": {
               "version_added": "22"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             }
           },
           "status": {

--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -12,6 +12,9 @@
             "version_added": true,
             "notes": "Starting in Chrome 52, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
           },
+          "edge": {
+            "version_added": null
+          },
           "firefox": {
             "version_added": "22",
             "notes": [
@@ -336,6 +339,9 @@
               "version_added": true,
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": "26",
               "notes": "From Firefox 26 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
@@ -658,6 +664,9 @@
             "chrome_android": {
               "version_added": true,
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": "26",

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -167,6 +167,9 @@
                 }
               ]
             },
+            "ie": {
+              "version_added": null
+            },
             "opera": {
               "version_added": true
             },
@@ -408,6 +411,9 @@
               "version_added": false,
               "notes": "Firefox doesn't implement this yet. See <a href='https://bugzil.la/847377'>bug 847377</a>."
             },
+            "ie": {
+              "version_added": null
+            },
             "opera": {
               "version_added": false
             },
@@ -489,11 +495,23 @@
             "chrome_android": {
               "version_added": "58"
             },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
             "opera": {
               "version_added": "45"
             },
             "opera_android": {
               "version_added": "42"
+            },
+            "safari": {
+              "version_added": null
             },
             "webview_android": {
               "version_added": "58"
@@ -679,6 +697,9 @@
             "firefox_android": {
               "version_added": "14"
             },
+            "ie": {
+              "version_added": null
+            },
             "opera": {
               "version_added": true
             },
@@ -726,6 +747,12 @@
             },
             "ie": {
               "version_added": "9"
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "webview_android": {
               "version_added": "43"
@@ -934,6 +961,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/fastSeek",
           "support": {
+            "chrome": {
+              "version_added": null
+            },
             "edge": {
               "version_added": false
             },
@@ -945,6 +975,15 @@
             },
             "firefox_android": {
               "version_added": "31"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             }
           },
           "status": {
@@ -958,6 +997,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/initialTime",
           "support": {
+            "chrome": {
+              "version_added": null
+            },
             "edge": {
               "version_added": false
             },
@@ -971,6 +1013,15 @@
             "firefox_android": {
               "version_added": "9",
               "version_removed": "23"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             }
           },
           "status": {
@@ -1053,6 +1104,12 @@
             "ie": {
               "version_added": "9"
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1068,6 +1125,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mediaGroup",
           "support": {
+            "chrome": {
+              "version_added": null
+            },
             "edge": {
               "version_added": false
             },
@@ -1081,6 +1141,15 @@
             "firefox_android": {
               "version_added": false,
               "notes": "Firefox doesn't implement this yet. See <a href='https://bugzil.la/847377'>bug 847377</a>."
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             }
           },
           "status": {
@@ -1093,7 +1162,26 @@
       "mediaKeys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mediaKeys",
-          "support": {},
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            }
+          },
           "status": {
             "experimental": false,
             "standard_track": true,
@@ -1104,7 +1192,26 @@
       "mozAudioCaptured": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozAudioCaptured",
-          "support": {},
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            }
+          },
           "status": {
             "experimental": false,
             "standard_track": false,
@@ -1115,7 +1222,26 @@
       "mozCaptureStreamUntilEnded": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozCaptureStreamUntilEnded",
-          "support": {},
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            }
+          },
           "status": {
             "experimental": false,
             "standard_track": false,
@@ -1174,7 +1300,26 @@
       "mozFragmentEnd": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozFragmentEnd",
-          "support": {},
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            }
+          },
           "status": {
             "experimental": false,
             "standard_track": false,
@@ -1524,7 +1669,26 @@
       "onencrypted": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/onencrypted",
-          "support": {},
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            }
+          },
           "status": {
             "experimental": false,
             "standard_track": true,
@@ -1536,6 +1700,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/onmozinterruptbegin",
           "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": true,
               "version_removed": "55"
@@ -1543,6 +1713,15 @@
             "firefox_android": {
               "version_added": true,
               "version_removed": "55"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             }
           },
           "status": {
@@ -1556,6 +1735,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/onmozinterruptend",
           "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": true,
               "version_removed": "55"
@@ -1563,6 +1748,15 @@
             "firefox_android": {
               "version_added": true,
               "version_removed": "55"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             }
           },
           "status": {
@@ -1588,11 +1782,20 @@
             "edge_mobile": {
               "version_added": false
             },
+            "firefox": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
             "opera": {
               "version_added": "42"
             },
             "opera_android": {
               "version_added": "42"
+            },
+            "safari": {
+              "version_added": null
             },
             "webview_android": {
               "version_added": "55"
@@ -1774,6 +1977,12 @@
             "ie": {
               "version_added": "9"
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1810,6 +2019,12 @@
             "ie": {
               "version_added": "9"
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1845,6 +2060,12 @@
             },
             "ie": {
               "version_added": "9"
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "webview_android": {
               "version_added": true
@@ -1959,6 +2180,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/seekToNextFrame",
           "support": {
+            "chrome": {
+              "version_added": null
+            },
             "edge": {
               "version_added": false
             },
@@ -1984,6 +2208,15 @@
                   "value_to_set": "true"
                 }
               ]
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             }
           },
           "status": {
@@ -2017,6 +2250,12 @@
             },
             "ie": {
               "version_added": "9"
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "webview_android": {
               "version_added": true
@@ -2080,7 +2319,26 @@
       "setMediaKeys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/setMediaKeys",
-          "support": {},
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            }
+          },
           "status": {
             "experimental": false,
             "standard_track": true,
@@ -2165,6 +2423,18 @@
             },
             "edge_mobile": {
               "version_added": false
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "webview_android": {
               "version_added": "49"
@@ -2273,6 +2543,9 @@
                 "prefix": "moz"
               }
             ],
+            "ie": {
+              "version_added": null
+            },
             "opera": {
               "version_added": "39",
               "partial_implementation": true,
@@ -2282,6 +2555,9 @@
               "version_added": "39",
               "partial_implementation": true,
               "notes": "Currently only supports <code>MediaStream</code> objects."
+            },
+            "safari": {
+              "version_added": null
             },
             "webview_android": {
               "version_added": "52",
@@ -2300,11 +2576,26 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/textTracks",
           "support": {
+            "chrome": {
+              "version_added": null
+            },
             "edge": {
               "version_added": true
             },
             "edge_mobile": {
               "version_added": false
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             }
           },
           "status": {
@@ -2318,6 +2609,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/videoTracks",
           "support": {
+            "chrome": {
+              "version_added": null
+            },
             "edge": {
               "version_added": true
             },
@@ -2343,6 +2637,15 @@
                   "value_to_set": "true"
                 }
               ]
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             }
           },
           "status": {

--- a/api/HTMLMeterElement.json
+++ b/api/HTMLMeterElement.json
@@ -276,6 +276,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMeterElement/labels",
           "support": {
+            "chrome": {
+              "version_added": null
+            },
             "edge": {
               "version_added": false
             },
@@ -287,6 +290,15 @@
             },
             "firefox_android": {
               "version_added": "56"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             }
           },
           "status": {

--- a/api/HTMLOutputElement.json
+++ b/api/HTMLOutputElement.json
@@ -230,6 +230,15 @@
             "firefox_android": {
               "version_added": "56"
             },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "safari_ios": {
               "version_added": false
             },

--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -83,6 +83,15 @@
                 }
               ]
             },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "webview_android": {
               "version_added": true
             }
@@ -188,6 +197,15 @@
                 ]
               }
             ],
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "webview_android": {
               "version_added": true
             }
@@ -293,6 +311,15 @@
                 ]
               }
             ],
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "webview_android": {
               "version_added": true
             }

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -35,6 +35,12 @@
           "ie": {
             "version_added": false
           },
+          "opera": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
           "samsunginternet_android": {
             "version_added": "5.0"
           },
@@ -83,6 +89,12 @@
             ],
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -133,6 +145,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "5.0"
             },
@@ -182,6 +200,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "5.0"
             },
@@ -230,6 +254,12 @@
             ],
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -281,6 +311,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "5.0"
             },
@@ -329,6 +365,12 @@
             ],
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -380,6 +422,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "5.0"
             },
@@ -429,6 +477,12 @@
             ],
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -35,6 +35,12 @@
           "ie": {
             "version_added": false
           },
+          "opera": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
           "samsunginternet_android": {
             "version_added": "5.0"
           },
@@ -82,6 +88,12 @@
             ],
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -132,6 +144,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "5.0"
             },
@@ -180,6 +198,12 @@
             ],
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -230,6 +254,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "5.0"
             },
@@ -278,6 +308,12 @@
             ],
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -328,6 +364,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "5.0"
             },
@@ -376,6 +418,12 @@
             ],
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/LinearAccelerationSensor.json
+++ b/api/LinearAccelerationSensor.json
@@ -28,6 +28,9 @@
           "opera_android": {
             "version_added": "56"
           },
+          "safari": {
+            "version_added": null
+          },
           "samsunginternet_android": {
             "version_added": null
           },
@@ -69,6 +72,9 @@
             },
             "opera_android": {
               "version_added": "56"
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/Location.json
+++ b/api/Location.json
@@ -366,6 +366,9 @@
             "chrome_android": {
               "version_added": true
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": "26"
             },
@@ -772,6 +775,9 @@
             },
             "chrome_android": {
               "version_added": true
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": "26"

--- a/api/MediaError.json
+++ b/api/MediaError.json
@@ -31,6 +31,9 @@
           "opera_android": {
             "version_added": true
           },
+          "safari": {
+            "version_added": null
+          },
           "safari_ios": {
             "version_added": true
           },
@@ -78,6 +81,9 @@
             "opera_android": {
               "version_added": true
             },
+            "safari": {
+              "version_added": null
+            },
             "safari_ios": {
               "version_added": true
             },
@@ -105,17 +111,26 @@
             "chrome_android": {
               "version_added": "59"
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": "52"
             },
             "firefox_android": {
               "version_added": "52"
             },
+            "ie": {
+              "version_added": null
+            },
             "opera": {
               "version_added": "46"
             },
             "opera_android": {
               "version_added": "46"
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/PasswordCredential.json
+++ b/api/PasswordCredential.json
@@ -10,6 +10,9 @@
           "chrome_android": {
             "version_added": "51"
           },
+          "edge": {
+            "version_added": null
+          },
           "firefox": {
             "version_added": null
           },
@@ -50,6 +53,9 @@
             },
             "chrome_android": {
               "version_added": "51"
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": null
@@ -93,6 +99,9 @@
             "chrome_android": {
               "version_added": "51"
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": null
             },
@@ -134,6 +143,9 @@
             },
             "chrome_android": {
               "version_added": "52"
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": null
@@ -177,6 +189,9 @@
             "chrome_android": {
               "version_added": "51"
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": null
             },
@@ -218,6 +233,9 @@
             },
             "chrome_android": {
               "version_added": "52"
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": null
@@ -261,6 +279,9 @@
             "chrome_android": {
               "version_added": "60"
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": null
             },
@@ -302,6 +323,9 @@
             },
             "chrome_android": {
               "version_added": "51"
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": null

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -628,6 +628,9 @@
                 "prefix": "webkit"
               }
             ],
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": true
             },
@@ -745,6 +748,9 @@
             },
             "chrome_android": {
               "version_added": "62"
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": "59"

--- a/api/PerformanceFrameTiming.json
+++ b/api/PerformanceFrameTiming.json
@@ -12,6 +12,9 @@
             "version_added": false,
             "notes": "See <a href='https://code.google.com/p/chromium/issues/detail?id=120796'>Chrome bug 120796</a>"
           },
+          "edge": {
+            "version_added": null
+          },
           "firefox": {
             "version_added": false,
             "notes": "See <a href='https://bugzil.la/1158032'>bug 1158032</a>"

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -10,6 +10,9 @@
           "chrome_android": {
             "version_added": "52"
           },
+          "edge": {
+            "version_added": null
+          },
           "firefox": {
             "version_added": "57"
           },
@@ -50,6 +53,9 @@
             },
             "chrome_android": {
               "version_added": "62"
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": null
@@ -94,6 +100,9 @@
             "chrome_android": {
               "version_added": "52"
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": "57"
             },
@@ -135,6 +144,9 @@
             },
             "chrome_android": {
               "version_added": "52"
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": "57"
@@ -178,6 +190,9 @@
             "chrome_android": {
               "version_added": "52"
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": "57"
             },
@@ -219,6 +234,9 @@
             },
             "chrome_android": {
               "version_added": true
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": "60"

--- a/api/ReadableStreamBYOBRequest.json
+++ b/api/ReadableStreamBYOBRequest.json
@@ -10,6 +10,9 @@
           "chrome_android": {
             "version_added": false
           },
+          "edge": {
+            "version_added": null
+          },
           "firefox": {
             "version_added": false
           },
@@ -51,6 +54,9 @@
             },
             "chrome_android": {
               "version_added": false
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": false
@@ -94,6 +100,9 @@
             "chrome_android": {
               "version_added": false
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": false
             },
@@ -136,6 +145,9 @@
             "chrome_android": {
               "version_added": false
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": false
             },
@@ -177,6 +189,9 @@
             },
             "chrome_android": {
               "version_added": false
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": false

--- a/api/RelativeOrientationSensor.json
+++ b/api/RelativeOrientationSensor.json
@@ -28,6 +28,9 @@
           "opera_android": {
             "version_added": "56"
           },
+          "safari": {
+            "version_added": null
+          },
           "samsunginternet_android": {
             "version_added": null
           },
@@ -69,6 +72,9 @@
             },
             "opera_android": {
               "version_added": "56"
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -773,11 +773,26 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBuffer/trackDefaults",
           "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": false
             },
             "firefox_android": {
               "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "safari_ios": {
               "version_added": false
@@ -1235,8 +1250,14 @@
             "firefox_android": {
               "version_added": false
             },
+            "ie": {
+              "version_added": null
+            },
             "opera": {
               "version_added": false
+            },
+            "safari": {
+              "version_added": null
             },
             "safari_ios": {
               "version_added": false

--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -78,6 +78,9 @@
             "chrome_android": {
               "version_added": "45"
             },
+            "edge": {
+              "version_added": null
+            },
             "edge_mobile": {
               "version_added": true
             },

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -1074,11 +1074,23 @@
         "__compat": {
           "description": "Available in workers",
           "support": {
+            "chrome": {
+              "version_added": null
+            },
             "edge": {
               "version_added": false
             },
             "firefox": {
               "version_added": "48"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             }
           },
           "status": {

--- a/api/Text.json
+++ b/api/Text.json
@@ -52,6 +52,9 @@
             "chrome_android": {
               "version_added": "28"
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": "24"
             },
@@ -93,6 +96,9 @@
             },
             "chrome_android": {
               "version_added": false
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": true,
@@ -232,6 +238,9 @@
             "chrome_android": {
               "version_added": true,
               "version_removed": "45"
+            },
+            "edge": {
+              "version_added": null
             },
             "firefox": {
               "version_added": true,

--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -482,8 +482,17 @@
             "firefox_android": {
               "version_added": "31"
             },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
             "opera_android": {
               "version_added": false
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -43,6 +43,12 @@
           "ie": {
             "version_added": false
           },
+          "opera": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
           "samsunginternet_android": {
             "version_added": "6.0"
           },
@@ -98,6 +104,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -156,6 +168,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -212,6 +230,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -270,6 +294,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -326,6 +356,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -384,6 +420,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -440,6 +482,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -498,6 +546,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -554,6 +608,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -612,6 +672,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -657,6 +723,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": false
@@ -715,6 +787,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -750,6 +828,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": false
@@ -808,6 +892,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -864,6 +954,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -922,6 +1018,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -978,6 +1080,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1036,6 +1144,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -1093,6 +1207,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -1149,6 +1269,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -43,6 +43,12 @@
           "ie": {
             "version_added": false
           },
+          "opera": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
           "samsunginternet_android": {
             "version_added": "6.0"
           },
@@ -98,6 +104,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -156,6 +168,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -212,6 +230,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -270,6 +294,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -326,6 +356,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -43,6 +43,12 @@
           "ie": {
             "version_added": false
           },
+          "opera": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
           "samsunginternet_android": {
             "version_added": "6.0"
           },
@@ -99,6 +105,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -157,6 +169,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -213,6 +231,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -43,6 +43,12 @@
           "ie": {
             "version_added": false
           },
+          "opera": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
           "samsunginternet_android": {
             "version_added": "6.0"
           },
@@ -99,6 +105,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -145,6 +157,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": false
             },
@@ -190,6 +208,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": false
@@ -248,6 +272,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -283,6 +313,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": false
@@ -341,6 +377,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -376,6 +418,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": false
@@ -433,6 +481,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -43,6 +43,12 @@
           "ie": {
             "version_added": false
           },
+          "opera": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
           "samsunginternet_android": {
             "version_added": "6.0"
           },
@@ -78,6 +84,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": false
@@ -136,6 +148,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -192,6 +210,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -250,6 +274,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -306,6 +336,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -43,6 +43,12 @@
           "ie": {
             "version_added": false
           },
+          "opera": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
           "samsunginternet_android": {
             "version_added": "6.0"
           },
@@ -99,6 +105,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -157,6 +169,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -213,6 +231,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -271,6 +295,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -327,6 +357,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -385,6 +421,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -441,6 +483,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/VRLayerInit.json
+++ b/api/VRLayerInit.json
@@ -43,6 +43,12 @@
           "ie": {
             "version_added": false
           },
+          "opera": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
           "samsunginternet_android": {
             "version_added": "6.0"
           },
@@ -98,6 +104,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -156,6 +168,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -212,6 +230,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -43,6 +43,12 @@
           "ie": {
             "version_added": false
           },
+          "opera": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
           "samsunginternet_android": {
             "version_added": "6.0"
           },
@@ -98,6 +104,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -156,6 +168,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -192,6 +210,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": false
             },
@@ -227,6 +251,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": false
@@ -285,6 +315,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -341,6 +377,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -399,6 +441,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -456,6 +504,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -491,6 +545,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -43,6 +43,12 @@
           "ie": {
             "version_added": false
           },
+          "opera": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
           "samsunginternet_android": {
             "version_added": "6.0"
           },
@@ -98,6 +104,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -156,6 +168,12 @@
             "ie": {
               "version_added": false
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -212,6 +230,12 @@
             },
             "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/Window.json
+++ b/api/Window.json
@@ -489,6 +489,12 @@
             "ie": {
               "version_added": null
             },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": null
             },

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -642,6 +642,21 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport/viewport-fit",
             "description": "<code>viewport-fit</code> descriptor",
             "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
               "safari": {
                 "version_added": "11"
               },

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -387,6 +387,9 @@
               "firefox_android": {
                 "version_added": "52"
               },
+              "ie": {
+                "version_added": null
+              },
               "opera": {
                 "version_added": "44"
               },

--- a/css/properties/border-image-repeat.json
+++ b/css/properties/border-image-repeat.json
@@ -61,6 +61,9 @@
               "ie": {
                 "version_added": "11"
               },
+              "opera": {
+                "version_added": null
+              },
               "safari": {
                 "version_added": "9.1"
               }

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -141,11 +141,26 @@
           "__compat": {
             "description": "optional <code>&lt;border-image-slice&gt;</code>",
             "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
               "firefox": {
                 "version_added": "15"
               },
               "firefox_android": {
                 "version_added": "15"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
               }
             },
             "status": {
@@ -162,11 +177,20 @@
               "chrome": {
                 "version_added": true
               },
+              "edge": {
+                "version_added": null
+              },
               "firefox": {
                 "version_added": "15"
               },
               "firefox_android": {
                 "version_added": "15"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
               },
               "safari": {
                 "version_added": "6"
@@ -191,6 +215,9 @@
             "support": {
               "chrome": {
                 "version_added": true
+              },
+              "edge": {
+                "version_added": null
               },
               "firefox": {
                 "version_added": "29"

--- a/css/properties/border-inline-end.json
+++ b/css/properties/border-inline-end.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": false
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/border-inline-start.json
+++ b/css/properties/border-inline-start.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": false
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/column-fill.json
+++ b/css/properties/column-fill.json
@@ -35,6 +35,15 @@
                 "version_added": "14"
               }
             ],
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
             "samsunginternet_android": {
               "version_added": true
             },

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -101,6 +101,9 @@
               "chrome": {
                 "version_added": false
               },
+              "edge": {
+                "version_added": null
+              },
               "firefox": {
                 "version_added": false
               },

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -182,11 +182,20 @@
               "chrome_android": {
                 "version_added": "69"
               },
+              "edge": {
+                "version_added": null
+              },
               "firefox": {
                 "version_added": "65"
               },
               "firefox_android": {
                 "version_added": "65"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
               },
               "safari": [
                 {

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -132,6 +132,9 @@
               "chrome": {
                 "version_added": "49"
               },
+              "edge": {
+                "version_added": null
+              },
               "firefox": {
                 "version_added": "32",
                 "notes": "Before Firefox 32, Firefox wasn't able to animate values starting or stopping at <code>0</code>."
@@ -139,6 +142,9 @@
               "firefox_android": {
                 "version_added": "32",
                 "notes": "Before Firefox 32, Firefox wasn't able to animate values starting or stopping at <code>0</code>."
+              },
+              "ie": {
+                "version_added": null
               },
               "opera": {
                 "version_added": false

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1952,6 +1952,9 @@
             "chrome_android": {
               "version_added": "64"
             },
+            "edge": {
+              "version_added": null
+            },
             "firefox": {
               "version_added": "62"
             },
@@ -1966,6 +1969,9 @@
             },
             "opera_android": {
               "version_added": "51"
+            },
+            "safari": {
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": false

--- a/webextensions/match_patterns.json
+++ b/webextensions/match_patterns.json
@@ -51,6 +51,9 @@
               "chrome": {
                 "version_added": false
               },
+              "edge": {
+                "version_added": null
+              },
               "firefox": {
                 "version_added": "55"
               },
@@ -111,6 +114,9 @@
               "chrome": {
                 "version_added": false
               },
+              "edge": {
+                "version_added": null
+              },
               "firefox": {
                 "version_added": "55"
               },
@@ -128,6 +134,9 @@
             "support": {
               "chrome": {
                 "version_added": false
+              },
+              "edge": {
+                "version_added": null
               },
               "firefox": {
                 "version_added": "55"
@@ -211,6 +220,9 @@
             "support": {
               "chrome": {
                 "version_added": false
+              },
+              "edge": {
+                "version_added": null
               },
               "firefox": {
                 "version_added": "48",


### PR DESCRIPTION
Done using a modified test-browsers.js:
https://gist.github.com/foolip/fb7cd495510bf7f1a7083c64dd94df08

Fixes https://github.com/mdn/browser-compat-data/issues/3410.