### PR TITLE
Mark <datalist> support for Safari 12.1

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -103,8 +103,12 @@
         },
         "12": {
           "release_date": "2018-09-24",
-          "release_notes": "https://developer.apple.com/safari/whats-new/",
+          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_release_notes",
           "status": "current"
+        },
+        "12.1": {
+          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes",
+          "status": "beta"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -86,8 +86,12 @@
         },
         "12": {
           "release_date": "2018-09-17",
-          "release_notes": "https://developer.apple.com/safari/whats-new/",
+          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_release_notes",
           "status": "current"
+        },
+        "12.2": {
+          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes",
+          "status": "beta"
         }
       }
     }

--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -33,10 +33,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
Apple added support for `<datalist>` in Safari TP 69, and it's set to be released in Safari 12.1.
This PR marks corresponding changes, though the actual release date of Safari 12.1 is yet unknown.

Ref: https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes#3130314