### PR TITLE
Clarify IE support for input's files property

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -210,7 +210,9 @@
               "version_added": null
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "10",
+              "partial_implementation": true,
+              "notes": "This property is read-only."
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
As far as I can tell, assigning to `fileInputField.files` is unsupported in Internet Explorer: This operation [throws an exception in strict mode](https://github.com/react-bootstrap/dom-helpers/issues/40), in non-strict mode the assignment is silently ignored.

(I was attempting to assign a `FileList` received via a drag'n'drop operation: `fileInputField.files = ev.dataTransfer.files` - I could create a reduced test case if necessary.)

Tested on Windows 8.1 with Internet Explorer 11 (version 11.0.9600.19236), using a [virtual machine provided by Microsoft](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/).
