### PR TITLE
Add WebSpeech events

### DIFF
--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -158,6 +158,104 @@
           }
         }
       },
+      "audioend_event": {
+        "__compat": {
+          "description": "<code>audioend/code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/audioend_event",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "audiostart_event": {
+        "__compat": {
+          "description": "<code>audiostart/code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/audiostart_event",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "continuous": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/continuous",
@@ -203,6 +301,104 @@
               "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "end_event": {
+        "__compat": {
+          "description": "<code>end/code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/end_event",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error_event": {
+        "__compat": {
+          "description": "<code>error/code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/error_event",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -419,6 +615,55 @@
               "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "nomatch_event": {
+        "__compat": {
+          "description": "<code>nomatch/code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/nomatch_event",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -1022,6 +1267,55 @@
           }
         }
       },
+      "result_event": {
+        "__compat": {
+          "description": "<code>result/code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/result_event",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "serviceURI": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/serviceURI",
@@ -1067,6 +1361,202 @@
               "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "soundend_event": {
+        "__compat": {
+          "description": "<code>soundend/code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/soundend_event",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "soundstart_event": {
+        "__compat": {
+          "description": "<code>soundstart/code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/soundstart_event",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "speechend_event": {
+        "__compat": {
+          "description": "<code>speechend/code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/speechend_event",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "speechstart_event": {
+        "__compat": {
+          "description": "<code>speechstart/code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/speechstart_event",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -1130,6 +1620,55 @@
           }
         }
       },
+      "start_event": {
+        "__compat": {
+          "description": "<code>start/code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/start_event",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "stop": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/stop",
@@ -1181,536 +1720,6 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }
-        }
-      },
-      "events": {
-        "audioend": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/audioend_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "audiostart": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/audiostart_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "end": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/end_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "error": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/error_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "nomatch": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/nomatch_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "result": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/result_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "soundend": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/soundend_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "soundstart": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/soundstart_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "speechend": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/speechend_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "speechstart": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/speechstart_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "start": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/start_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       }

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -1183,6 +1183,536 @@
             "deprecated": false
           }
         }
+      },
+      "events": {
+        "audioend": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/audioend_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "audiostart": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/audiostart_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "end": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/end_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "error": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/error_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "nomatch": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/nomatch_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "result": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/result_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "soundend": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/soundend_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "soundstart": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/soundstart_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "speechend": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/speechend_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "speechstart": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/speechstart_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "start": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/start_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
       }
     }
   }

--- a/api/SpeechSynthesis.json
+++ b/api/SpeechSynthesis.json
@@ -608,6 +608,69 @@
             "deprecated": false
           }
         }
+      },
+      "events": {
+        "voiceschanged": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesis/voiceschanged_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": "33"
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webspeech.synth.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "21"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
+              },
+              "webview_android": {
+                "version_added": "4.4.3"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
       }
     }
   }

--- a/api/SpeechSynthesis.json
+++ b/api/SpeechSynthesis.json
@@ -609,66 +609,65 @@
           }
         }
       },
-      "events": {
-        "voiceschanged": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesis/voiceschanged_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": "33"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "49"
-              },
-              "firefox_android": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webspeech.synth.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "21"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "7"
-              },
-              "safari_ios": {
-                "version_added": "7.1"
-              },
-              "webview_android": {
-                "version_added": "4.4.3"
-              }
+      "voiceschanged_event": {
+        "__compat": {
+          "description": "<code>voiceschanged</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesis/voiceschanged_event",
+          "support": {
+            "chrome": {
+              "version_added": "33"
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "chrome_android": {
+              "version_added": "33"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "version_removed": "62",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.webspeech.synth.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "21"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "7.1"
+            },
+            "webview_android": {
+              "version_added": "4.4.3"
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/SpeechSynthesisUtterance.json
+++ b/api/SpeechSynthesisUtterance.json
@@ -914,6 +914,435 @@
             "deprecated": false
           }
         }
+      },
+      "events": {
+        "boundary": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/boundary_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": "33"
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webspeech.synth.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "21"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "end": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/end_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": "33"
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webspeech.synth.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "21"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "error": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/error_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": "33"
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webspeech.synth.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "21"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "mark": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/mark_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": "33"
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webspeech.synth.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "21"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "pause": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/pause_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": "33"
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webspeech.synth.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "21"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "resume": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/resume_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": "33"
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webspeech.synth.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "21"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "start": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/start_event",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": "33"
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.webspeech.synth.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "21"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7.1"
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
       }
     }
   }

--- a/api/SpeechSynthesisUtterance.json
+++ b/api/SpeechSynthesisUtterance.json
@@ -122,9 +122,257 @@
           }
         }
       },
+      "boundary_event": {
+        "__compat": {
+          "description": "<code>boundary</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/boundary_event",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": "33"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "version_removed": "62",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.webspeech.synth.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "21"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "7.1"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "end_event": {
+        "__compat": {
+          "description": "<code>end</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/end_event",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": "33"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "version_removed": "62",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.webspeech.synth.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "21"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "7.1"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error_event": {
+        "__compat": {
+          "description": "<code>error</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/error_event",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": "33"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "version_removed": "62",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.webspeech.synth.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "21"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "7.1"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "lang": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/lang",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": "33"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "version_removed": "62",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.webspeech.synth.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "21"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "7.1"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mark_event": {
+        "__compat": {
+          "description": "<code>mark</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/mark_event",
           "support": {
             "chrome": {
               "version_added": "33"
@@ -610,6 +858,68 @@
           }
         }
       },
+      "pause_event": {
+        "__compat": {
+          "description": "<code>pause</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/pause_event",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": "33"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "version_removed": "62",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.webspeech.synth.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "21"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "7.1"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "pitch": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/pitch",
@@ -674,6 +984,130 @@
       "rate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/rate",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": "33"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "version_removed": "62",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.webspeech.synth.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "21"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "7.1"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "resume_event": {
+        "__compat": {
+          "description": "<code>resume</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/resume_event",
+          "support": {
+            "chrome": {
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "version_added": "33"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "version_removed": "62",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.webspeech.synth.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "21"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "7.1"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "start_event": {
+        "__compat": {
+          "description": "<code>start</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/start_event",
           "support": {
             "chrome": {
               "version_added": "33"
@@ -912,435 +1346,6 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }
-        }
-      },
-      "events": {
-        "boundary": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/boundary_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": "33"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "49"
-              },
-              "firefox_android": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webspeech.synth.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "21"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "7"
-              },
-              "safari_ios": {
-                "version_added": "7.1"
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "end": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/end_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": "33"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "49"
-              },
-              "firefox_android": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webspeech.synth.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "21"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "7"
-              },
-              "safari_ios": {
-                "version_added": "7.1"
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "error": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/error_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": "33"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "49"
-              },
-              "firefox_android": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webspeech.synth.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "21"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "7"
-              },
-              "safari_ios": {
-                "version_added": "7.1"
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "mark": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/mark_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": "33"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "49"
-              },
-              "firefox_android": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webspeech.synth.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "21"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "7"
-              },
-              "safari_ios": {
-                "version_added": "7.1"
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "pause": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/pause_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": "33"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "49"
-              },
-              "firefox_android": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webspeech.synth.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "21"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "7"
-              },
-              "safari_ios": {
-                "version_added": "7.1"
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "resume": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/resume_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": "33"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "49"
-              },
-              "firefox_android": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webspeech.synth.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "21"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "7"
-              },
-              "safari_ios": {
-                "version_added": "7.1"
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "start": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisUtterance/start_event",
-            "support": {
-              "chrome": {
-                "version_added": "33"
-              },
-              "chrome_android": {
-                "version_added": "33"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "49"
-              },
-              "firefox_android": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webspeech.synth.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "21"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "7"
-              },
-              "safari_ios": {
-                "version_added": "7.1"
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       }


### PR DESCRIPTION
This is a proposal to add the events compat data for the Web Speech API. The docs have been moved and refactored, now we also need to see where we want to install the compat data.
See https://github.com/mdn/sprints/issues/915#issuecomment-460693457 for the discussion.

~In here I'm proposing install events at "targetInterface.events.eventname".~

Much like the new MDN page slugs, the events are installed under "_targetInterface_._eventname_\_event"

The compat data itself is assumed to be the same as the already existing data for Web Speech.