### PR TITLE
Migrate data about AudioContext out of BaseAudioContext

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -408,13 +408,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createConstantSource",
           "support": {
             "chrome": {
-              "version_added": "10",
+              "version_added": "14",
               "version_removed": "56",
               "prefix": "webkit",
               "notes": "Available as a part of <code>BaseAudioContext</code>."
             },
             "chrome_android": {
-              "version_added": "33",
+              "version_added": "18",
               "version_removed": "56",
               "notes": "Available as a part of <code>BaseAudioContext</code>."
             },

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -403,6 +403,82 @@
           }
         }
       },
+      "createConstantSource": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createConstantSource",
+          "support": {
+            "chrome": {
+              "version_added": "10",
+              "version_removed": "56",
+              "prefix": "webkit",
+              "notes": "Available as a part of <code>BaseAudioContext</code>."
+            },
+            "chrome_android": {
+              "version_added": "33",
+              "version_removed": "56",
+              "notes": "Available as a part of <code>BaseAudioContext</code>."
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "25",
+              "version_removed": true,
+              "notes": "Available as a part of <code>BaseAudioContext</code>."
+            },
+            "firefox_android": {
+              "version_added": "26",
+              "version_removed": true,
+              "notes": "Available as a part of <code>BaseAudioContext</code>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22",
+                "version_removed": "43",
+                "notes": "Available as a part of <code>BaseAudioContext</code>."
+              },
+              {
+                "version_added": "15",
+                "version_removed": "22",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": {
+              "version_added": true,
+              "version_removed": "43",
+              "notes": "Available as a part of <code>BaseAudioContext</code>."
+            },
+            "safari": {
+              "version_added": "6",
+              "version_removed": true,
+              "prefix": "webkit",
+              "notes": "Available as a part of <code>BaseAudioContext</code>."
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true,
+              "version_removed": "56",
+              "notes": "Available as a part of <code>BaseAudioContext</code>."
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "createMediaElementSource": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioContext/createMediaElementSource",

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -494,7 +494,7 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -510,65 +510,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "implemented_on_audio_context": {
-          "__compat": {
-            "description": "Implemented on <code>AudioContext</code>",
-            "support": {
-              "chrome": {
-                "version_added": "10",
-                "prefix": "webkit"
-              },
-              "chrome_android": {
-                "version_added": "33"
-              },
-              "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "25"
-              },
-              "firefox_android": {
-                "version_added": "26"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": [
-                {
-                  "version_added": "22"
-                },
-                {
-                  "version_added": "15",
-                  "prefix": "webkit"
-                }
-              ],
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "6",
-                "prefix": "webkit"
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -80,7 +80,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -92,7 +92,7 @@
               "version_added": null
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -772,7 +772,7 @@
               "version_added": "50"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -784,7 +784,7 @@
               "version_added": null
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1040,7 +1040,7 @@
                 "version_added": null
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": null
@@ -1548,7 +1548,7 @@
               "version_added": null
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1658,7 +1658,7 @@
               "version_added": null
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null


### PR DESCRIPTION
Since the `implemented_on_audio_context` subfeature violates the upcoming [version+support lint check](#3368), I thought that this would be the best way to fix the issue.  Since it was data in `BaseAudioContext` that really should be in `AudioContext` anyways, I migrated it over, and included a `version_removed` with a note mentioning that it's now available in `BaseAudioContext`.  This is a sub-PR of #3368 for the fixes of the files themselves.