### PR TITLE
Add status_url property to browsers

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -2,6 +2,7 @@
   "browsers": {
     "chrome": {
       "name": "Chrome",
+      "status_url": "https://www.chromestatus.com",
       "releases": {
         "1": {
           "release_date": "2008-12-11",

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -2,6 +2,7 @@
   "browsers": {
     "chrome_android": {
       "name": "Chrome Android",
+      "status_url": "https://www.chromestatus.com",
       "releases": {
         "18": {
           "release_date": "2012-06-27",

--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -2,6 +2,7 @@
   "browsers": {
     "edge": {
       "name": "Edge",
+      "status_url": "https://developer.microsoft.com/en-us/microsoft-edge/platform/status/",
       "releases": {
         "12": {
           "release_date": "2015-07-28",

--- a/browsers/edge_mobile.json
+++ b/browsers/edge_mobile.json
@@ -2,6 +2,7 @@
   "browsers": {
     "edge_mobile": {
       "name": "Edge Mobile",
+      "status_url": "https://developer.microsoft.com/en-us/microsoft-edge/platform/status/",
       "releases": {
         "12": {
           "release_date": "2015-07-15",

--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -2,6 +2,7 @@
   "browsers": {
     "firefox": {
       "name": "Firefox",
+      "status_url": "https://platform-status.mozilla.org/",
       "releases": {
         "1": {
           "release_date": "2004-11-09",

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -2,6 +2,7 @@
   "browsers": {
     "firefox_android": {
       "name": "Firefox Android",
+      "status_url": "https://platform-status.mozilla.org/",
       "releases": {
         "4": {
           "release_date": "2011-03-29",

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -2,6 +2,7 @@
   "browsers": {
     "opera": {
       "name": "Opera",
+      "status_url": "https://www.chromestatus.com",
       "releases": {
         "2": {
           "release_date": "1996-07-14",

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -2,6 +2,7 @@
   "browsers": {
     "safari": {
       "name": "Safari",
+      "status_url": "https://webkit.org/status/",
       "releases": {
         "1": {
           "release_date": "2003-06-23",

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -2,6 +2,7 @@
   "browsers": {
     "safari_ios": {
       "name": "iOS Safari",
+      "status_url": "https://webkit.org/status/",
       "releases": {
         "1": {
           "status": "retired"

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -2,6 +2,7 @@
   "browsers": {
     "webview_android": {
       "name": "WebView Android",
+      "status_url": "https://www.chromestatus.com",
       "releases": {
         "1": {
           "release_date": "2008-09-23",

--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -17,6 +17,7 @@ The file `firefox.json` is structured like this:
   "browsers": {
     "firefox": {
       "name": "Firefox",
+      "status_url": "https://platform-status.mozilla.org",
       "releases": {
         "1.5": {
           "release_date": "2005-11-29",
@@ -35,7 +36,11 @@ Underneath, there is a `releases` object which will hold the various releases of
 
 ### `name`
 
-The `name` string is an optional property which should use the browser brand name and avoid English words if possible, for example `"Firefox"`, `"Firefox Android"`, `"Safari"`, `"iOS Safari"`, etc.
+The `name` string is a required property which should use the browser brand name and avoid English words if possible, for example `"Firefox"`, `"Firefox Android"`, `"Safari"`, `"iOS Safari"`, etc.
+
+### `status_url`
+
+The `status_url` string is an optional property that links to the browser's official feature tracking page, for example `https://platform-status.mozilla.org` for Firefox.
 
 ### Release objects
 The release objects consist of the following properties:

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -34,6 +34,11 @@
           "type": "string",
           "description": "Browser name, avoid using unnecessary English (e.g. prefer 'Chrome Android' over 'Chrome for Android')."
         },
+        "status_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Official browser feature support tracking webpage."
+        },
         "releases": {
           "type": "object",
           "additionalProperties": { "$ref": "#/definitions/release_statement" }


### PR DESCRIPTION
This adds the URLs for browsers' feature support websites to the browsers, and updates the documentation accordingly.  Closes #1995.