### PR TITLE
Edge doesn't support HTMLDialogElement

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -11,7 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": true
+            "version_added": false
           },
           "edge_mobile": {
             "version_added": null
@@ -77,7 +77,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -144,7 +144,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -211,7 +211,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -278,7 +278,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -345,7 +345,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null


### PR DESCRIPTION
Marking `HTMLDialogElement` as not supported in any version of Edge.

Via Edge Platform Status, [`<dialog>` support is "Under Consideration"](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/dialogelementformodals/), and [`HTMLDialogElement`  has zero support](https://developer.microsoft.com/en-us/microsoft-edge/platform/catalog/?q=HTMLDialogElement&page=1).

The [UserVoice entry for "Dialog element"](https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6508895-dialog-element) has status "ON THE BACKLOG".

I ran [wpt's `<dialog>` element tests](https://github.com/web-platform-tests/wpt/tree/master/html/semantics/interactive-elements/the-dialog-element) in my local Edge (Microsoft EdgeHTML 18.17763), and every test failed completely.