### PR TITLE
Add PerformanceServerTiming to window.

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4501,6 +4501,57 @@
           }
         }
       },
+      "PerformanceServerTiming": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/PerformanceServerTiming",
+          "support": {
+            "chrome": {
+              "version_added": "65"
+            },
+            "chrome_android": {
+              "version_added": "65"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "65"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "personalbar": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/personalbar",


### PR DESCRIPTION
It should have been part of this: https://github.com/mdn/browser-compat-data/commit/a40807f94f34f4ec990d6a9ff021a0809cf70cc8#diff-76c0f87dce49d0d0b82de78dc224106b