### PR TITLE
Separate api.TextMetrics.advanced_text_metrics

### DIFF
--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -101,7 +101,587 @@
           }
         }
       },
-      "advanced_text_metrics": {
+      "actualBoundingBoxLeft": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "actualBoundingBoxRight": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "fontBoundingBoxAscent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "fontBoundingBoxDescent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "actualBoundingBoxAscent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "actualBoundingBoxDescent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "emHeightAscent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "emHeightDescent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hangingBaseline": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "alphabeticBaseline": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ideographicBaseline": {
         "__compat": {
           "description": "Advanced text metrics properties",
           "support": {

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -58,7 +58,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "edge": {
               "version_added": "12"
@@ -114,7 +114,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "edge": {
               "version_added": false
@@ -149,7 +155,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -172,7 +178,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "edge": {
               "version_added": false
@@ -207,7 +219,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -230,7 +242,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "edge": {
               "version_added": false
@@ -265,7 +283,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -288,7 +306,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "edge": {
               "version_added": false
@@ -323,7 +347,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -346,7 +370,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "edge": {
               "version_added": false
@@ -381,7 +411,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -404,7 +434,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "edge": {
               "version_added": false
@@ -439,7 +475,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -462,7 +498,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "edge": {
               "version_added": false
@@ -497,7 +539,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -520,7 +562,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "edge": {
               "version_added": false
@@ -555,7 +603,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -578,7 +626,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "edge": {
               "version_added": false
@@ -613,7 +667,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -636,7 +690,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "edge": {
               "version_added": false
@@ -671,7 +731,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -694,7 +754,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "edge": {
               "version_added": false
@@ -729,7 +795,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -683,7 +683,6 @@
       },
       "ideographicBaseline": {
         "__compat": {
-          "description": "Advanced text metrics properties",
           "support": {
             "chrome": {
               "version_added": true,

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -58,7 +58,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "4"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -91,7 +91,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "2"
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
Fixes #2345 by separating `advanced_text_metrics` into its individual properties.