### PR TITLE
Setting Node.baseURI to true for Firefox & Safari

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -122,7 +122,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -137,7 +137,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null

--- a/api/Node.json
+++ b/api/Node.json
@@ -122,10 +122,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
Unable to pinpoint the exact version in which this was introduced
because I'm unable to find the specific issue page for it.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version

Verified by comparing the return value of `document.baseURI` in each browsers console with the actual URI.

- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
