### PR TITLE
test: Add support for Node < 6

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -3,9 +3,9 @@ const fs = require('fs');
 const path = require('path');
 const ora = require('ora');
 const yargs = require('yargs');
-const {testStyle} = require('./test-style');
-const {testSchema} = require('./test-schema');
-const {testVersions} = require('./test-versions');
+const testStyle = require('./test-style');
+const testSchema = require('./test-schema');
+const testVersions = require('./test-versions');
 const testBrowsers = require('./test-browsers');
 /** @type {Map<string, string>} */
 const filesWithErrors = new Map();

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -23,4 +23,4 @@ function testSchema(dataFilename, schemaFilename = './../schemas/compat-data.sch
   }
 }
 
-module.exports.testSchema = testSchema;
+module.exports = testSchema;

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -166,4 +166,4 @@ function testStyle(filename) {
   return hasErrors;
 }
 
-module.exports.testStyle = testStyle;
+module.exports = testStyle;

--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -1,6 +1,6 @@
 'use strict';
 const path = require('path');
-const {browsers} = require('..');
+const browsers = require('..').browsers;
 const compareVersions = require('compare-versions');
 
 const validBrowserVersions = {};
@@ -80,4 +80,4 @@ function testVersions(dataFilename) {
   }
 }
 
-module.exports.testVersions = testVersions;
+module.exports = testVersions;


### PR DESCRIPTION
Node&nbsp;<&nbsp;6 doesn’t support destructuring.

This updates the tests (and other code) to not use it, thus removing the&nbsp;reason why&nbsp;https://github.com/mdn/browser-compat-data/pull/3428 was set&nbsp;to&nbsp;<code>&gt;=&nbsp;6.0.0</code>