### PR TITLE
Add media formats to the audio element

### DIFF
--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -53,6 +53,3660 @@
             "deprecated": false
           }
         },
+        "__containers": {
+          "3gp": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "adts": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            },
+            "aac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "amr": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "flac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "mp3": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "opus": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "pcm": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "vorbis": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "flac": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            },
+            "aac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "amr": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "flac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "mp3": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "opus": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "pcm": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "vorbis": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "mkv": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            },
+            "aac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "amr": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "flac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "mp3": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "opus": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "pcm": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "vorbis": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "mp4": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            },
+            "aac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "amr": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "flac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "mp3": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "opus": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "pcm": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "vorbis": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "mpeg": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            },
+            "aac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "amr": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "flac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "mp3": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "opus": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "pcm": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "vorbis": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "ogg": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            },
+            "aac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "amr": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "flac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "mp3": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "opus": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "pcm": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "vorbis": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "mov": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "notes": "QuickTime is supported only if available on the host device, such as on macOS.",
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "notes": "QuickTime is supported only if available on the host device, such as on macOS.",
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            },
+            "aac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "amr": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "flac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "mp3": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "opus": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": null
+                  },
+                  "firefox_android": {
+                    "version_added": null
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "pcm": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "vorbis": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "wav": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            },
+            "aac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "amr": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "flac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "mp3": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "opus": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "pcm": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "vorbis": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "webm": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            },
+            "aac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "amr": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "flac": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "mp3": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "opus": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "pcm": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "vorbis": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": null
+                  },
+                  "chrome_android": {
+                    "version_added": null
+                  },
+                  "edge": {
+                    "version_added": null
+                  },
+                  "edge_mobile": {
+                    "version_added": null
+                  },
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "ie": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": null
+                  },
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": null
+                  },
+                  "webview_android": {
+                    "version_added": null
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          }
+        },
         "autoplay": {
           "__compat": {
             "support": {


### PR DESCRIPTION
This adds the media format support structure to the
`<audio>` element, with the `__containers` object
listing each media container that supports audio.
Within each of those is a list of the audio codecs.
Currently compatibility is "unknown" for everything
but Firefox, which should be correct in strictly binary
terms (no version information is provided yet, just
yes/no compatibility).

My aim is to get feedback and reviews based on this,
then get the binary information for Firefox pushed. Once
that's done, we can work on future PRs to get the data
for the other browsers in place, as well as potentially
more detailed information for Firefox.

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
