### PR TITLE
Fix DOMImplementation IE versions

### DIFF
--- a/api/DOMImplementation.json
+++ b/api/DOMImplementation.json
@@ -70,7 +70,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -118,7 +118,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -166,7 +166,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "6",
+              "version_added": "9",
               "notes": "The <code>title</code> parameter is required, but can be empty string."
             },
             "opera": {


### PR DESCRIPTION
We just ran into an issue because the current version of IE for some of these methods are incorrect: https://github.com/twbs/bootstrap/commit/0d11551607e20dba91b039247edba1446406abe4#r32301832

According Microsoft's website, [`implementation.hasFeature`](https://technet.microsoft.com/en-us/sysinternals/ms536446(v=vs.110)) was the only thing introduced in IE6.

It wasn't until IE9 that it added:

[`implementation.createDocument`](https://technet.microsoft.com/en-us/sysinternals/ff975455(v=vs.110))
[`implementation.createDocumentType`](https://technet.microsoft.com/en-us/sysinternals/ff975456(v=vs.110))
[`implementation.createHTMLDocument`](https://technet.microsoft.com/en-us/sysinternals/ff975457(v=vs.110))
