### PR TITLE
fix(css): `font-weight: <number>` is supported in latest Edge

### DIFF
--- a/css/properties/font-weight.json
+++ b/css/properties/font-weight.json
@@ -15,7 +15,7 @@
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -62,7 +62,7 @@
                 "version_added": "62"
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
                 "version_added": null


### PR DESCRIPTION
I’ve tested this in **Microsoft Edge 17**.