### PR TITLE
Logical shorthands and mappings

### DIFF
--- a/css/properties/border-block-color.json
+++ b/css/properties/border-block-color.json
@@ -6,7 +6,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-color",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": false
@@ -18,10 +25,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/border-block-color.json
+++ b/css/properties/border-block-color.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-color",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "69",
               "flags": [
                 {
                   "type": "preference",
@@ -16,7 +16,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false

--- a/css/properties/border-block-style.json
+++ b/css/properties/border-block-style.json
@@ -6,7 +6,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-style",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": false
@@ -18,10 +25,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/border-block-style.json
+++ b/css/properties/border-block-style.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-style",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "69",
               "flags": [
                 {
                   "type": "preference",
@@ -16,7 +16,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false

--- a/css/properties/border-block-width.json
+++ b/css/properties/border-block-width.json
@@ -6,7 +6,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-width",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": false
@@ -18,10 +25,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/border-block-width.json
+++ b/css/properties/border-block-width.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-width",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "69",
               "flags": [
                 {
                   "type": "preference",
@@ -16,7 +16,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false

--- a/css/properties/border-block.json
+++ b/css/properties/border-block.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "69",
               "flags": [
                 {
                   "type": "preference",
@@ -16,7 +16,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false

--- a/css/properties/border-block.json
+++ b/css/properties/border-block.json
@@ -6,7 +6,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": false
@@ -18,10 +25,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/border-end-end-radius.json
+++ b/css/properties/border-end-end-radius.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/border-end-start-radius.json
+++ b/css/properties/border-end-start-radius.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/border-inline-color.json
+++ b/css/properties/border-inline-color.json
@@ -6,7 +6,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-color",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": false
@@ -18,10 +25,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/border-inline-color.json
+++ b/css/properties/border-inline-color.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-color",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "69",
               "flags": [
                 {
                   "type": "preference",
@@ -16,7 +16,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false

--- a/css/properties/border-inline-style.json
+++ b/css/properties/border-inline-style.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-style",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "69",
               "flags": [
                 {
                   "type": "preference",
@@ -16,7 +16,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false

--- a/css/properties/border-inline-style.json
+++ b/css/properties/border-inline-style.json
@@ -6,7 +6,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-style",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": false
@@ -18,10 +25,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/border-inline-width.json
+++ b/css/properties/border-inline-width.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-width",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "69",
               "flags": [
                 {
                   "type": "preference",
@@ -16,7 +16,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false

--- a/css/properties/border-inline-width.json
+++ b/css/properties/border-inline-width.json
@@ -6,7 +6,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-width",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": false
@@ -18,10 +25,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/border-inline.json
+++ b/css/properties/border-inline.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "69",
               "flags": [
                 {
                   "type": "preference",
@@ -16,7 +16,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false

--- a/css/properties/border-inline.json
+++ b/css/properties/border-inline.json
@@ -6,7 +6,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": false
@@ -18,10 +25,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/border-start-end-radius.json
+++ b/css/properties/border-start-end-radius.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/border-start-start-radius.json
+++ b/css/properties/border-start-start-radius.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/margin-block.json
+++ b/css/properties/margin-block.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "69",
               "flags": [
                 {
                   "type": "preference",
@@ -16,7 +16,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false

--- a/css/properties/margin-block.json
+++ b/css/properties/margin-block.json
@@ -6,7 +6,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": false
@@ -18,10 +25,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/margin-inline.json
+++ b/css/properties/margin-inline.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-inline",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "69",
               "flags": [
                 {
                   "type": "preference",
@@ -16,7 +16,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false

--- a/css/properties/margin-inline.json
+++ b/css/properties/margin-inline.json
@@ -6,7 +6,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-inline",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": false
@@ -18,10 +25,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/padding-block.json
+++ b/css/properties/padding-block.json
@@ -6,7 +6,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-block",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": false
@@ -18,10 +25,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/padding-block.json
+++ b/css/properties/padding-block.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-block",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "69",
               "flags": [
                 {
                   "type": "preference",
@@ -16,7 +16,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false

--- a/css/properties/padding-inline.json
+++ b/css/properties/padding-inline.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-inline",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "69",
               "flags": [
                 {
                   "type": "preference",
@@ -16,7 +16,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false

--- a/css/properties/padding-inline.json
+++ b/css/properties/padding-inline.json
@@ -6,7 +6,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-inline",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": false
@@ -18,10 +25,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Updating the compat data due to browser implementation of these features.

Firefox 66 has implemented the two value shorthands for margins, borders and padding. Chrome has these behind a flag.

Firefox 66 has also implemented the border-radius longhand mappings. Chrome has not got these yet.

Intent to ship for FF: 
- https://groups.google.com/forum/#!topic/mozilla.dev.platform/Pjf2a6t-sFA
- https://groups.google.com/forum/#!topic/mozilla.dev.platform/gpubhXTxI6o

Several related FF bugs: https://trello.com/c/1CtY17he/51-css-logical-properties-level-1-fx-66

Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=850004

CodePen for the shorthands: https://codepen.io/rachelandrew/pen/LqBOyx
CodePen for the radius properties: https://codepen.io/rachelandrew/pen/rPrJOK
