### PR TITLE
Add NumberFormat data for Android webview.

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -975,7 +975,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": "37"
+                "version_added": true
               }
             },
             "status": {
@@ -1029,7 +1029,7 @@
                   "version_added": true
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": true
                 }
               },
               "status": {
@@ -1084,7 +1084,7 @@
                   "version_added": true
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": true
                 }
               },
               "status": {
@@ -1194,7 +1194,7 @@
                   "version_added": true
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": true
                 }
               },
               "status": {
@@ -1249,7 +1249,7 @@
                   "version_added": true
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": true
                 }
               },
               "status": {


### PR DESCRIPTION
Addresses #3432 

Feature in webview because it's not listed in https://cs.chromium.org/chromium/src/android_webview/tools/system_webview_shell/test/data/webexposed/not-webview-exposed.txt