### PR TITLE
Updating intrinsic sizing keywords data

### DIFF
--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -72,7 +72,165 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "max-content": {
+        "__compat": {
+          "description": "<code>max-content</code>",
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "66"
+            },
+            "firefox_android": {
+              "version_added": "66"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "prefix": "-webkit-",
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
+            "webview_android": {
+              "version_added": "46"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "min-content": {
+        "__compat": {
+          "description": "<code>min-content</code>",
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "66"
+            },
+            "firefox_android": {
+              "version_added": "66"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "prefix": "-webkit-",
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
+            "webview_android": {
+              "version_added": "46"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "fit-content": {
+        "__compat": {
+          "description": "<code>fit-content</code>",
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "prefix": "-moz-",
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "prefix": "-webkit-",
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "alternative_name": "-webkit-fill-available",
+              "version_added": "5.0"
+            },
+            "webview_android": {
+              "version_added": "46"
+            }
+          },
+          "status": {
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -76,160 +76,160 @@
             "standard_track": true,
             "deprecated": false
           }
-        }
-      },
-      "max-content": {
-        "__compat": {
-          "description": "<code>max-content</code>",
-          "support": {
-            "chrome": {
-              "version_added": "57"
+        },
+        "max-content": {
+          "__compat": {
+            "description": "<code>max-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "44"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "57"
+              }
             },
-            "chrome_android": {
-              "version_added": "57"
-            },
-            "edge": {
-              "version_added": false
-            },
-            "edge_mobile": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "66"
-            },
-            "firefox_android": {
-              "version_added": "66"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "44"
-            },
-            "opera_android": {
-              "version_added": "44"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": "57"
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
           }
-        }
-      },
-      "min-content": {
-        "__compat": {
-          "description": "<code>min-content</code>",
-          "support": {
-            "chrome": {
-              "version_added": "57"
+        },
+        "min-content": {
+          "__compat": {
+            "description": "<code>min-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "44"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "57"
+              }
             },
-            "chrome_android": {
-              "version_added": "57"
-            },
-            "edge": {
-              "version_added": false
-            },
-            "edge_mobile": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "66"
-            },
-            "firefox_android": {
-              "version_added": "66"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "44"
-            },
-            "opera_android": {
-              "version_added": "44"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": "57"
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
           }
-        }
-      },
-      "fit-content": {
-        "__compat": {
-          "description": "<code>fit-content</code>",
-          "support": {
-            "chrome": {
-              "version_added": "57"
+        },
+        "fit-content": {
+          "__compat": {
+            "description": "<code>fit-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "prefix": "-moz-",
+                "version_added": "41"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "44"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "57"
+              }
             },
-            "chrome_android": {
-              "version_added": "57"
-            },
-            "edge": {
-              "version_added": false
-            },
-            "edge_mobile": {
-              "version_added": false
-            },
-            "firefox": {
-              "prefix": "-moz-",
-              "version_added": "41"
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "44"
-            },
-            "opera_android": {
-              "version_added": "44"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "alternative_name": "-webkit-fill-available",
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": "57"
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
           }
         }
       }

--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -65,7 +65,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "57"
@@ -104,11 +104,10 @@
               "version_added": false
             },
             "opera": {
-              "prefix": "-webkit-",
-              "version_added": "15"
+              "version_added": "44"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "44"
             },
             "safari": {
               "version_added": false
@@ -120,7 +119,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "46"
+              "version_added": "57"
             }
           },
           "status": {
@@ -156,11 +155,10 @@
               "version_added": false
             },
             "opera": {
-              "prefix": "-webkit-",
-              "version_added": "15"
+              "version_added": "44"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "44"
             },
             "safari": {
               "version_added": false
@@ -172,7 +170,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "46"
+              "version_added": "57"
             }
           },
           "status": {
@@ -209,11 +207,10 @@
               "version_added": false
             },
             "opera": {
-              "prefix": "-webkit-",
-              "version_added": "15"
+              "version_added": "44"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "44"
             },
             "safari": {
               "version_added": false
@@ -226,7 +223,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "46"
+              "version_added": "57"
             }
           },
           "status": {

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -51,6 +51,108 @@
             "deprecated": false
           }
         },
+        "max-content": {
+          "__compat": {
+            "description": "<code>max-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "46"
+              },
+              "chrome_android": {
+                "version_added": "46"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "min-content": {
+          "__compat": {
+            "description": "<code>min-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "46"
+              },
+              "chrome_android": {
+                "version_added": "46"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "stretch": {
           "__compat": {
             "description": "<code>stretch</code>",
@@ -116,19 +218,19 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -137,112 +239,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": "5.0"
-              },
-              "webview_android": {
-                "version_added": "46"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "max-content": {
-          "__compat": {
-            "description": "<code>max-content</code>",
-            "support": {
-              "chrome": {
-                "version_added": "46"
-              },
-              "chrome_android": {
-                "version_added": "46"
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": "5.0"
-              },
-              "webview_android": {
-                "version_added": "46"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "min-content": {
-          "__compat": {
-            "description": "<code>min-content</code>",
-            "support": {
-              "chrome": {
-                "version_added": "46"
-              },
-              "chrome_android": {
-                "version_added": "46"
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": "5.0"

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -77,10 +77,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": true
@@ -128,10 +128,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": true

--- a/css/properties/inline-size.json
+++ b/css/properties/inline-size.json
@@ -65,7 +65,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "57"
@@ -103,11 +103,10 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": false
@@ -119,7 +118,7 @@
                 "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": "46"
+                "version_added": "57"
               }
             },
             "status": {
@@ -155,11 +154,10 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": false
@@ -171,7 +169,7 @@
                 "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": "46"
+                "version_added": "57"
               }
             },
             "status": {
@@ -208,11 +206,10 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": false
@@ -225,7 +222,7 @@
                 "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": "46"
+                "version_added": "57"
               }
             },
             "status": {

--- a/css/properties/inline-size.json
+++ b/css/properties/inline-size.json
@@ -76,6 +76,164 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "max-content": {
+          "__compat": {
+            "description": "<code>max-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "min-content": {
+          "__compat": {
+            "description": "<code>min-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "fit-content": {
+          "__compat": {
+            "description": "<code>fit-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "prefix": "-moz-",
+                "version_added": "3"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/max-block-size.json
+++ b/css/properties/max-block-size.json
@@ -65,7 +65,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "57"
@@ -103,11 +103,10 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": false
@@ -119,7 +118,7 @@
                 "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": "46"
+                "version_added": "57"
               }
             },
             "status": {
@@ -155,11 +154,10 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": false
@@ -171,7 +169,7 @@
                 "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": "46"
+                "version_added": "57"
               }
             },
             "status": {
@@ -198,21 +196,19 @@
                 "version_added": false
               },
               "firefox": {
-                "prefix": "-moz-",
-                "version_added": "3"
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": false
@@ -225,7 +221,7 @@
                 "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": "46"
+                "version_added": "57"
               }
             },
             "status": {

--- a/css/properties/max-block-size.json
+++ b/css/properties/max-block-size.json
@@ -72,9 +72,167 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "max-content": {
+          "__compat": {
+            "description": "<code>max-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "min-content": {
+          "__compat": {
+            "description": "<code>min-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "fit-content": {
+          "__compat": {
+            "description": "<code>fit-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "prefix": "-moz-",
+                "version_added": "3"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -53,16 +53,15 @@
             "deprecated": false
           }
         },
-        "sizing_values": {
+        "max-content": {
           "__compat": {
-            "description": "<code>fit-content</code>, <code>max-content</code>, and <code>min-content</code>",
+            "description": "<code>max-content</code>",
             "support": {
               "chrome": {
-                "version_added": false,
-                "notes": "Chrome implements an earlier proposal for setting height to an intrinsic height: the keywords <code>intrinsic</code> (instead of <code>max-content</code>), and <code>min-intrinsic</code> (instead of <code>min-content</code>). There is no equivalent for <code>stretch</code> or <code>fit-content</code>."
+                "version_added": "46"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "46"
               },
               "edge": {
                 "version_added": false
@@ -71,40 +70,86 @@
                 "version_added": false
               },
               "firefox": {
-                "partial_implementation": true,
-                "prefix": "-moz-",
-                "version_added": "3",
-                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+                "version_added": "66"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "66"
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": null
               },
               "opera_android": {
                 "version_added": null
               },
               "safari": {
-                "version_added": "9",
-                "notes": "Safari implements an earlier proposal for setting height to an intrinsic height: the keywords <code>intrinsic</code> (instead of <code>max-content</code>), and <code>min-intrinsic</code> (instead of <code>min-content</code>). There is no equivalent for <code>stretch</code> or <code>fit-content</code>."
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": "9",
-                "notes": "Safari implements an earlier proposal for setting height to an intrinsic height: the keywords <code>intrinsic</code> (instead of <code>max-content</code>), and <code>min-intrinsic</code> (instead of <code>min-content</code>). There is no equivalent for <code>stretch</code> or <code>fit-content</code>."
+                "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "46"
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "min-content": {
+          "__compat": {
+            "description": "<code>min-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "46"
+              },
+              "chrome_android": {
+                "version_added": "46"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -161,6 +206,72 @@
               "experimental": true,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "fit-content": {
+            "__compat": {
+              "description": "<code>fit-content</code>",
+              "support": {
+                "chrome": [
+                  {
+                    "version_added": "46"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "22"
+                  }
+                ],
+                "chrome_android": {
+                  "version_added": "46"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "prefix": "-moz-",
+                  "version_added": "3"
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "prefix": "-webkit-",
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": [
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "6.1"
+                  },
+                  {
+                    "alternative_name": "intrinsic",
+                    "version_added": "2"
+                  }
+                ],
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": "5.0"
+                },
+                "webview_android": {
+                  "version_added": "46"
+                }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -9,7 +9,7 @@
               "version_added": "18"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -221,9 +221,15 @@
                     "version_added": "25"
                   }
                 ],
-                "chrome_android": {
-                  "version_added": "46"
-                },
+                "chrome_android": [
+                  {
+                    "version_added": "46"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "25"
+                  }
+                ],
                 "edge": {
                   "version_added": false
                 },
@@ -261,10 +267,15 @@
                 "samsunginternet_android": {
                   "version_added": "5.0"
                 },
-                "webview_android": {
+                "webview_android": [
+                {
                   "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": true
                 }
-              },
+              ]},
               "status": {
                 "experimental": true,
                 "standard_track": true,

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -268,14 +268,15 @@
                   "version_added": "5.0"
                 },
                 "webview_android": [
-                {
-                  "version_added": "46"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": true
-                }
-              ]},
+                  {
+                    "version_added": "46"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": true
+                  }
+                ]
+              },
               "status": {
                 "experimental": true,
                 "standard_track": true,

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -22,7 +22,7 @@
               "notes": "CSS 2.1 leaves the behavior of <code>max-height</code> with <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>table</code></a> undefined. Firefox supports applying <code>max-height</code> to <code>table</code> elements."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "7"
@@ -32,19 +32,19 @@
               "notes": "CSS 2.1 leaves the behavior of <code>max-height</code> with <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>table</code></a> undefined. Opera supports applying <code>max-height</code> to <code>table</code> elements."
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -79,10 +79,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": true
@@ -130,10 +130,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": true
@@ -231,21 +231,19 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "prefix": "-moz-",
-                  "version_added": "3"
+                  "version_added": false
                 },
                 "firefox_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "ie": {
                   "version_added": false
                 },
                 "opera": {
-                  "prefix": "-webkit-",
-                  "version_added": "15"
+                  "version_added": "44"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "44"
                 },
                 "safari": [
                   {

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max-height",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "18"
             },
             "chrome_android": {
               "version_added": true
@@ -218,7 +218,7 @@
                   },
                   {
                     "prefix": "-webkit-",
-                    "version_added": "22"
+                    "version_added": "25"
                   }
                 ],
                 "chrome_android": {

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -105,11 +105,10 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": false
@@ -121,7 +120,7 @@
                 "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": "46"
+                "version_added": "57"
               }
             },
             "status": {
@@ -157,11 +156,10 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": false
@@ -173,7 +171,7 @@
                 "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": "46"
+                "version_added": "57"
               }
             },
             "status": {
@@ -210,11 +208,10 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": false
@@ -227,7 +224,7 @@
                 "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": "46"
+                "version_added": "57"
               }
             },
             "status": {

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -74,9 +74,167 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "max-content": {
+          "__compat": {
+            "description": "<code>max-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "min-content": {
+          "__compat": {
+            "description": "<code>min-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "fit-content": {
+          "__compat": {
+            "description": "<code>fit-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "prefix": "-moz-",
+                "version_added": "3"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -53,52 +53,139 @@
             "deprecated": false
           }
         },
-        "sizing_values": {
+        "max-content": {
           "__compat": {
-            "description": "<code>fit-content</code>, <code>max-content</code>, and <code>min-content</code>",
+            "description": "<code>max-content</code>",
             "support": {
-              "chrome": {
-                "version_added": false,
-                "notes": "Chrome implements an earlier proposal for setting width to an intrinsic width: the keywords <code>intrinsic</code> (instead of <code>max-content</code>), and <code>min-intrinsic</code> (instead of <code>min-content</code>). There is no equivalent for <code>stretch</code> or <code>fit-content</code>."
-              },
+              "chrome": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "22"
+                }
+              ],
               "chrome_android": {
-                "version_added": null
+                "version_added": "46"
               },
               "edge": {
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "3",
-                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
-              },
-              "firefox_android": {
                 "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "3"
+                }
+              ],
+              "firefox_android": {
+                "version_added": "66"
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "prefix": "-webkit-",
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": null
               },
-              "safari": {
-                "version_added": false,
-                "notes": "Safari implements an earlier proposal for setting width to an intrinsic width: the keywords <code>intrinsic</code> (instead of <code>max-content</code>), and <code>min-intrinsic</code> (instead of <code>min-content</code>). There is no equivalent for <code>stretch</code> or <code>fit-content</code>."
-              },
+              "safari": [
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "6.1"
+                },
+                {
+                  "alternative_name": "intrinsic",
+                  "version_added": "2"
+                }
+              ],
               "safari_ios": {
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "5.0"
               },
               "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "min-content": {
+          "__compat": {
+            "description": "<code>min-content</code>",
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "22"
+                }
+              ],
+              "chrome_android": {
+                "version_added": "46"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "3"
+                }
+              ],
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
                 "version_added": null
+              },
+              "safari": [
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "6.1"
+                },
+                {
+                  "alternative_name": "intrinsic",
+                  "version_added": "2"
+                }
+              ],
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
               }
             },
             "status": {
@@ -159,6 +246,72 @@
               "experimental": true,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "fit-content": {
+            "__compat": {
+              "description": "<code>fit-content</code>",
+              "support": {
+                "chrome": [
+                  {
+                    "version_added": "46"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "22"
+                  }
+                ],
+                "chrome_android": {
+                  "version_added": "46"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "prefix": "-moz-",
+                  "version_added": "3"
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "prefix": "-webkit-",
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": [
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "6.1"
+                  },
+                  {
+                    "alternative_name": "intrinsic",
+                    "version_added": "2"
+                  }
+                ],
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": "5.0"
+                },
+                "webview_android": {
+                  "version_added": "46"
+                }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -91,11 +91,10 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": [
                 {
@@ -162,11 +161,10 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": [
                 {
@@ -281,11 +279,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "prefix": "-webkit-",
-                  "version_added": "15"
+                  "version_added": "44"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "44"
                 },
                 "safari": [
                   {

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -305,7 +305,7 @@
                 "samsunginternet_android": {
                   "version_added": "5.0"
                 },
-                "webview_android":  [
+                "webview_android": [
                 {
                   "version_added": "46"
                 },

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -133,7 +133,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "22"
+                  "version_added": "25"
                 }
               ],
               "chrome_android": {
@@ -256,7 +256,7 @@
                   },
                   {
                     "prefix": "-webkit-",
-                    "version_added": "22"
+                    "version_added": "25"
                   }
                 ],
                 "chrome_android": {

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -112,10 +112,15 @@
               "samsunginternet_android": {
                 "version_added": "5.0"
               },
-              "webview_android": {
+              "webview_android":  [
+              {
                 "version_added": "46"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
               }
-            },
+            ]},
             "status": {
               "experimental": true,
               "standard_track": true,
@@ -300,10 +305,15 @@
                 "samsunginternet_android": {
                   "version_added": "5.0"
                 },
-                "webview_android": {
+                "webview_android":  [
+                {
                   "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": true
                 }
-              },
+              ]},
               "status": {
                 "experimental": true,
                 "standard_track": true,

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -112,15 +112,16 @@
               "samsunginternet_android": {
                 "version_added": "5.0"
               },
-              "webview_android":  [
-              {
-                "version_added": "46"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ]},
+              "webview_android": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": true
+                }
+              ]
+            },
             "status": {
               "experimental": true,
               "standard_track": true,
@@ -306,14 +307,15 @@
                   "version_added": "5.0"
                 },
                 "webview_android": [
-                {
-                  "version_added": "46"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": true
-                }
-              ]},
+                  {
+                    "version_added": "46"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": true
+                  }
+                ]
+              },
               "status": {
                 "experimental": true,
                 "standard_track": true,

--- a/css/properties/min-block-size.json
+++ b/css/properties/min-block-size.json
@@ -72,9 +72,167 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "max-content": {
+          "__compat": {
+            "description": "<code>max-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "min-content": {
+          "__compat": {
+            "description": "<code>min-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "fit-content": {
+          "__compat": {
+            "description": "<code>fit-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "prefix": "-moz-",
+                "version_added": "41"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/properties/min-block-size.json
+++ b/css/properties/min-block-size.json
@@ -103,11 +103,10 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": false
@@ -119,7 +118,7 @@
                 "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": "46"
+                "version_added": "57"
               }
             },
             "status": {
@@ -155,11 +154,10 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": false
@@ -171,7 +169,7 @@
                 "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": "46"
+                "version_added": "57"
               }
             },
             "status": {
@@ -198,21 +196,19 @@
                 "version_added": false
               },
               "firefox": {
-                "prefix": "-moz-",
-                "version_added": "41"
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": false
@@ -225,7 +221,7 @@
                 "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": "46"
+                "version_added": "57"
               }
             },
             "status": {

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -54,52 +54,103 @@
             "deprecated": false
           }
         },
-        "sizing_values": {
+        "max-content": {
           "__compat": {
-            "description": "<code>fit-content</code>, <code>max-content</code>, and <code>min-content</code>",
+            "description": "<code>max-content</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "46"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "46"
               },
               "edge": {
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
                 "version_added": false
               },
+              "firefox": {
+                "version_added": "66"
+              },
               "firefox_android": {
-                "version_added": null
+                "version_added": "66"
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": null
               },
               "opera_android": {
                 "version_added": null
               },
               "safari": {
-                "version_added": "9"
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "46"
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "min-content": {
+          "__compat": {
+            "description": "<code>min-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "46"
+              },
+              "chrome_android": {
+                "version_added": "46"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -154,6 +205,72 @@
               "webview_android": {
                 "alternative_name": "-webkit-fill-available",
                 "version_added": "37"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "fit-content": {
+          "__compat": {
+            "description": "<code>fit-content</code>",
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "22"
+                }
+              ],
+              "chrome_android": {
+                "version_added": "46"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "prefix": "-moz-",
+                "version_added": "3"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": [
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "6.1"
+                },
+                {
+                  "alternative_name": "intrinsic",
+                  "version_added": "2"
+                }
+              ],
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
               }
             },
             "status": {

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -224,7 +224,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "22"
+                  "version_added": "25"
                 }
               ],
               "chrome_android": {

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -80,7 +80,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added":  "44"
+                "version_added": "44"
               },
               "opera_android": {
                 "version_added": "44"

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -267,7 +267,7 @@
               "samsunginternet_android": {
                 "version_added": "5.0"
               },
-              "webview_android":  [
+              "webview_android": [
               {
                 "version_added": "46"
               },

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -268,14 +268,15 @@
                 "version_added": "5.0"
               },
               "webview_android": [
-              {
-                "version_added": "46"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ]},
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": true
+                }
+              ]
+            },
             "status": {
               "experimental": true,
               "standard_track": true,

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -80,10 +80,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added":  "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": true
@@ -131,10 +131,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": true
@@ -237,21 +237,19 @@
                 "version_added": false
               },
               "firefox": {
-                "prefix": "-moz-",
-                "version_added": "3"
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": [
                 {

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -267,10 +267,15 @@
               "samsunginternet_android": {
                 "version_added": "5.0"
               },
-              "webview_android": {
+              "webview_android":  [
+              {
                 "version_added": "46"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
               }
-            },
+            ]},
             "status": {
               "experimental": true,
               "standard_track": true,

--- a/css/properties/min-inline-size.json
+++ b/css/properties/min-inline-size.json
@@ -119,7 +119,7 @@
                 "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": "46"
+                "version_added": "57"
               }
             },
             "status": {
@@ -171,7 +171,7 @@
                 "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": "46"
+                "version_added": "57"
               }
             },
             "status": {
@@ -208,11 +208,10 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": {
                 "version_added": false
@@ -225,7 +224,7 @@
                 "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": "46"
+                "version_added": "57"
               }
             },
             "status": {

--- a/css/properties/min-inline-size.json
+++ b/css/properties/min-inline-size.json
@@ -72,9 +72,167 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "max-content": {
+          "__compat": {
+            "description": "<code>max-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "min-content": {
+          "__compat": {
+            "description": "<code>min-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "fit-content": {
+          "__compat": {
+            "description": "<code>fit-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "prefix": "-moz-",
+                "version_added": "41"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -112,7 +112,7 @@
               "samsunginternet_android": {
                 "version_added": "5.0"
               },
-              "webview_android":  [
+              "webview_android": [
               {
                 "version_added": "46"
               },
@@ -310,7 +310,7 @@
                 "alternative_name": "-webkit-fill-available",
                 "version_added": "5.0"
               },
-              "webview_android":  [
+              "webview_android": [
               {
                 "version_added": "46"
               },

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -112,10 +112,15 @@
               "samsunginternet_android": {
                 "version_added": "5.0"
               },
-              "webview_android": {
+              "webview_android":  [
+              {
                 "version_added": "46"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
               }
-            },
+            ]},
             "status": {
               "experimental": false,
               "standard_track": true,
@@ -130,6 +135,10 @@
               "chrome": [
                 {
                   "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "25"
                 },
                 {
                   "alternative_name": "min-intrinsic",
@@ -301,10 +310,15 @@
                 "alternative_name": "-webkit-fill-available",
                 "version_added": "5.0"
               },
-              "webview_android": {
+              "webview_android":  [
+              {
                 "version_added": "46"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
               }
-            },
+            ]},
             "status": {
               "experimental": false,
               "standard_track": true,

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -191,9 +191,15 @@
               "samsunginternet_android": {
                 "version_added": "5.0"
               },
-              "webview_android": {
-                "version_added": "46"
-              }
+              "webview_android": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": true
+                }
+              ]
             },
             "status": {
               "experimental": false,

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -113,14 +113,15 @@
                 "version_added": "5.0"
               },
               "webview_android": [
-              {
-                "version_added": "46"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ]},
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": true
+                }
+              ]
+            },
             "status": {
               "experimental": false,
               "standard_track": true,
@@ -311,14 +312,15 @@
                 "version_added": "5.0"
               },
               "webview_android": [
-              {
-                "version_added": "46"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ]},
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": true
+                }
+              ]
+            },
             "status": {
               "experimental": false,
               "standard_track": true,

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -161,11 +161,10 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": [
                 {

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -63,7 +63,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "22"
+                  "version_added": "25"
                 }
               ],
               "chrome_android": {
@@ -133,7 +133,7 @@
                 },
                 {
                   "alternative_name": "min-intrinsic",
-                  "version_added": "22"
+                  "version_added": "25"
                 }
               ],
               "chrome_android": {
@@ -256,7 +256,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "22"
+                  "version_added": "25"
                 }
               ],
               "chrome_android": {

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -38,7 +38,7 @@
               "version_added": "2"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -53,16 +53,21 @@
             "deprecated": false
           }
         },
-        "sizing_values": {
+        "max-content": {
           "__compat": {
-            "description": "<code>fit-content</code>, <code>max-content</code>, and <code>min-content</code>",
+            "description": "<code>max-content</code>",
             "support": {
-              "chrome": {
-                "prefix": "-webkit-",
-                "version_added": "24"
-              },
+              "chrome": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "22"
+                }
+              ],
               "chrome_android": {
-                "version_added": null
+                "version_added": "46"
               },
               "edge": {
                 "version_added": false
@@ -70,38 +75,119 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "3",
-                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "3"
+                }
+              ],
               "firefox_android": {
-                "version_added": null
+                "version_added": "66"
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "prefix": "-webkit-",
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": null
               },
-              "safari": {
-                "version_added": false
-              },
+              "safari": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "alternative_name": "intrinsic",
+                  "version_added": "2"
+                }
+              ],
               "safari_ios": {
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "46"
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "min-content": {
+          "__compat": {
+            "description": "<code>min-content</code>",
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "alternative_name": "min-intrinsic",
+                  "version_added": "22"
+                }
+              ],
+              "chrome_android": {
+                "version_added": "46"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "3"
+                }
+              ],
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "alternative_name": "min-intrinsic",
+                  "version_added": "2"
+                }
+              ],
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -156,6 +242,72 @@
             },
             "status": {
               "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "fit-content": {
+          "__compat": {
+            "description": "<code>fit-content</code>",
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "22"
+                }
+              ],
+              "chrome_android": {
+                "version_added": "46"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "prefix": "-moz-",
+                "version_added": "3"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": [
+                {
+                  "version_added": true
+                },
+                {
+                  "alternative_name": "-webkit-fill-available",
+                  "version_added": "6.1"
+                }
+              ],
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -124,15 +124,20 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "3"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "3"
+                }
+              ],
               "firefox_android": {
-                "version_added": null
+                "version_added": "66"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "prefix": "-webkit-",
@@ -143,8 +148,7 @@
               },
               "safari": [
                 {
-                  "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "11"
                 },
                 {
                   "alternative_name": "intrinsic",
@@ -162,7 +166,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -190,15 +194,20 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "3"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "3"
+                }
+              ],
               "firefox_android": {
-                "version_added": null
+                "version_added": "66"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "prefix": "-webkit-",
@@ -209,8 +218,7 @@
               },
               "safari": [
                 {
-                  "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "11"
                 },
                 {
                   "alternative_name": "min-intrinsic",
@@ -228,7 +236,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -329,10 +337,15 @@
               "opera_android": {
                 "version_added": null
               },
-              "safari": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "6.1"
-              },
+              "safari": [
+                {
+                  "version_added": true
+                },
+                {
+                  "alternative_name": "-webkit-fill-available",
+                  "version_added": "6.1"
+                }
+              ],
               "safari_ios": {
                 "version_added": null
               },
@@ -345,7 +358,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -140,11 +140,10 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": [
                 {
@@ -210,11 +209,10 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "44"
               },
               "safari": [
                 {


### PR DESCRIPTION
Firefox 66 has unprefixed the min-content and max-content keywords: https://bugzilla.mozilla.org/show_bug.cgi?id=1322780. I've updated the compat data based on this and my testing. The fit-content keyword is still left prefixed.

The data is pretty patchy so I also tested on some other browsers to fill out some nulls, so have updated Edge and Safari too.

All of the sizing keywords were combined in some files, and as data typically is different, I split these out. I added sections for these keywords where there were none.