### PR TITLE
FormData not available in worker in Safari

### DIFF
--- a/api/FormData.json
+++ b/api/FormData.json
@@ -704,7 +704,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
[FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData) is not available in web workers in Safari. It was already set to `false` for Safari iOS, but desktop Safari also does not support `FormData` in web workers.

Tested latest stable release: Safari Version 12.0.3 (14606.4.5)

Test (in a worker):
```js
console.log(typeof FormData);
// undefined
```

It logs `function` in Firefox and Chrome.