### PR TITLE
[Chrome] List support for XMLDocument.

### DIFF
--- a/api/XMLDocument.json
+++ b/api/XMLDocument.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLDocument",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "45"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "45"
           },
           "edge": {
             "version_added": true
@@ -41,7 +41,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "45"
           }
         },
         "status": {


### PR DESCRIPTION
Addresses #3458 

Here's its commit: https://storage.googleapis.com/chromium-find-releases-static/7b0.html#7b0411a93c0d818aab3613e28be7d92211931af7