### PR TITLE
Complete the compat data for Array in Edge

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true
@@ -1376,7 +1376,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -1929,7 +1929,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -2146,7 +2146,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -2311,7 +2311,7 @@
                 "version_added": "66"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": true
@@ -2382,7 +2382,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null
@@ -2465,7 +2465,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -2531,7 +2531,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null


### PR DESCRIPTION
For each entry set to "12", it was confirmed in an Edge 12 VM with
`Array.prototype.hasOwnProperty(...)`, which of course implies basic
support and support for `Array.prototype`.

@@species was found missing in Edge 18 and set to false.