### PR TITLE
[Chrome] sync-xhr was enabled by default in 65.

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1324,24 +1324,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/sync-xhr",
             "support": {
               "chrome": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "65"
               },
               "chrome_android": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "65"
               },
               "edge": {
                 "version_added": false
@@ -1359,24 +1345,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "52"
               },
               "opera_android": {
-                "version_added": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "52"
               },
               "safari": {
                 "version_added": false
@@ -1388,14 +1360,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "65"
               }
             },
             "status": {


### PR DESCRIPTION
I can usually show the commit's version number in Chrome's lookup tool. I'm having trouble finding that. Here's the tracking bug marked M-65 (Chrome 65). The person who added 'M-65' to this ticket is in a good position within Chrome to know.

https://bugs.chromium.org/p/chromium/issues/detail?id=661283