### PR TITLE
Update SameSite cookie attribute data for Edge and Safari

### DIFF
--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -215,7 +215,7 @@
                 "version_added": "51"
               },
               "edge": {
-                "version_added": false
+                "version_added": "16"
               },
               "edge_mobile": {
                 "version_added": false
@@ -236,10 +236,10 @@
                 "version_added": "39"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [X] Summarize your changes
SameSite cookie attribute works as expected in Edge version 16+, Safari OS and iOS version 12+, physically tested and referenced from https://caniuse.com/#feat=same-site-cookie-attribute
- [X] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
https://caniuse.com/#feat=same-site-cookie-attribute
- [X] Data: if you tested something, describe how you tested with details like browser and version
I utilized Browserstack for versions listed in summary
- [X] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
N/A
- [X] Link to related issues or pull requests, if any
N/A
