### PR TITLE
Add indexeddb events

### DIFF
--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -181,7 +181,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -238,11 +238,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/close_event",
           "support": {
             "chrome": {
-              "version_added": "31",
-              "notes": "approx"
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "edge": {
               "version_added": true
@@ -301,7 +300,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -367,7 +366,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -433,7 +432,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -499,7 +498,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -559,7 +558,7 @@
               "notes": "approx"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "edge": {
               "version_added": true
@@ -617,7 +616,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -683,7 +682,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": null
@@ -749,7 +748,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -816,7 +815,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": null
@@ -882,7 +881,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -948,7 +947,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -1014,7 +1013,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -1080,7 +1079,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -165,6 +165,193 @@
           }
         }
       },
+      "abort_event": {
+        "__compat": {
+          "description": "<code>abort</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/abort_event",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "23",
+                "version_removed": "24",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "16",
+                "prefix": "moz"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": "10",
+              "notes": "partial"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "22"
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "8"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "close_event": {
+        "__compat": {
+          "description": "<code>close</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/close_event",
+          "support": {
+            "chrome": {
+              "version_added": "31",
+              "notes": "approx"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "50"
+            },
+            "firefox_android": {
+              "version_added": "50"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.1"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error_event": {
+        "__compat": {
+          "description": "<code>error</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/error_event",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "23",
+                "version_removed": "24",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "16",
+                "prefix": "moz"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": "10",
+              "notes": "partial"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "22"
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "8"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/name",
@@ -569,6 +756,73 @@
             },
             "edge_mobile": {
               "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "16",
+                "prefix": "moz"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": "10",
+              "notes": "partial"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "22"
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "8"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "versionchange_event": {
+        "__compat": {
+          "description": "<code>versionchange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/versionchange_event",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "23",
+                "version_removed": "24",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
             },
             "firefox": [
               {

--- a/api/IDBOpenDBRequest.json
+++ b/api/IDBOpenDBRequest.json
@@ -137,6 +137,94 @@
           }
         }
       },
+      "blocked_event": {
+        "__compat": {
+          "description": "<code>blocked</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBOpenDBRequest/blocked_event",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "23",
+                "version_removed": "57",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "25"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "57",
+                "prefix": "webkit"
+              }
+            ],
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "16",
+                "prefix": "moz"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": "10",
+              "notes": "partial"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "22"
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "8"
+            },
+            "samsunginternet_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_removed": "7.0",
+                "prefix": "webkit",
+                "version_added": true
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": true,
+                "version_removed": "57",
+                "prefix": "webkit"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "onblocked": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBOpenDBRequest/onblocked",
@@ -227,6 +315,94 @@
       "onupgradeneeded": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBOpenDBRequest/onupgradeneeded",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "23",
+                "version_removed": "57",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "25"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "57",
+                "prefix": "webkit"
+              }
+            ],
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "16",
+                "prefix": "moz"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": "10",
+              "notes": "partial"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "22"
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "8"
+            },
+            "samsunginternet_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_removed": "7.0",
+                "prefix": "webkit",
+                "version_added": true
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": true,
+                "version_removed": "57",
+                "prefix": "webkit"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "upgradeneeded_event": {
+        "__compat": {
+          "description": "<code>upgradeneeded</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBOpenDBRequest/upgradeneeded_event",
           "support": {
             "chrome": [
               {

--- a/api/IDBRequest.json
+++ b/api/IDBRequest.json
@@ -275,6 +275,72 @@
           }
         }
       },
+      "error_event": {
+        "__compat": {
+          "description": "<code>error</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBRequest/error_event",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "23",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "16",
+                "prefix": "moz"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": "10",
+              "notes": "partial"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "22"
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "8"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "onerror": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBRequest/onerror",
@@ -538,6 +604,72 @@
       "source": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBRequest/source",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "23",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "16",
+                "prefix": "moz"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": "10",
+              "notes": "partial"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "22"
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "8"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "success_event": {
+        "__compat": {
+          "description": "<code>success</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBRequest/success_event",
           "support": {
             "chrome": [
               {

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -137,6 +137,138 @@
           }
         }
       },
+      "abort_event": {
+        "__compat": {
+          "description": "<code>abort</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/abort_event",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "23",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "16",
+                "prefix": "moz"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": "10",
+              "notes": "partial"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "22"
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "8"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "complete_event": {
+        "__compat": {
+          "description": "<code>complete</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/complete_event",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "23",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "16",
+                "prefix": "moz"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": "10",
+              "notes": "partial"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "22"
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "8"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "db": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/db",
@@ -359,6 +491,72 @@
               "standard_track": true,
               "deprecated": false
             }
+          }
+        }
+      },
+      "error_event": {
+        "__compat": {
+          "description": "<code>error</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/error_event",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "23",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "16",
+                "prefix": "moz"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": "10",
+              "notes": "partial"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "22"
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "8"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
This PR adds compat data for IndexedDB events. It's part of https://github.com/mdn/sprints/issues/926. It updates the following files:

* IDBDatabase.json:
    * add data for [`abort`](https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/abort_event), [`close`](https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/close_event), [`error`](https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/error_event), [`versionchange`](https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/versionchange_event).
* IDBOpenDBRequest.json:
    * add data for [`blocked`](https://developer.mozilla.org/en-US/docs/Web/API/IDBOpenDBRequest/blocked_event) and [`upgradeneeded`](https://developer.mozilla.org/en-US/docs/Web/API/IDBOpenDBRequest/upgradeneeded_event).
* IDBRequest.json:
    * add data for [`error`](https://developer.mozilla.org/en-US/docs/Web/API/IDBRequest/error_event) and [`success`](https://developer.mozilla.org/en-US/docs/Web/API/IDBRequest/success_event).
* IDBTransaction.json:
    * add data for [`abort`](https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/abort_event), [`complete`](https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/complete_event), and [`error`](https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/error_event).

I've gone with a flat hierarchy using "_eventname_\_event" as the identifier and "`eventname` event"
as the description.

None of the original events had compat tables, so I just copied the data from the `on-` property. I'm not sure whether that was a good choice.

I've tried to maintain alphabetical order but didn't fix any existing misordering, but I wouldn't mind doing that in this PR if it seems like a good idea. Either way I thought it would be easier to review without reordering.


