### PR TITLE
Add compatibility data for prefers-color-scheme

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1188,6 +1188,55 @@
             }
           }
         },
+        "prefers-color-scheme": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/prefers-color-scheme",
+            "description": "<code>prefers-color-scheme</code> media feature",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "67"
+              },
+              "firefox_android": {
+                "version_added": "67"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "12.1"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "prefers-reduced-motion": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/prefers-reduced-motion",


### PR DESCRIPTION
This adds the compatibility data for `prefers-color-scheme` media query

Chromium: [bug 889087](https://crbug.com/889087)  
Edge: [manually tested](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme#Result) version 44.17763.1.0  
Firefox: [bug 1494034](https://bugzilla.mozilla.org/show_bug.cgi?id=1494034)  
Safari: [Release Notes for Safari Technology Preview 68](https://webkit.org/blog/8475/release-notes-for-safari-technology-preview-68/)