### PR TITLE
Firefox doesn't support worklets yet

### DIFF
--- a/api/Worklet.json
+++ b/api/Worklet.json
@@ -17,10 +17,10 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": true
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -67,10 +67,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "63"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "63"
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
In particular, `audioWorklet` and its `addModule` method are not yet available in any Firefox version up to the current nightly.

Consequently, I've marked the "version_added" fields for "firefox" and "firefox_android" for both those entries as `false`.

[Bug 1062849](https://bugzilla.mozilla.org/show_bug.cgi?id=1062849) tracks AudioWorklet API implementation for the Web Audio API.