### PR TITLE
Add missing Edge 18 data based on Confluence

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5892,7 +5892,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/FormData.json
+++ b/api/FormData.json
@@ -222,7 +222,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": false
@@ -273,7 +273,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": false
@@ -324,7 +324,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": false
@@ -375,7 +375,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": false
@@ -426,7 +426,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": false
@@ -477,7 +477,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": false
@@ -528,7 +528,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": false
@@ -579,7 +579,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": false

--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -367,7 +367,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -520,7 +520,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -522,7 +522,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": false

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -576,7 +576,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/HTMLLabelElement.json
+++ b/api/HTMLLabelElement.json
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/HTMLMeterElement.json
+++ b/api/HTMLMeterElement.json
@@ -280,7 +280,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": false

--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -1258,7 +1258,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/HTMLOutputElement.json
+++ b/api/HTMLOutputElement.json
@@ -219,7 +219,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": false

--- a/api/HTMLProgressElement.json
+++ b/api/HTMLProgressElement.json
@@ -202,7 +202,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": false

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -203,7 +203,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": false

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -205,7 +205,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": false

--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -290,7 +290,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -214,7 +214,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -775,7 +775,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -723,7 +723,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": false

--- a/api/RadioNodeList.json
+++ b/api/RadioNodeList.json
@@ -61,7 +61,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -583,7 +583,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -217,7 +217,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/XMLHttpRequestEventTarget.json
+++ b/api/XMLHttpRequestEventTarget.json
@@ -61,7 +61,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": null
@@ -112,7 +112,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": null
@@ -163,7 +163,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": null
@@ -214,7 +214,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": null
@@ -265,7 +265,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": null
@@ -316,7 +316,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": null
@@ -367,7 +367,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": null

--- a/api/XMLHttpRequestEventTarget.json
+++ b/api/XMLHttpRequestEventTarget.json
@@ -61,7 +61,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": "18"
+              "version_added": null
             },
             "edge_mobile": {
               "version_added": null
@@ -112,7 +112,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": "18"
+              "version_added": null
             },
             "edge_mobile": {
               "version_added": null
@@ -163,7 +163,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": "18"
+              "version_added": null
             },
             "edge_mobile": {
               "version_added": null
@@ -214,7 +214,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": "18"
+              "version_added": null
             },
             "edge_mobile": {
               "version_added": null
@@ -265,7 +265,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": "18"
+              "version_added": null
             },
             "edge_mobile": {
               "version_added": null
@@ -316,7 +316,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": "18"
+              "version_added": null
             },
             "edge_mobile": {
               "version_added": null
@@ -367,7 +367,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": "18"
+              "version_added": null
             },
             "edge_mobile": {
               "version_added": null

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -1272,7 +1272,7 @@
                 "version_added": "63"
               },
               "edge": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge_mobile": {
                 "version_added": false


### PR DESCRIPTION
Produced by `npm run confluence -- --fill-only --browsers=edge` with
local changes applied to only include changes where the new version
was 18.

To review this, double check each change manually by running some scripts in Edge 17 and Edge 18. (I will self-review first.)