### PR TITLE
Firefox only supports three-parameter calls to scale()

### DIFF
--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -1655,6 +1655,7 @@
             },
             "firefox_android": {
               "version_added": "33",
+              "partial_support": true,
               "notes": "Firefox currently still supports the older three-parameter syntax — <code>DOMMatrix.scale(scaleX[, originX][, originY])</code> — not the six-parameter version."
             },
             "ie": {

--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -1650,6 +1650,7 @@
             },
             "firefox": {
               "version_added": "33",
+              "partial_support": true,
               "notes": "Firefox currently still supports the older three-parameter syntax — <code>DOMMatrix.scale(scaleX[, originX][, originY])</code> — not the six-parameter version."
             },
             "firefox_android": {

--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -1649,10 +1649,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "33"
+              "version_added": "33",
+              "notes": "Firefox currently still supports the older three-parameter syntax — <code>DOMMatrix.scale(scaleX[, originX][, originY])</code> — not the six-parameter version."
             },
             "firefox_android": {
-              "version_added": "33"
+              "version_added": "33",
+              "notes": "Firefox currently still supports the older three-parameter syntax — <code>DOMMatrix.scale(scaleX[, originX][, originY])</code> — not the six-parameter version."
             },
             "ie": {
               "version_added": false

--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -1650,12 +1650,12 @@
             },
             "firefox": {
               "version_added": "33",
-              "partial_support": true,
+              "partial_implementation": true,
               "notes": "Firefox currently still supports the older three-parameter syntax — <code>DOMMatrix.scale(scaleX[, originX][, originY])</code> — not the six-parameter version."
             },
             "firefox_android": {
               "version_added": "33",
-              "partial_support": true,
+              "partial_implementation": true,
               "notes": "Firefox currently still supports the older three-parameter syntax — <code>DOMMatrix.scale(scaleX[, originX][, originY])</code> — not the six-parameter version."
             },
             "ie": {


### PR DESCRIPTION
In writing MDN docs for `DOMMatrixReadOnly.scale` I've found that the implementation does not match the current spec in Firefox.

The spec lists `scale(scaleX[, scaleY][, scaleZ][, originX][, originY][, originZ])`
but the Firefox implementation accepts `scale(scaleX[, originX][, originY])`

[Here's the relevant part of the spec](https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-scale)
[Here's the implementation in Firefox](https://hg.mozilla.org/integration/autoland/file/d5eeebfcad8c/dom/base/DOMMatrix.cpp#l81)
[And here's the documentation with a working example](https://developer.mozilla.org/en-US/docs/Web/API/DOMMatrixReadOnly/scale)