### PR TITLE
Update Edge 16 support for SharedArrayBuffer and Atomics

### DIFF
--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -22,7 +22,8 @@
               "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
             },
             "edge": {
-              "version_added": false,
+              "version_added": "16",
+              "version_removed": "17",
               "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
             },
             "edge_mobile": {
@@ -139,7 +140,8 @@
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
               },
               "edge": {
-                "version_added": false,
+                "version_added": "16",
+                "version_removed": "17",
                 "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
               },
               "edge_mobile": {
@@ -257,7 +259,8 @@
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
               },
               "edge": {
-                "version_added": false,
+                "version_added": "16",
+                "version_removed": "17",
                 "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
               },
               "edge_mobile": {
@@ -375,7 +378,8 @@
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
               },
               "edge": {
-                "version_added": false,
+                "version_added": "16",
+                "version_removed": "17",
                 "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
               },
               "edge_mobile": {
@@ -493,7 +497,8 @@
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
               },
               "edge": {
-                "version_added": false,
+                "version_added": "16",
+                "version_removed": "17",
                 "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
               },
               "edge_mobile": {
@@ -611,7 +616,8 @@
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
               },
               "edge": {
-                "version_added": false,
+                "version_added": "16",
+                "version_removed": "17",
                 "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
               },
               "edge_mobile": {
@@ -729,7 +735,8 @@
                 "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
               },
               "edge": {
-                "version_added": false,
+                "version_added": "16",
+                "version_removed": "17",
                 "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
               },
               "edge_mobile": {
@@ -1021,7 +1028,8 @@
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
               },
               "edge": {
-                "version_added": false,
+                "version_added": "16",
+                "version_removed": "17",
                 "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
               },
               "edge_mobile": {
@@ -1139,7 +1147,8 @@
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
               },
               "edge": {
-                "version_added": false,
+                "version_added": "16",
+                "version_removed": "17",
                 "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
               },
               "edge_mobile": {
@@ -1257,7 +1266,8 @@
                 "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
               },
               "edge": {
-                "version_added": false,
+                "version_added": "16",
+                "version_removed": "17",
                 "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
               },
               "edge_mobile": {
@@ -1375,7 +1385,8 @@
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
               },
               "edge": {
-                "version_added": false,
+                "version_added": "16",
+                "version_removed": "17",
                 "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
               },
               "edge_mobile": {
@@ -1519,7 +1530,8 @@
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
               },
               "edge": {
-                "version_added": false,
+                "version_added": "16",
+                "version_removed": "17",
                 "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
               },
               "edge_mobile": {

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -22,7 +22,8 @@
               "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
             },
             "edge": {
-              "version_added": false,
+              "version_added": "16",
+              "version_removed": "17",
               "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
             },
             "edge_mobile": {
@@ -138,8 +139,7 @@
                 "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
               },
               "edge": {
-                "version_added": false,
-                "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -256,7 +256,8 @@
                 "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
               },
               "edge": {
-                "version_added": false,
+                "version_added": "16",
+                "version_removed": "17",
                 "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
               },
               "edge_mobile": {
@@ -374,7 +375,8 @@
                 "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
               },
               "edge": {
-                "version_added": false,
+                "version_added": "16",
+                "version_removed": "17",
                 "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
               },
               "edge_mobile": {
@@ -492,7 +494,8 @@
                 "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
               },
               "edge": {
-                "version_added": false,
+                "version_added": "16",
+                "version_removed": "17",
                 "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
               },
               "edge_mobile": {


### PR DESCRIPTION
Because `version_removed` was missing, the status was misleading:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#Browser_compatibility
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics#Browser_compatibility

Complete the tables based on testing in Edge 16 and 17, where
SharedArrayBuffer, SharedArrayBuffer.prototype and Atomics are exposed
in Edge 16 but gone in Edge 17.

SharedArrayBuffer.isView isn't supported in Edge 16, so
`sab_in_dataview` should simply be false without note.