### PR TITLE
Remove experimental flags form the source element

### DIFF
--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -97,7 +97,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -183,7 +183,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -319,7 +319,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
## This PR will
-  Remove the experimental flags about the `sizes`, `srcset` and `media` attributes since they are now part of the [living standard](https://html.spec.whatwg.org/multipage/embedded-content.html#attr-source-media)

## FIle changed
Browsers data
https://github.com/mdn/browser-compat-data/blob/master/html/elements/source.json

