### PR TITLE
Update HTMLCollection.json

### DIFF
--- a/api/HTMLCollection.json
+++ b/api/HTMLCollection.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null
@@ -23,7 +23,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": true
           },
           "opera": {
             "version_added": null
@@ -32,7 +32,7 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
             "version_added": null
@@ -166,7 +166,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": null
@@ -175,7 +175,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null


### PR DESCRIPTION
Update to reflect `namedItem` being available to ie11, edge and safari. 

IE11:
![image](https://user-images.githubusercontent.com/13875792/53042806-1c1c6c00-3455-11e9-8ba8-fb114b9a098f.png)

Safari 12.0.3: 
![image](https://user-images.githubusercontent.com/13875792/53042866-35bdb380-3455-11e9-8085-a666d046ce75.png)

Edge 18: 
![image](https://user-images.githubusercontent.com/13875792/53043067-a2d14900-3455-11e9-8dda-9c1ed54bb100.png)


A checklist to help your pull request get merged faster:
- [ x ] Summarize your changes
- [ x ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ x ] Data: if you tested something, describe how you tested with details like browser and version
- [ x ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ x ] Link to related issues or pull requests, if any
