### PR TITLE
Bring location.json->hostname inline with HTMLHyperlinkElementUtils/hostname

### DIFF
--- a/api/Location.json
+++ b/api/Location.json
@@ -223,13 +223,13 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false
             },
             "safari": {
               "version_added": true


### PR DESCRIPTION
I noticed that the Location.hostname in https://developer.mozilla.org/en-US/docs/Web/API/Location said that it should work in Internet Explorer, while clicking on it (https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/hostname) shows that it shouldn't work. My own testing shows that indeed window.location.hostname doesn't work in Internet Explorer 11, so I assume the compatibility matrix on the more specific page is more correct.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
