### PR TITLE
Mark Symbol.species as available in Edge 13 (was 14)

### DIFF
--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -738,7 +738,7 @@
                 "version_added": "51"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "13"
               },
               "edge_mobile": {
                 "version_added": "14"


### PR DESCRIPTION
Suggested by `npm run confluence` and confirmed by
https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=6668 in
Edge 12 in a VM and Edge 13 on Sauce. (It wasn't in Edge 12.)