### PR TITLE
Update the ReadableStream support for Edge

### DIFF
--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -11,7 +11,7 @@
             "version_added": "43"
           },
           "edge": {
-            "version_added": "16"
+            "version_added": "14"
           },
           "edge_mobile": {
             "version_added": false
@@ -96,7 +96,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "16"
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": false
@@ -181,7 +181,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "16"
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": false
@@ -266,7 +266,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "16"
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": false
@@ -351,7 +351,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "16"
+              "version_added": "14"
             },
             "edge_mobile": {
               "version_added": false
@@ -436,7 +436,7 @@
               "version_added": "59"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -487,7 +487,7 @@
               "version_added": "59"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -538,7 +538,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "16"
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": false


### PR DESCRIPTION
The current data is from https://github.com/mdn/browser-compat-data/pull/849.

Running https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=6670
in Edge 13-18, it appears that the contructor, `pipeThrough`, `pipeTo`
and `tee` aren't supported at all even in Edge 18.