### PR TITLE
Update the support status for `initAnimationEvent`

### DIFF
--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -284,10 +284,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEvent/initAnimationEvent",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": false
             },
             "edge": {
               "version_added": "12",
@@ -308,22 +308,24 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "10"
+              "version_added": "10",
+              "version_removed": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "15"
             },
             "safari": {
-              "version_added": "4"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {

--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -284,7 +284,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEvent/initAnimationEvent",
           "support": {
             "chrome": {
-              "version_added": false
+              "alternative_name": "initWebKitAnimationEvent",
+              "version_added": true,
+              "version_removed": "18"
             },
             "chrome_android": {
               "version_added": false
@@ -316,10 +318,14 @@
               "version_removed": "15"
             },
             "safari": {
-              "version_added": false
+              "alternative_name": "initWebKitAnimationEvent",
+              "version_added": true,
+              "version_removed": "6"
             },
             "safari_ios": {
-              "version_added": false
+              "alternative_name": "initWebKitAnimationEvent",
+              "version_added": true,
+              "version_removed": "6"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
`initAnimationEvent` was never supported in WebKit, confirmed by

`git log -S initAnimationEvent` in the WebKit source tree, where the
only cases are in a test from Chakra [1] and in spec drafts [2], not
in any code.

Also confirmed by testing various old versions of Chrome and Safari with:
https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=6671
https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=6672

A `initWebKitAnimationEvent` was supported, but it was removed in 2011:
https://trac.webkit.org/changeset/103751/webkit

Every WebKit- and Blink-based browser should therefore not support
this. For Opera, which did support it with Presto, set it to removed
in version 15, the first Chromium-based Opera release.

[1] https://trac.webkit.org/changeset/205387/webkit
[2] https://trac.webkit.org/changeset/66236/webkit