### PR TITLE
[Chrome] Webview also supports destination.

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -857,7 +857,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "65"
             }
           },
           "status": {


### PR DESCRIPTION
Generally, whatever is in Chrome for Android is in webview. Here's data showing that `Request.destination` landed in 65. https://storage.googleapis.com/chromium-find-releases-static/e98.html#e98a80cde1a08624aaf6c9a06a816991059991af

Out test code keeps a list of things that are **not** in webview. Please note the absence of `Request.destination`. https://cs.chromium.org/chromium/src/android_webview/tools/system_webview_shell/test/data/webexposed/not-webview-exposed.txt