### PR TITLE
adding webvr eventcompat data

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1518,6 +1518,108 @@
           }
         }
       },
+      "onvrdisplaypointerrestricted": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplaypointerrestricted",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onvrdisplaypointerunrestricted": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onvrdisplaypointerunrestricted",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "crypto": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/crypto",
@@ -7443,6 +7545,545 @@
             },
             "webview_android": {
               "version_added": "60"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vrdisplayactivate": {
+        "__compat": {
+          "description": "<code>vrdisplayactivate</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplayactivate_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
+              }
+            ],
+            "firefox_android": {
+              "version_added": "55"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vrdisplayblur": {
+        "__compat": {
+          "description": "<code>vrdisplayblur</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplayblur_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vrdisplayconnect": {
+        "__compat": {
+          "description": "<code>vrdisplayconnect</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplayconnect_event",
+          "support": {
+            "chrome": {
+              "version_added": false,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": true,
+              "notes": [
+                "Chrome for Android 56 supports only Google Daydream View.",
+                "Chrome for Android 57 adds support for Google Cardboard."
+              ]
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
+              }
+            ],
+            "firefox_android": {
+              "version_added": "55"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Supported on Samsung Internet for GearVR."
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vrdisplaydeactivate": {
+        "__compat": {
+          "description": "<code>vrdisplaydeactivate</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplaydeactivate_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
+              }
+            ],
+            "firefox_android": {
+              "version_added": "55"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vrdisplaydisconnect": {
+        "__compat": {
+          "description": "<code>vrdisplaydisconnect</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplaydisconnect_event",
+          "support": {
+            "chrome": {
+              "version_added": false,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": "56",
+              "notes": [
+                "Chrome for Android 56 supports only Google Daydream View.",
+                "Chrome for Android 57 adds support for Google Cardboard."
+              ]
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
+              }
+            ],
+            "firefox_android": {
+              "version_added": "55"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Supported on Samsung Internet for GearVR."
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vrdisplayfocus": {
+        "__compat": {
+          "description": "<code>vrdisplayfocus</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplayfocus_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vrdisplaypresentchange": {
+        "__compat": {
+          "description": "<code>vrdisplaypresentchange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplaypresentchange_event",
+          "support": {
+            "chrome": {
+              "version_added": "65",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebVR",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": "56",
+              "notes": [
+                "Chrome for Android 56 supports only Google Daydream View.",
+                "Chrome for Android 57 adds support for Google Cardboard."
+              ]
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "55",
+                "notes": "Windows support was enabled in Firefox 55."
+              },
+              {
+                "version_added": "64",
+                "notes": "macOS support was enabled in Firefox 64."
+              }
+            ],
+            "firefox_android": {
+              "version_added": "55"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Supported on Samsung Internet for GearVR."
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vrdisplaypointerrestricted": {
+        "__compat": {
+          "description": "<code>vrdisplaypointerrestricted</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplaypointerrestricted_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vrdisplaypointerunrestricted": {
+        "__compat": {
+          "description": "<code>vrdisplaypointerunrestricted</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplaypointerunrestricted_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -7554,7 +7554,7 @@
           }
         }
       },
-      "vrdisplayactivate": {
+      "vrdisplayactivate_event": {
         "__compat": {
           "description": "<code>vrdisplayactivate</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplayactivate_event",
@@ -7613,7 +7613,7 @@
           }
         }
       },
-      "vrdisplayblur": {
+      "vrdisplayblur_event": {
         "__compat": {
           "description": "<code>vrdisplayblur</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplayblur_event",
@@ -7665,7 +7665,7 @@
           }
         }
       },
-      "vrdisplayconnect": {
+      "vrdisplayconnect_event": {
         "__compat": {
           "description": "<code>vrdisplayconnect</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplayconnect_event",
@@ -7736,7 +7736,7 @@
           }
         }
       },
-      "vrdisplaydeactivate": {
+      "vrdisplaydeactivate_event": {
         "__compat": {
           "description": "<code>vrdisplaydeactivate</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplaydeactivate_event",
@@ -7795,7 +7795,7 @@
           }
         }
       },
-      "vrdisplaydisconnect": {
+      "vrdisplaydisconnect_event": {
         "__compat": {
           "description": "<code>vrdisplaydisconnect</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplaydisconnect_event",
@@ -7866,7 +7866,7 @@
           }
         }
       },
-      "vrdisplayfocus": {
+      "vrdisplayfocus_event": {
         "__compat": {
           "description": "<code>vrdisplayfocus</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplayfocus_event",
@@ -7918,7 +7918,7 @@
           }
         }
       },
-      "vrdisplaypresentchange": {
+      "vrdisplaypresentchange_event": {
         "__compat": {
           "description": "<code>vrdisplaypresentchange</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplaypresentchange_event",
@@ -7989,7 +7989,7 @@
           }
         }
       },
-      "vrdisplaypointerrestricted": {
+      "vrdisplaypointerrestricted_event": {
         "__compat": {
           "description": "<code>vrdisplaypointerrestricted</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplaypointerrestricted_event",
@@ -8041,7 +8041,7 @@
           }
         }
       },
-      "vrdisplaypointerunrestricted": {
+      "vrdisplaypointerunrestricted_event": {
         "__compat": {
           "description": "<code>vrdisplaypointerunrestricted</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/vrdisplaypointerunrestricted_event",


### PR DESCRIPTION
As per https://github.com/mdn/sprints/issues/948.

As well as adding compat data for the seven events listed here, I also added compat data for

vrdisplaypointerrestricted event
onvrdisplaypointerrestricted
vrdisplaypointerunrestricted event
onvrdisplaypointerunrestricted