### PR TITLE
[Chrome] Add/correct relList version number.

### DIFF
--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -361,10 +361,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/relList",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "65"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "65"
             },
             "edge": {
               "version_added": "18"
@@ -397,7 +397,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "65"
             }
           },
           "status": {

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -514,10 +514,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/relList",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "65"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "65"
             },
             "edge": {
               "version_added": "18"
@@ -550,7 +550,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "65"
             }
           },
           "status": {

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -244,10 +244,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/relList",
           "support": {
             "chrome": {
-              "version_added": "50"
+              "version_added": "54"
             },
             "chrome_android": {
-              "version_added": "50"
+              "version_added": "54"
             },
             "edge": {
               "version_added": "17"
@@ -277,7 +277,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "50"
+              "version_added": "54"
             }
           },
           "status": {


### PR DESCRIPTION
For `HTMLAnchorElement` and `HTMLAreaElement`: https://storage.googleapis.com/chromium-find-releases-static/81d.html#81dfadbe1460bc740a695c2d9b2abeda412b9d68

for `HTMLLinkElement`: https://storage.googleapis.com/chromium-find-releases-static/77f.html#77fbfc4061196ea9c83c24891aab37850157600a