### PR TITLE
[Chrome] Add AudioWorklet data.

### DIFF
--- a/api/AudioParamMap.json
+++ b/api/AudioParamMap.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParamMap",
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": "66"
           },
           "chrome_android": {
-            "version_added": "61"
+            "version_added": "66"
           },
           "edge": {
             "version_added": null
@@ -41,7 +41,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": "61"
+            "version_added": "66"
           }
         },
         "status": {
@@ -50,15 +50,66 @@
           "deprecated": false
         }
       },
+      "entries": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParamMap/entries",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "forEach": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParamMap/forEach",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "66"
             },
             "edge": {
               "version_added": null
@@ -91,7 +142,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "66"
             }
           },
           "status": {
@@ -106,10 +157,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParamMap/get",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "66"
             },
             "edge": {
               "version_added": null
@@ -142,7 +193,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "66"
             }
           },
           "status": {
@@ -157,10 +208,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParamMap/has",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "66"
             },
             "edge": {
               "version_added": null
@@ -193,7 +244,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "66"
             }
           },
           "status": {
@@ -208,10 +259,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParamMap/keys",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "66"
             },
             "edge": {
               "version_added": null
@@ -244,7 +295,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "66"
             }
           },
           "status": {
@@ -259,10 +310,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParamMap/size",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "66"
             },
             "edge": {
               "version_added": null
@@ -295,7 +346,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "66"
             }
           },
           "status": {
@@ -310,10 +361,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParamMap/values",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "66"
             },
             "edge": {
               "version_added": null
@@ -346,7 +397,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "66"
             }
           },
           "status": {

--- a/api/AudioWorklet.json
+++ b/api/AudioWorklet.json
@@ -1,0 +1,56 @@
+{
+  "api": {
+    "AudioWorklet": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorklet",
+        "support": {
+          "chrome": {
+            "version_added": "66"
+          },
+          "chrome_android": {
+            "version_added": "66"
+          },
+          "edge": {
+            "version_added": null
+          },
+          "edge_mobile": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": null
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          },
+          "samsunginternet_android": {
+            "version_added": null
+          },
+          "webview_android": {
+            "version_added": "66"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+
+    }
+  }
+}

--- a/api/AudioWorklet.json
+++ b/api/AudioWorklet.json
@@ -49,7 +49,7 @@
           "standard_track": true,
           "deprecated": false
         }
-      },
+      }
 
     }
   }

--- a/api/AudioWorklet.json
+++ b/api/AudioWorklet.json
@@ -50,7 +50,6 @@
           "deprecated": false
         }
       }
-
     }
   }
 }

--- a/api/AudioWorkletNode.json
+++ b/api/AudioWorkletNode.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": "66"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "66"
           },
           "edge": {
             "version_added": null
@@ -41,7 +41,7 @@
             "version_added": null
           },
           "webview_android": {
-            "version_added": null
+            "version_added": "66"
           }
         },
         "status": {
@@ -55,10 +55,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/onprocessorstatechange",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "66"
             },
             "edge": {
               "version_added": null
@@ -91,7 +91,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "66"
             }
           },
           "status": {
@@ -106,10 +106,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/parameters",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "66"
             },
             "edge": {
               "version_added": null
@@ -142,7 +142,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "66"
             }
           },
           "status": {
@@ -157,10 +157,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/port",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "66"
             },
             "edge": {
               "version_added": null
@@ -193,7 +193,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "66"
             }
           },
           "status": {
@@ -208,10 +208,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/processorState",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -244,7 +244,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/api/AudioWorkletProcessor.json
+++ b/api/AudioWorkletProcessor.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletProcessor",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": "66"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "66"
           },
           "edge": {
             "version_added": null
@@ -41,7 +41,7 @@
             "version_added": null
           },
           "webview_android": {
-            "version_added": null
+            "version_added": "66"
           }
         },
         "status": {
@@ -55,10 +55,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletProcessor/port",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "66"
             },
             "edge": {
               "version_added": null
@@ -91,7 +91,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "66"
             }
           },
           "status": {

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -62,10 +62,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/audioWorklet",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "66"
             },
             "edge": {
               "version_added": null
@@ -98,7 +98,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "66"
             }
           },
           "status": {


### PR DESCRIPTION
This PR provides all items in a Chrome CL that landed in 66: https://storage.googleapis.com/chromium-find-releases-static/b38.html#b38d192d113384bc10627d88094aa43ed4541cb0

The IDL for `AudioParamMap` shows `maplike` instead of individual members. This IDL attribute is defined in the IDL spec for all the member listed in AudioParamMap.json. https://heycam.github.io/webidl/#idl-maplike

**Note:** The data in Confluence for `AudioWorkletNode` as landing in 67. I have [filed a ticket](https://github.com/GoogleChromeLabs/confluence/issues/349).