### PR TITLE
Object.assign was added in Opera for Android 32

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -421,7 +421,7 @@
                 "version_added": "32"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "32"
               },
               "safari": {
                 "version_added": "9"


### PR DESCRIPTION
Since it used Chromium 45.

Data: https://help.opera.com/en/opera-version-history/
Opera main version number reflects Chromium version but `- 13`.