### PR TITLE
[Chrome,Safari] Update CSSStyleRule.

### DIFF
--- a/api/CSSStyleRule.json
+++ b/api/CSSStyleRule.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleRule",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "37"
           }
         },
         "status": {
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleRule/selectorText",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -93,13 +93,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -114,10 +114,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleRule/style",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -141,13 +141,61 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "styleMap": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleRule/style",
+          "support": {
+            "chrome": {
+              "version_added": "65"
+            },
+            "chrome_android": {
+              "version_added": "65"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "65"
             }
           },
           "status": {

--- a/api/CSSStyleRule.json
+++ b/api/CSSStyleRule.json
@@ -159,7 +159,7 @@
       },
       "styleMap": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleRule/style",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleRule/styleMap",
           "support": {
             "chrome": {
               "version_added": "65"


### PR DESCRIPTION
* Safari changes are from Confluence
* `CSSStyleRule` landed in Chrome in version 1 containing `selectorText` and `style`: https://chromium.googlesource.com/chromium/src/+/40e856b910e02f7d0f2644b3ab5204568806706b/third_party/WebKit/WebCore/css/CSSStyleRule.idl
* `.styleMap` was [behind a runtime flag called `CSSPaintAPI`](https://chromium.googlesource.com/chromium/src/+/adc4f1e5aa8b792e2a9a4fb359a7d4e0855c3e77). It was flipped to stable here: https://storage.googleapis.com/chromium-find-releases-static/9df.html#9df518ea41271fef3a3b4b9b85164b632092c5db
 
