### PR TITLE
New Element data for several items.

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -391,7 +391,7 @@
       },
       "attributeStyleMap": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/attributes",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/attributeStyleMap",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/Element.json
+++ b/api/Element.json
@@ -389,6 +389,57 @@
           }
         }
       },
+      "attributeStyleMap": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/attributes",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "classList": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/classList",
@@ -611,7 +662,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": true
+              "version_added": "13"
             },
             "edge_mobile": {
               "version_added": true
@@ -3737,7 +3788,7 @@
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "edge": {
-              "version_added": true
+              "version_added": "13"
             },
             "edge_mobile": {
               "version_added": true
@@ -5885,7 +5936,7 @@
               "version_added": "56"
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
               "version_added": null


### PR DESCRIPTION
* Adds `attributeStyleMap` property (Houdini related). I was unable to track down the commit where its runtime flag was flipped to stable. Confluence shows that it [arrived in Chrome 66](http://web-confluence.appspot.com/#!/catalog?releases=%5B%22Chrome_64.0.3282.119_OSX_10.11.6%22,%22Chrome_65.0.3325.146_OSX_10.11.6%22,%22Chrome_66.0.3359.117_OSX_10.11.6%22,%22Chrome_67.0.3396.62_OSX_10.13.4%22%5D&q=%22attributeStyleMap%22).
* Weirdly, this property didn't show up when I ran the confluence command; however that command supplied some Edge and Safari numbers, which I left in the PR.