### PR TITLE
[Chrome,Safari] Improvements to HTMLElement.

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -143,6 +143,54 @@
           }
         }
       },
+      "autoCapitalize": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/autoCapitalize",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "blur": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/blur",
@@ -821,6 +869,57 @@
             },
             "webview_android": {
               "version_added": "37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "inputMode": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/inputMode",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "66"
             }
           },
           "status": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "webview_android": {
-            "version_added": "37"
+            "version_added": true
           }
         },
         "status": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2119,7 +2119,7 @@
               "version_added": "19"
             },
             "chrome_android": {
-              "version_added": "19"
+              "version_added": "25"
             },
             "edge": {
               "version_added": false

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "37"
           }
         },
         "status": {
@@ -55,7 +55,7 @@
               "version_added": "17"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -79,13 +79,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "37"
             }
           },
           "status": {
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/accessKeyLabel",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -133,7 +133,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -148,10 +148,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/blur",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -175,13 +175,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "37"
             }
           },
           "status": {
@@ -200,7 +200,8 @@
               "notes": "Before Chrome 19, <code>click</code> is only defined on buttons and inputs."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18",
+              "notes": "Before Chrome 19, <code>click</code> is only defined on buttons and inputs."
             },
             "edge": {
               "version_added": "12"
@@ -225,7 +226,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true,
+              "version_added": "6",
               "notes": "Before Safari 6, <code>click</code> is only defined on buttons and inputs."
             },
             "safari_ios": {
@@ -249,10 +250,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/contentEditable",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -276,13 +277,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -297,10 +298,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/contextMenu",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "45",
+              "version_removed": "61"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45",
+              "version_removed": "61"
             },
             "edge": {
               "version_added": true
@@ -330,7 +333,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "45",
+              "version_removed": "61"
             }
           },
           "status": {
@@ -348,7 +352,7 @@
               "version_added": "8"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -372,13 +376,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "37"
             }
           },
           "status": {
@@ -393,10 +397,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/dir",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -420,13 +424,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -441,10 +445,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/draggable",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -468,13 +472,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -489,10 +493,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/dropzone",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "14",
+              "version_removed": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18",
+              "version_removed": "59"
             },
             "edge": {
               "version_added": true
@@ -522,7 +528,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37",
+              "version_removed": "59"
             }
           },
           "status": {
@@ -537,10 +544,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/focus",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -564,13 +571,13 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "37"
             }
           },
           "status": {
@@ -636,7 +643,7 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -666,7 +673,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
@@ -681,7 +688,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
               "version_added": true
@@ -708,7 +715,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": null
@@ -777,10 +784,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/innerText",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -813,7 +820,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -828,10 +835,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/isContentEditable",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -855,13 +862,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -876,10 +883,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/itemId",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "17",
+              "version_removed": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18",
+              "version_removed": "28"
             },
             "edge": {
               "version_added": false
@@ -910,7 +919,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
@@ -925,10 +934,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/itemProp",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "17",
+              "version_removed": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18",
+              "version_removed": "28"
             },
             "edge": {
               "version_added": false
@@ -959,7 +970,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
@@ -974,10 +985,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/itemRef",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "17",
+              "version_removed": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18",
+              "version_removed": "28"
             },
             "edge": {
               "version_added": false
@@ -1008,7 +1021,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
@@ -1023,10 +1036,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/itemScope",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "17",
+              "version_removed": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18",
+              "version_removed": "28"
             },
             "edge": {
               "version_added": false
@@ -1057,7 +1072,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
@@ -1072,10 +1087,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/itemType",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "17",
+              "version_removed": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18",
+              "version_removed": "28"
             },
             "edge": {
               "version_added": false
@@ -1106,7 +1123,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
@@ -1121,10 +1138,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/itemValue",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "17",
+              "version_removed": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18",
+              "version_removed": "28"
             },
             "edge": {
               "version_added": false
@@ -1155,7 +1174,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
@@ -1170,10 +1189,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/lang",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1197,13 +1216,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -1314,10 +1333,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetHeight",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "edge": {
               "version_added": "12"
@@ -1341,13 +1360,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "47"
             }
           },
           "status": {
@@ -1362,10 +1381,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetLeft",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "edge": {
               "version_added": "12"
@@ -1389,13 +1408,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "47"
             }
           },
           "status": {
@@ -1410,10 +1429,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetParent",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "edge": {
               "version_added": "12"
@@ -1437,13 +1456,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "47"
             }
           },
           "status": {
@@ -1458,10 +1477,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetWidth",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "edge": {
               "version_added": "12"
@@ -1485,13 +1504,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "47"
             }
           },
           "status": {
@@ -1506,10 +1525,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetWidth",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "edge": {
               "version_added": "12"
@@ -1533,13 +1552,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "47"
             }
           },
           "status": {
@@ -1602,10 +1621,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/oncopy",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "71"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "71"
             },
             "edge": {
               "version_added": "12"
@@ -1635,7 +1654,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "71"
             }
           },
           "status": {
@@ -1650,10 +1669,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/oncut",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "71"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "71"
             },
             "edge": {
               "version_added": "12"
@@ -1683,7 +1702,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "71"
             }
           },
           "status": {
@@ -1698,10 +1717,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/onpaste",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "71"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "71"
             },
             "edge": {
               "version_added": "12"
@@ -1731,7 +1750,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "71"
             }
           },
           "status": {
@@ -1746,10 +1765,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/outerText",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -1773,13 +1792,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -1794,10 +1813,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/spellcheck",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -1821,13 +1840,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -1842,10 +1861,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/style",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "12"
@@ -1870,13 +1889,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "45"
             }
           },
           "status": {
@@ -1891,10 +1910,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/tabIndex",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": [
               {
@@ -1929,13 +1948,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -1950,10 +1969,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/title",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1977,13 +1996,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -1998,10 +2017,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/translate",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "19"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "19"
             },
             "edge": {
               "version_added": false
@@ -2025,13 +2044,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {


### PR DESCRIPTION
* Items for Safari are from Confluence
* Here’s what was in Chrome 1. https://chromium.googlesource.com/chromium/src/+/b9679dc82ba724084429364f1422edc917772a2a/third_party/WebKit/WebCore/html/HTMLElement.idl
* Here’s the current state showing items I marked `false`: https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/html/html_element.idl?q=HTMLElement+f:.idl+file:%5Esrc/third_party/blink/renderer/+package:%5Echromium$&dr=C&l=21
* `contextMenu` was added in 45, here: https://storage.googleapis.com/chromium-find-releases-static/d92.html#d92527e8f6032374056532d57dd086eea859992c 
* `contextMenu` was removed in 61, here: https://storage.googleapis.com/chromium-find-releases-static/e90.html#e90a0487386316a1e97f69159f20fbe5933cb3b9
* `draggable` is too old to be in Omaha Proxy, but its PR is July 14, 2009, which puts it in range for Chrome 7: https://chromium.googlesource.com/chromium/src/+/726e9fa405761cf5870266ed184da3812309e81b
* `dropzone` was removed in 59, here: https://storage.googleapis.com/chromium-find-releases-static/798.html#798a0d0b8b42492f3acd803caa2ce0b35b8b29d2
* `dropzone` is too old to be in Omaha Proxy, but its PR is May 27, 2011, which puts it in range for Chrome 14: https://chromium.googlesource.com/chromium/src/+/947f0135b2cd186d2d17e495ed1ea6a8d181697a
* I can find no evidence that `forceSpellCheck` is or ever has been supported.
* `hidden` is too old to be in Omaha Proxy, but its PR is June 24, 2010, which puts it in range for an extremely early version of Chrome. 
* `itemId`, `itemProp`, `itemRef` `itemScope`, `itemType`, `itemValue` are too old to be in Omaha Proxy, but their *Removal* PR is April 12, 2013, which puts them in range for Chrome 28: https://chromium.googlesource.com/chromium/src/+/cafe0dbac468f3686a74aa4587909f1d9b442ed0
* `itemId` is too old to be in Omaha Proxy, but its PR is October 31, 2011, which puts it in range for Chrome 17: https://chromium.googlesource.com/chromium/src/+/8e5511d74bcb367fe6b2c3d87c95126b8b2b67da
* `itemProp`, `itemRef`, `itemScope`, `itemType`, `itemValue` are too old to be in Omaha Proxy, but their PR is October 25, 2011, which puts them in range for Chrome 17: https://chromium.googlesource.com/chromium/src/+/534b26ad510a61a360b3f5df52703f32523d7e3f
* `translate` was added on Feb 17, 2012, which puts it in range for Chrome 19: https://chromium.googlesource.com/chromium/src/+/a79c634d822b4fe74293d58884aeae7e8d7b1cf1
* `autoCapitalize` is in Chrome 66: https://storage.googleapis.com/chromium-find-releases-static/1de.html#1de83967752e0cf4f36f3a013b4f1ab687b88e11
* `inputMode` [This shows that ](https://chromium.googlesource.com/chromium/src/+/1de83967752e0cf4f36f3a013b4f1ab687b88e11/third_party/WebKit/Source/core/html/HTMLElement.idl) it was behind a flag called `inputModeAttribute`. This flag was set to stable in Chrome 66 https://storage.googleapis.com/chromium-find-releases-static/5ba.html#5ba5958247e67477d72d0b12d1b32ce557cbded6
