### PR TITLE
[Chrome] Correct/update Request.

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -1044,7 +1044,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "66"
             }
           },
           "status": {
@@ -1421,10 +1421,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/signal",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "66"
             },
             "edge": {
               "version_added": "16"
@@ -1457,7 +1457,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "66"
             }
           },
           "status": {


### PR DESCRIPTION
* The `keepAlive` property is supported as show by [this file in our webview test system](https://cs.chromium.org/chromium/src/android_webview/tools/system_webview_shell/test/data/webexposed/global-interface-listing-expected.txt?g=0&l=4693).
* The `signal` property [landed in 66](https://storage.googleapis.com/chromium-find-releases-static/c63.html#c631f71be2e78da5d3ca2cb4dc1a05e08ac5930c).