### PR TITLE
[Chrome] Version numbers for RTCDTMFSender.

### DIFF
--- a/api/RTCDTMFSender.json
+++ b/api/RTCDTMFSender.json
@@ -41,7 +41,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": "37"
+            "version_added": true
           }
         },
         "status": {
@@ -91,7 +91,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": true
             }
           },
           "status": {
@@ -142,7 +142,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": true
             }
           },
           "status": {
@@ -193,7 +193,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": true
             }
           },
           "status": {
@@ -244,7 +244,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": true
             }
           },
           "status": {

--- a/api/RTCDTMFSender.json
+++ b/api/RTCDTMFSender.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDTMFSender",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "27"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "27"
           },
           "edge": {
             "version_added": null
@@ -41,7 +41,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "37"
           }
         },
         "status": {
@@ -55,10 +55,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDTMFSender/toneBuffer",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "27"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "edge": {
               "version_added": null
@@ -91,7 +91,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -106,10 +106,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDTMFSender/ontonechange",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "27"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "edge": {
               "version_added": null
@@ -142,7 +142,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -157,10 +157,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDTMFSender/insertDTMF",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "27"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "edge": {
               "version_added": null
@@ -193,7 +193,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -208,10 +208,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDTMFSender/canInsertDTMF",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "27"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "27"
             },
             "edge": {
               "version_added": null
@@ -244,7 +244,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "37"
             }
           },
           "status": {


### PR DESCRIPTION
The first version of this landed [on Feb 6, 2013](https://chromium.googlesource.com/chromium/src/+/87a94142bbc06d32cba1b7c84192b165bed34854). It’s not in Omaha Proxy, but the date puts it in Chrome 27.