### PR TITLE
Fix capitalization of the WebKitMutationObserver prefix

### DIFF
--- a/api/MutationObserver.json
+++ b/api/MutationObserver.json
@@ -11,7 +11,7 @@
             {
               "version_added": "18",
               "version_removed": "26",
-              "prefix": "Webkit"
+              "prefix": "WebKit"
             }
           ],
           "chrome_android": [
@@ -21,7 +21,7 @@
             {
               "version_added": "18",
               "version_removed": "26",
-              "prefix": "Webkit"
+              "prefix": "WebKit"
             }
           ],
           "edge": {
@@ -52,7 +52,7 @@
             {
               "version_added": "6",
               "version_removed": "7",
-              "prefix": "Webkit"
+              "prefix": "WebKit"
             }
           ],
           "safari_ios": [
@@ -62,7 +62,7 @@
             {
               "version_added": "6",
               "version_removed": "7",
-              "prefix": "Webkit"
+              "prefix": "WebKit"
             }
           ],
           "samsunginternet_android": {
@@ -75,7 +75,7 @@
             {
               "version_added": true,
               "version_removed": true,
-              "prefix": "Webkit"
+              "prefix": "WebKit"
             }
           ]
         },
@@ -97,7 +97,7 @@
               {
                 "version_added": "18",
                 "version_removed": "26",
-                "prefix": "Webkit"
+                "prefix": "WebKit"
               }
             ],
             "chrome_android": [
@@ -107,7 +107,7 @@
               {
                 "version_added": "18",
                 "version_removed": "26",
-                "prefix": "Webkit"
+                "prefix": "WebKit"
               }
             ],
             "edge": {
@@ -138,7 +138,7 @@
               {
                 "version_added": "6",
                 "version_removed": "7",
-                "prefix": "Webkit"
+                "prefix": "WebKit"
               }
             ],
             "safari_ios": [
@@ -148,7 +148,7 @@
               {
                 "version_added": "6",
                 "version_removed": "7",
-                "prefix": "Webkit"
+                "prefix": "WebKit"
               }
             ],
             "samsunginternet_android": {
@@ -161,7 +161,7 @@
               {
                 "version_added": true,
                 "version_removed": true,
-                "prefix": "Webkit"
+                "prefix": "WebKit"
               }
             ]
           },


### PR DESCRIPTION
The name of the interface was `WebKitMutationObserver`, confirmed by
Confluence data and search WebKit source for `WebKitMutationObserver`
(many hits) and `WebkitMutationObserver` (no hits).