### PR TITLE
[Chrome] Fill in Android data for background.

### DIFF
--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -59,7 +59,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -110,7 +110,7 @@
                 "version_added": "31"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "31"
               },
               "edge": {
                 "version_added": "12"
@@ -161,7 +161,7 @@
                 "version_added": "21"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"
@@ -212,7 +212,7 @@
                 "version_added": "21"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"
@@ -263,7 +263,7 @@
                 "version_added": "21"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"


### PR DESCRIPTION
This one is based on the fact that except in very rare circumstances, whatever lands in desktop, lands in Android. Some of the items landed in Chrome 21. Since there was no Chrome for Android 21, those features arrived in the next Chrome for Android version, which happened to be 25. 