### PR TITLE
[Chrome] Ignore <a download> for cross-origin URLs.

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -166,7 +166,7 @@
               },
               "chrome_android": {
                 "version_added": "18",
-                "notes": "Starting in Chrome 65, cross-origin downloads are not supported on the anchor element."
+                "notes": "Starting in Chrome 65, cross-origin downloads are not supported on the <code>&lt;a&gt;</code> element."
               },
               "edge": [
                 {

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -162,7 +162,7 @@
             "support": {
               "chrome": {
                 "version_added": "14",
-                "notes": "Starting in Chrome 65, cross-origin downloads are not supported on the anchor element."
+                "notes": "Starting in Chrome 65, cross-origin downloads are not supported on the <code>&lt;a&gt;</code> element."
               },
               "chrome_android": {
                 "version_added": "18",

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -210,7 +210,7 @@
               },
               "webview_android": {
                 "version_added": true,
-                "notes": "Starting in Chrome 65, cross-origin downloads are not supported on the anchor element."
+                "notes": "Starting in WebView 65, cross-origin downloads are not supported on the <code>&lt;a&gt;</code> element."
               }
             },
             "status": {

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -161,10 +161,12 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Starting in Chrome 65, cross-origin downloads are not supported on the anchor element."
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18",
+                "notes": "Starting in Chrome 65, cross-origin downloads are not supported on the anchor element."
               },
               "edge": [
                 {
@@ -207,7 +209,8 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "37",
+                "notes": "Starting in Chrome 65, cross-origin downloads are not supported on the anchor element."
               }
             },
             "status": {

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -209,7 +209,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": "37",
+                "version_added": true,
                 "notes": "Starting in Chrome 65, cross-origin downloads are not supported on the anchor element."
               }
             },


### PR DESCRIPTION
https://storage.googleapis.com/chromium-find-releases-static/2a6.html#2a6afcb26ba6cd2324ddaa366b11968237e304a3