### PR TITLE
Reland #2058 (mark periodicSync as unsupported)

### DIFF
--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -488,7 +488,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -319,31 +319,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/onupdatefound",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "40"
             },
-            "edge": {
-              "version_added": "17"
-            },
+            "edge": [
+              {
+                "version_added": "17"
+              },
+              {
+                "version_added": "16",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable service workers"
+                  }
+                ]
+              }
+            ],
             "edge_mobile": {
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "44",
+              "notes": "Service workers (and Push) have been disabled in the Firefox 45 and 52 Extended Support Releases (ESR)."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "27"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "27"
             },
             "safari": {
               "version_added": "11.1"
@@ -352,10 +364,10 @@
               "version_added": "11.1"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "40"
             }
           },
           "status": {
@@ -440,17 +452,29 @@
             "chrome_android": {
               "version_added": "40"
             },
-            "edge": {
-              "version_added": null
-            },
+            "edge": [
+              {
+                "version_added": "16",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable service workers"
+                  }
+                ]
+              },
+              {
+                "version_added": "17"
+              }
+            ],
             "edge_mobile": {
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "44",
+              "notes": "Service workers (and Push) have been disabled in the Firefox 45 and 52 Extended Support Releases (ESR)."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "44"
             },
             "ie": {
               "version_added": false

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -447,55 +447,43 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/periodicSync",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": false
             },
-            "edge": [
-              {
-                "version_added": "16",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable service workers"
-                  }
-                ]
-              },
-              {
-                "version_added": "17"
-              }
-            ],
+            "edge": {
+              "version_added": false
+            },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "Service workers (and Push) have been disabled in the Firefox 45 and 52 Extended Support Releases (ESR)."
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "27"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "27"
+              "version_added": false
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "49"
+              "version_added": false
             }
           },
           "status": {
@@ -1061,29 +1049,17 @@
             "chrome_android": {
               "version_added": "49"
             },
-            "edge": [
-              {
-                "version_added": "17"
-              },
-              {
-                "version_added": "16",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable service workers"
-                  }
-                ]
-              }
-            ],
+            "edge": {
+              "version_added": null
+            },
             "edge_mobile": {
               "version_added": null
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "Service workers (and Push) have been disabled in the Firefox 45 and 52 Extended Support Releases (ESR)."
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -1095,20 +1071,16 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "45",
-              "notes": [
-                "Starting with Chrome 46, update() returns a promise that resolves with 'undefined' if the operation completed successfully or there was no update, and rejects if update failed. If the new worker ran but installation failed, the promise still resolves. Formerly, it raised an exception.",
-                "Before Chrome 48, this method always bypassed the browser cache. Starting with Chrome 48, it only bypasses the cache when the previous service worker check was more than twenty-four hours ago."
-              ]
+              "version_added": "49"
             }
           },
           "status": {


### PR DESCRIPTION
This is relanding #2058 from @mantou132 as the merge commit bea2202 didn't change the correct sections of the file.