### PR TITLE
[Chrome] Add Bug Note for Intl.DateTimeFormat.formatToParts

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -717,11 +717,11 @@
               "support": {
                 "chrome": {
                   "version_added": "57",
-                  "notes": "Before version 71, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 71 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>"
+                  "notes": "Before version 71, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 71 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>."
                 },
                 "chrome_android": {
                   "version_added": "57",
-                  "notes": "Before version 71, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 71 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>"
+                  "notes": "Before version 71, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 71 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>."
                 },
                 "edge": {
                   "version_added": true
@@ -757,7 +757,8 @@
                   "version_added": "7.0"
                 },
                 "webview_android": {
-                  "version_added": "57"
+                  "version_added": "57",
+                  "notes": "Before version 71, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 71 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>."
                 }
               },
               "status": {

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -716,10 +716,12 @@
               "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.DateTimeFormat.prototype.formatToParts",
               "support": {
                 "chrome": {
-                  "version_added": "57"
+                  "version_added": "57",
+                  "notes": "Before version 71, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 71 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>"
                 },
                 "chrome_android": {
-                  "version_added": "57"
+                  "version_added": "57",
+                  "notes": "Before version 71, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 71 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>"
                 },
                 "edge": {
                   "version_added": true


### PR DESCRIPTION
Adds a note on a chromium bug in versions prior to 71, that caused Intl.DateTimeFormat.formatToParts to return a key that was incorrectly cased (`dayperiod` instead of `dayPeriod`)

See https://crbug.com/865351 for details

Confirmed the bug using `Chrome Version 70.0.3538.77 (Official Build) (64-bit)` on Linux 
No related issue or PR for this that I found.

I didn't see any notes on commit title/message formatting, but let me know if it needs to be amended