### PR TITLE
Add TransitionEvent.propertyName support to Chromium et-al

### DIFF
--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/TransitionEvent",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "2"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": true

--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -149,10 +149,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TransitionEvent/propertyName",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -182,7 +182,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -149,10 +149,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TransitionEvent/propertyName",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"


### PR DESCRIPTION
Adding this flag as the property in question is supported since the beginning of time.

See for example a blob from 2013 where it's present:

https://chromium.googlesource.com/chromium/blink/+/2b50b8af2f44f8be3308ac430692422aa2b8cea7/Source/WebCore/dom/TransitionEvent.cpp