### PR TITLE
Add Chrome version data for performance.getEntries/webkitGetEntries

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -216,9 +216,16 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Performance/getEntries",
           "support": {
-            "chrome": {
-              "version_added": true
-            },
+            "chrome": [
+              {
+                "version_added": "28"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "25",
+                "version_removed": "36"
+              }
+            ],
             "chrome_android": {
               "version_added": true
             },


### PR DESCRIPTION
Using https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=6714 in
Chrome 24-28, 35 and 36 on BrowserStack.

Safari 10-11 also tested to verify that data, Safari didn't ship the
prefixed variant.