### PR TITLE
setting periodicsync support data to false, as it was never implement…

### DIFF
--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -435,16 +435,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/periodicSync",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -456,27 +456,27 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "27"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "27"
+              "version_added": false
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "49"
+              "version_added": false
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
+            "experimental": false,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -435,7 +435,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/periodicSync",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true,
+              "version_removed": 48
             },
             "chrome_android": {
               "version_added": false


### PR DESCRIPTION
…ed anywhere

After a [conversation on Twitter](https://twitter.com/jaffathecake/status/1100307442477486080), we realised that `periodicSync` was never implemented anywhere. It was mentioned in the explainer briefly at some point, but that's about as far as it got. I suspect it was in the spec at some point, otherwise we never would've documented it...

Supporting evidence for this change:

* Chrome folks have confirmed it is not available in Chrome
* it isn't in Gecko: https://dxr.mozilla.org/mozilla-central/source/dom/webidl/ServiceWorkerRegistration.webidl
* It isn't in Webkit: https://trac.webkit.org/browser/webkit/releases/Apple/Safari%2012.0.3/WebCore/workers/service/ServiceWorkerRegistration.idl 

Anyway, I am setting all the support info to `false` rather than just removing it, because people have talked about the idea now, and need to be set straight, plus it might be explored in the future.