### PR TITLE
Add new behavior for window.focus as a note.

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -147,7 +147,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": true
             }
           },
           "status": {
@@ -454,7 +454,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": true
             }
           },
           "status": {
@@ -551,7 +551,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": true
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -111,10 +111,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/blur",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -147,7 +147,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -416,10 +416,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/close",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -454,7 +454,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -514,10 +514,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/focus",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1",
+              "notes": "Starting in Chrome 66, opening a popup in fullscreen mode and calling this function will case fullscreen mode to end."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -550,7 +551,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -515,7 +515,7 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "notes": "Starting in Chrome 66, opening a popup in fullscreen mode and calling this function will case fullscreen mode to end."
+              "notes": "Starting in Chrome 66, opening a popup in fullscreen mode and calling this function will end fullscreen mode."
             },
             "chrome_android": {
               "version_added": "18"


### PR DESCRIPTION
The new fullscreen behavior [landed in Chrome 66](https://storage.googleapis.com/chromium-find-releases-static/36f.html#36f801fdbec07d116a6f4f07bb363f10897d6a51). While I was here, I confirmed that `focus()`, `blur()`, and `close()` [were in all the earliest versions](https://chromium.googlesource.com/chromium/src/+/543ba7a3e8576dd2dea9ec24170a3440f9efae85).