### PR TITLE
Update Safari compat data for `KeyboardEvent.isComposing`

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -388,10 +388,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": null


### PR DESCRIPTION
Support for `KeyboardEvent.isComposing` was added in Safari 10.1+ according to Apple Developer documentation: https://developer.apple.com/documentation/webkitjs/keyboardevent/2871003-iscomposing