### PR TITLE
Revise confusing Console.exception description

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -586,7 +586,7 @@
       "exception": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/exception",
-          "description": "<code>Console.exception</code> alias for <code>Console.error</code>",
+          "description": "<code>exception</code> (an alias for <code>error</code>)",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/Console.json
+++ b/api/Console.json
@@ -586,7 +586,7 @@
       "exception": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/exception",
-          "description": "Alias for Console.error",
+          "description": "<code>Console.exception</code> alias for <code>Console.error</code>",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
I thought `api.Console.exception`'s description was confusing. Hopefully this is less confusing.