### PR TITLE
fix(:defined): update Edge and Edge Mobile compatibility

### DIFF
--- a/css/selectors/defined.json
+++ b/css/selectors/defined.json
@@ -16,7 +16,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": {
               "version_added": "63"

--- a/css/selectors/defined.json
+++ b/css/selectors/defined.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
               "version_added": "63"


### PR DESCRIPTION
Edge 18 (latest) does not have support for the selector (see link to screenshot).
https://app.crossbrowsertesting.com/public/i8faa3138bf88a28/screenshots/z720d997bb5e91319837/z68440bfa87f3108c192

~Edge mobile has same support as Chrome on Andoid (Blink) and Safari on iOS (WebKit).~ Updated to reflect Edge on Win 10 mobile.