### PR TITLE
IE does not support nextElementSibling on CharacterData nodes

### DIFF
--- a/api/NonDocumentTypeChildNode.json
+++ b/api/NonDocumentTypeChildNode.json
@@ -121,7 +121,7 @@
             "ie": {
               "version_added": "9",
               "partial_implementation": true,
-              "notes": "Only implemented for <code>Element</code>, not for <code>CharacterData</code>. See <a href='#Polyfill_for_Internet_Explorer_9_and_Safari'>polyfill</a>."
+              "notes": "Only implemented for <code>Element</code>, not for <code>CharacterData</code>. See <a href='https://developer.mozilla.org/docs/Web/API/NonDocumentTypeChildNode/nextElementSibling#Polyfill_for_Internet_Explorer_9_and_Safari'>polyfill</a>."
             },
             "opera": {
               "version_added": "10"
@@ -171,7 +171,7 @@
             "ie": {
               "version_added": "9",
               "partial_implementation": true,
-              "notes": "Only implemented for <code>Element</code>, not for <code>CharacterData</code>. See <a href='#Polyfill_for_Internet_Explorer_9_and_Safari'>polyfill</a>."
+              "notes": "Only implemented for <code>Element</code>, not for <code>CharacterData</code>. See <a href='https://developer.mozilla.org/docs/Web/API/NonDocumentTypeChildNode/previousElementSibling#Polyfill_for_Internet_Explorer_9_and_Safari'>polyfill</a>."
             },
             "opera": {
               "version_added": "10"

--- a/api/NonDocumentTypeChildNode.json
+++ b/api/NonDocumentTypeChildNode.json
@@ -71,7 +71,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": false
             },
             "opera": {
               "version_added": "10"
@@ -119,7 +119,9 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "9",
+              "partial_implementation": true,
+              "notes": "Only implemented for <code>Element</code>, not for <code>CharacterData</code>. See <a href='#Polyfill_for_Internet_Explorer_9_and_Safari'>polyfill</a>."
             },
             "opera": {
               "version_added": "10"
@@ -167,7 +169,9 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "9",
+              "partial_implementation": true,
+              "notes": "Only implemented for <code>Element</code>, not for <code>CharacterData</code>. See <a href='#Polyfill_for_Internet_Explorer_9_and_Safari'>polyfill</a>."
             },
             "opera": {
               "version_added": "10"


### PR DESCRIPTION
Update `NonDocumentTypeChildNode` to indicate lack of support by IE for `nextElementSibling` and `previousElementSibling` on `CharacterData` nodes.

The documentation includes a polyfill for IE9+, but the compatibility section indicated full support starting with IE9.  I was curious why a polyfill would be needed for something that was natively supported.  The polyfill is accurate, the compatibility section is inaccurate.  Hence this PR.

The polyfill implies that Safari lacks support as well, which is incongruous with the compatibility table, but I'm unable to test that, so I haven't changed anything for Safari.