### PR TITLE
CSP report-to enabled in Chrome 70

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1111,10 +1111,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "70"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "70"
               },
               "edge": {
                 "version_added": false
@@ -1147,7 +1147,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "70"
               }
             },
             "status": {

--- a/http/headers/report-to.json
+++ b/http/headers/report-to.json
@@ -1,0 +1,57 @@
+{
+  "http": {
+    "headers": {
+      "Report-To": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Report-To",
+          "support": {
+            "chrome": {
+              "version_added": "70"
+            },
+            "chrome_android": {
+              "version_added": "70"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "70"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
In September 2018, the Content Security Policy `report-to` directive was put behind the Reporting API feature flag (https://bugs.chromium.org/p/chromium/issues/detail?id=726634#c18), and the `Report-To` header was then enabled in Chrome 70 for Intervention and Deprecation reports (https://developers.google.com/web/updates/2018/10/nic70#more, https://www.chromestatus.com/feature/5544632075157504), which also enabled it for CSP.

I tested sending/receiving CSP reports via `report-to` in Chrome 71.