### PR TITLE
Fix CSPRO being marked deprecated instead of HPKPRO

### DIFF
--- a/http/headers/content-security-policy-report-only.json
+++ b/http/headers/content-security-policy-report-only.json
@@ -6,12 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only",
           "support": {
             "chrome": {
-              "version_added": "25",
-              "version_removed": "72"
+              "version_added": "25"
             },
             "chrome_android": {
-              "version_added": true,
-              "version_removed": "72"
+              "version_added": true
             },
             "edge": {
               "version_added": "14"

--- a/http/headers/public-key-pins-report-only.json
+++ b/http/headers/public-key-pins-report-only.json
@@ -6,10 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Public-Key-Pins-Report-Only",
           "support": {
             "chrome": {
-              "version_added": "46"
+              "version_added": "46",
+              "version_removed": "72"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "72"
             },
             "edge": {
               "version_added": false,


### PR DESCRIPTION
#3175 incorrectly marked Content-Security-Policy-Report-Only deprecated, and not Public-Key-Pins-Read-Only, as intended.