### PR TITLE
Add IE support for HTMLSelectElement.options

### DIFF
--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -407,7 +407,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
Add data for `HTMLSelectElement.options` for IE.

I tested it on IE 11, 10 and 9 using https://codepen.io/jmsfwk/full/eXpPQJ.
