### PR TITLE
Samsung Internet supports localStorage

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -2994,7 +2994,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true


### PR DESCRIPTION
Verified for Samsung Internet version 6.2 in a Samsung Galaxy S8 running Android version 8 using [this](https://codepen.io/gab/pen/AxFoB) test. 

In a somehow related note, Samsung also supports web storage for Smart TVs as you can see [here](https://developer.samsung.com/tv/develop/guides/data-handling/using-web-storage/)
