### PR TITLE
Add WebGL bptc/rgtc compression extensions

### DIFF
--- a/api/EXT_texture_compression_bptc.json
+++ b/api/EXT_texture_compression_bptc.json
@@ -1,0 +1,55 @@
+{
+  "api": {
+    "EXT_texture_compression_bptc": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_texture_compression_bptc",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "65"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -1,0 +1,55 @@
+{
+  "api": {
+    "EXT_texture_compression_rgtc": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_texture_compression_rgtc",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "65"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Specs:

- https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_bptc/
- https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_rgtc/
(These are [NoInterfaceObject] and I wonder if on MDN we should rather document them under e.g. https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Extensions/xxxxx and in BCD have a folder in "api/wegbl-extensions/" instead of having them in the global api tree on MDN and here. For now I'm just following what we've done with all other extensions, though.)

Docs:
- https://developer.mozilla.org/en-US/docs/Web/API/EXT_texture_compression_bptc
- https://developer.mozilla.org/en-US/docs/Web/API/EXT_texture_compression_rgtc

Browsers:

- Firefox implemented this version 65: https://bugzilla.mozilla.org/show_bug.cgi?id=1507263 and I confirmed by calling [getSupportedExtensions](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getSupportedExtensions).
- Firefox Android doesn't implement it for me per https://webglreport.com/
- Chrome: it doesn't show up in my testing. Although I found a commit that added the ANGLE version that supports this https://storage.googleapis.com/chromium-find-releases-static/aef.html#aefd059dae13f857dd4b5e5bc0cdf5a99595daca and https://bugs.chromium.org/p/angleproject/issues/detail?id=2869 Maybe it isn't on by default yet or something.

Edit: Graphics stuff might depend on the OS. I've tested on Ubuntu. Maybe Chrome has support on Windows?