### PR TITLE
[All] Update FontFace data.

### DIFF
--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -252,7 +252,7 @@
                 "version_added": "35",
                 "version_removed": "45",
                 "partial_implementation": true,
-                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification instead of void."
+                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
               }
             ],
             "chrome_android": [

--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -263,7 +263,7 @@
                 "version_added": "35",
                 "version_removed": "45",
                 "partial_implementation": true,
-                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification instead of void."
+                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
               }
             ],
             "edge": {

--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -252,7 +252,7 @@
                 "version_added": "35",
                 "version_removed": "45",
                 "partial_implementation": true,
-                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification instead of void."
               }
             ],
             "chrome_android": [
@@ -263,7 +263,7 @@
                 "version_added": "35",
                 "version_removed": "45",
                 "partial_implementation": true,
-                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification instead of void."
               }
             ],
             "edge": {
@@ -301,7 +301,7 @@
                 "version_added": "37",
                 "version_removed": "45",
                 "partial_implementation": true,
-                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification instead of void."
               }
             ]
           },
@@ -324,7 +324,7 @@
                 "version_added": "35",
                 "version_removed": "45",
                 "partial_implementation": true,
-                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification instead of void."
               }
             ],
             "chrome_android": [
@@ -335,7 +335,7 @@
                 "version_added": "35",
                 "version_removed": "45",
                 "partial_implementation": true,
-                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification instead of void."
               }
             ],
             "edge": {
@@ -373,7 +373,7 @@
                 "version_added": "37",
                 "version_removed": "45",
                 "partial_implementation": true,
-                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification instead of void."
               }
             ]
           },

--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -373,7 +373,7 @@
                 "version_added": "37",
                 "version_removed": "45",
                 "partial_implementation": true,
-                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification instead of void."
+                "notes": "Before WebView 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
               }
             ]
           },

--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -324,7 +324,7 @@
                 "version_added": "35",
                 "version_removed": "45",
                 "partial_implementation": true,
-                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification instead of void."
+                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
               }
             ],
             "chrome_android": [

--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -335,7 +335,7 @@
                 "version_added": "35",
                 "version_removed": "45",
                 "partial_implementation": true,
-                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification instead of void."
+                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
               }
             ],
             "edge": {

--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -301,7 +301,7 @@
                 "version_added": "37",
                 "version_removed": "45",
                 "partial_implementation": true,
-                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification instead of void."
+                "notes": "Before WebView 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
               }
             ]
           },

--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -161,7 +161,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "58"
             },
             "firefox_android": {
               "version_added": false
@@ -176,7 +176,7 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -197,10 +197,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/family",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "edge": {
               "version_added": null
@@ -209,7 +209,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -224,13 +224,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -245,10 +245,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/style",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "edge": {
               "version_added": null
@@ -257,7 +257,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -272,13 +272,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "37"
             }
           },
           "status": {
@@ -293,10 +293,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/weight",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "edge": {
               "version_added": null
@@ -305,7 +305,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -320,13 +320,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "37"
             }
           },
           "status": {
@@ -341,10 +341,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/stretch",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "edge": {
               "version_added": null
@@ -353,7 +353,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -368,13 +368,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "37"
             }
           },
           "status": {
@@ -389,10 +389,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/unicodeRange",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "edge": {
               "version_added": null
@@ -401,7 +401,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -416,13 +416,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "37"
             }
           },
           "status": {
@@ -437,10 +437,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/variant",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "edge": {
               "version_added": null
@@ -449,7 +449,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -464,13 +464,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "37"
             }
           },
           "status": {
@@ -485,10 +485,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/featureSettings",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "edge": {
               "version_added": null
@@ -497,7 +497,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -512,13 +512,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "37"
             }
           },
           "status": {
@@ -533,10 +533,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/status",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "edge": {
               "version_added": null
@@ -545,7 +545,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -560,13 +560,13 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "37"
             }
           },
           "status": {
@@ -580,12 +580,28 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/loaded",
           "support": {
-            "chrome": {
-              "version_added": null
-            },
-            "chrome_android": {
-              "version_added": null
-            },
+            "chrome": [
+              {
+                "version_added": "45"
+              },
+              {
+                "version_added": "35",
+                "version_removed": "45",
+                "partial_implementation": true,
+                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "45"
+              },
+              {
+                "version_added": "35",
+                "version_removed": "45",
+                "partial_implementation": true,
+                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -593,7 +609,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -608,14 +624,22 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
             },
-            "webview_android": {
-              "version_added": null
-            }
+            "webview_android": [
+              {
+                "version_added": "45"
+              },
+              {
+                "version_added": "37",
+                "version_removed": "45",
+                "partial_implementation": true,
+                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+              }
+            ]
           },
           "status": {
             "experimental": true,
@@ -628,12 +652,28 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/load",
           "support": {
-            "chrome": {
-              "version_added": null
-            },
-            "chrome_android": {
-              "version_added": null
-            },
+            "chrome": [
+              {
+                "version_added": "45"
+              },
+              {
+                "version_added": "35",
+                "version_removed": "45",
+                "partial_implementation": true,
+                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "45"
+              },
+              {
+                "version_added": "35",
+                "version_removed": "45",
+                "partial_implementation": true,
+                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -641,7 +681,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -656,14 +696,22 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
             },
-            "webview_android": {
-              "version_added": null
-            }
+            "webview_android": [
+              {
+                "version_added": "45"
+              },
+              {
+                "version_added": "37",
+                "version_removed": "45",
+                "partial_implementation": true,
+                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+              }
+            ]
           },
           "status": {
             "experimental": true,

--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -47,54 +47,6 @@
           "deprecated": false
         }
       },
-      "worker_support": {
-        "__compat": {
-          "description": "Available in workers",
-          "support": {
-            "chrome": {
-              "version_added": "69"
-            },
-            "chrome_android": {
-              "version_added": "69"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": "69"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "FontFace": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/FontFace",
@@ -192,6 +144,54 @@
           }
         }
       },
+      "featureSettings": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/featureSettings",
+          "support": {
+            "chrome": {
+              "version_added": "35"
+            },
+            "chrome_android": {
+              "version_added": "35"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "37"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "family": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/family",
@@ -240,16 +240,32 @@
           }
         }
       },
-      "style": {
+      "load": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/style",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/load",
           "support": {
-            "chrome": {
-              "version_added": "35"
-            },
-            "chrome_android": {
-              "version_added": "35"
-            },
+            "chrome": [
+              {
+                "version_added": "45"
+              },
+              {
+                "version_added": "35",
+                "version_removed": "45",
+                "partial_implementation": true,
+                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "45"
+              },
+              {
+                "version_added": "35",
+                "version_removed": "45",
+                "partial_implementation": true,
+                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -277,9 +293,17 @@
             "safari_ios": {
               "version_added": null
             },
-            "webview_android": {
-              "version_added": "37"
-            }
+            "webview_android": [
+              {
+                "version_added": "45"
+              },
+              {
+                "version_added": "37",
+                "version_removed": "45",
+                "partial_implementation": true,
+                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+              }
+            ]
           },
           "status": {
             "experimental": true,
@@ -288,9 +312,81 @@
           }
         }
       },
-      "weight": {
+      "loaded": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/weight",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/loaded",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "45"
+              },
+              {
+                "version_added": "35",
+                "version_removed": "45",
+                "partial_implementation": true,
+                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "45"
+              },
+              {
+                "version_added": "35",
+                "version_removed": "45",
+                "partial_implementation": true,
+                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+              }
+            ],
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": [
+              {
+                "version_added": "45"
+              },
+              {
+                "version_added": "37",
+                "version_removed": "45",
+                "partial_implementation": true,
+                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
+              }
+            ]
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "status": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/status",
           "support": {
             "chrome": {
               "version_added": "35"
@@ -339,6 +435,54 @@
       "stretch": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/stretch",
+          "support": {
+            "chrome": {
+              "version_added": "35"
+            },
+            "chrome_android": {
+              "version_added": "35"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "37"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/style",
           "support": {
             "chrome": {
               "version_added": "35"
@@ -480,9 +624,9 @@
           }
         }
       },
-      "featureSettings": {
+      "weight": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/featureSettings",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/weight",
           "support": {
             "chrome": {
               "version_added": "35"
@@ -528,15 +672,15 @@
           }
         }
       },
-      "status": {
+      "worker_support": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/status",
+          "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "69"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "69"
             },
             "edge": {
               "version_added": null
@@ -545,7 +689,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": null
             },
             "firefox_android": {
               "version_added": null
@@ -560,161 +704,17 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "10"
+              "version_added": null
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "69"
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "loaded": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/loaded",
-          "support": {
-            "chrome": [
-              {
-                "version_added": "45"
-              },
-              {
-                "version_added": "35",
-                "version_removed": "45",
-                "partial_implementation": true,
-                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "45"
-              },
-              {
-                "version_added": "35",
-                "version_removed": "45",
-                "partial_implementation": true,
-                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
-              }
-            ],
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": true
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": "10"
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "webview_android": [
-              {
-                "version_added": "45"
-              },
-              {
-                "version_added": "37",
-                "version_removed": "45",
-                "partial_implementation": true,
-                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
-              }
-            ]
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "load": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/load",
-          "support": {
-            "chrome": [
-              {
-                "version_added": "45"
-              },
-              {
-                "version_added": "35",
-                "version_removed": "45",
-                "partial_implementation": true,
-                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "45"
-              },
-              {
-                "version_added": "35",
-                "version_removed": "45",
-                "partial_implementation": true,
-                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
-              }
-            ],
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": true
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": "10"
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "webview_android": [
-              {
-                "version_added": "45"
-              },
-              {
-                "version_added": "37",
-                "version_removed": "45",
-                "partial_implementation": true,
-                "notes": "Starting in Chrome 45, the returned promise resolves with a <code>FontFace</code> object as required by the specification instead of void."
-              }
-            ]
-          },
-          "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -47,246 +47,6 @@
           "deprecated": false
         }
       },
-      "worker_support": {
-        "__compat": {
-          "description": "Available in workers",
-          "support": {
-            "chrome": {
-              "version_added": "69"
-            },
-            "chrome_android": {
-              "version_added": "69"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": "69"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "status": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/status",
-          "support": {
-            "chrome": {
-              "version_added": "48"
-            },
-            "chrome_android": {
-              "version_added": "48"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": "35"
-            },
-            "opera_android": {
-              "version_added": "35"
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": "48"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onloading": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/onloading",
-          "support": {
-            "chrome": {
-              "version_added": "48"
-            },
-            "chrome_android": {
-              "version_added": "48"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": "35"
-            },
-            "opera_android": {
-              "version_added": "35"
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": "48"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onloadingdone": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/onloadingdone",
-          "support": {
-            "chrome": {
-              "version_added": "48"
-            },
-            "chrome_android": {
-              "version_added": "48"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": "35"
-            },
-            "opera_android": {
-              "version_added": "35"
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": "48"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onloadingerror": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/onloadingerror",
-          "support": {
-            "chrome": {
-              "version_added": "48"
-            },
-            "chrome_android": {
-              "version_added": "48"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": "35"
-            },
-            "opera_android": {
-              "version_added": "35"
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": "48"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "add": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/add",
@@ -304,7 +64,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -319,7 +79,7 @@
               "version_added": "35"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
@@ -367,7 +127,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
@@ -400,7 +160,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -415,7 +175,7 @@
               "version_added": "35"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
@@ -448,7 +208,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -463,7 +223,7 @@
               "version_added": "35"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
@@ -511,13 +271,157 @@
               "version_added": "35"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
               "version_added": "37"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onloading": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/onloading",
+          "support": {
+            "chrome": {
+              "version_added": "48"
+            },
+            "chrome_android": {
+              "version_added": "48"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "35"
+            },
+            "opera_android": {
+              "version_added": "35"
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "48"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onloadingdone": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/onloadingdone",
+          "support": {
+            "chrome": {
+              "version_added": "48"
+            },
+            "chrome_android": {
+              "version_added": "48"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "35"
+            },
+            "opera_android": {
+              "version_added": "35"
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "48"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onloadingerror": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/onloadingerror",
+          "support": {
+            "chrome": {
+              "version_added": "48"
+            },
+            "chrome_android": {
+              "version_added": "48"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "35"
+            },
+            "opera_android": {
+              "version_added": "35"
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "48"
             }
           },
           "status": {
@@ -559,13 +463,109 @@
               "version_added": "35"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
             },
             "webview_android": {
               "version_added": "37"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "status": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/status",
+          "support": {
+            "chrome": {
+              "version_added": "48"
+            },
+            "chrome_android": {
+              "version_added": "48"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "35"
+            },
+            "opera_android": {
+              "version_added": "35"
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "48"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "69"
             }
           },
           "status": {


### PR DESCRIPTION
* Non-Chrome changes were generated by Confluence.
* The interface shipped in Chrome 35 by flipping the default on a runtime flag. History for runtime flags is no longer that far back. I found the [beta blog post announcing its release](https://blog.chromium.org/2014/04/chrome-35-beta-more-developer-control.html).
* Before Chrome 45 load() and loaded returned void promises. [Starting with 45](https://storage.googleapis.com/chromium-find-releases-static/4e5.html#4e5bd2dafd23ae978222f7e4a73225a89a567f55) they return a FontFace instance.
