### PR TITLE
Add VisualViewport event handlers and Fx support data

### DIFF
--- a/api/VisualViewport.json
+++ b/api/VisualViewport.json
@@ -288,10 +288,24 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.visualviewport.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.visualviewport.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false
@@ -369,10 +383,24 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.visualviewport.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.visualviewport.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false
@@ -543,6 +571,198 @@
             "webview_android": {
               "version_added": "61"
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "resize_event": {
+        "__compat": {
+          "description": "<code>resize</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/VisualViewport/resize_event",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "partial_implementation": true
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "partial_implementation": true
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "66",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.visualviewport.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "66",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.visualviewport.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_added": "48",
+                "partial_implementation": true
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_added": "48",
+                "partial_implementation": true
+              }
+            ],
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "partial_implementation": true
+              }
+            ]
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "scroll_event": {
+        "__compat": {
+          "description": "<code>scroll</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/VisualViewport/scroll_event",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "partial_implementation": true
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "partial_implementation": true
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "66",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.visualviewport.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "66",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.visualviewport.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_added": "48",
+                "partial_implementation": true
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_added": "48",
+                "partial_implementation": true
+              }
+            ],
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": [
+              {
+                "version_added": "62"
+              },
+              {
+                "version_added": "61",
+                "partial_implementation": true
+              }
+            ]
           },
           "status": {
             "experimental": true,


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1478776

I updated the two event handlers to show support in Fx66 behind the same pref as the other features.

I also added the two events, and just mirrored the support information of the `on...` handlers