### PR TITLE
Added HTMLMediaElement Events

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1381,7 +1381,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": true
             }
           },
           "status": {
@@ -1433,7 +1433,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": true
             }
           },
           "status": {
@@ -1475,7 +1475,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -1490,7 +1490,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mediaGroup",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -1514,6 +1517,9 @@
             },
             "safari": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
             }
           },
           "status": {
@@ -2262,7 +2268,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": true
             }
           },
           "status": {
@@ -2410,7 +2416,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": true
             }
           },
           "status": {
@@ -2546,7 +2552,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": true
             }
           },
           "status": {
@@ -2690,7 +2696,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": true
             }
           },
           "status": {
@@ -2708,7 +2714,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -2738,7 +2744,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -331,7 +331,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": true
             }
           },
           "status": {
@@ -383,7 +383,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": true
             }
           },
           "status": {
@@ -1007,7 +1007,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": true
             }
           },
           "status": {
@@ -1059,7 +1059,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": true
             }
           },
           "status": {
@@ -1159,7 +1159,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": true
             }
           },
           "status": {
@@ -2790,7 +2790,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": true
             }
           },
           "status": {
@@ -2842,7 +2842,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": true
             }
           },
           "status": {
@@ -2857,7 +2857,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/seekToNextFrame",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -2893,6 +2893,9 @@
             },
             "safari": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
             }
           },
           "status": {
@@ -3290,7 +3293,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": true
             }
           },
           "status": {
@@ -3342,7 +3345,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": true
             }
           },
           "status": {
@@ -3427,7 +3430,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": true
             }
           },
           "status": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -289,6 +289,110 @@
           }
         }
       },
+      "canplay_event": {
+        "__compat": {
+          "description": "<code>canplay</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/canplay_event",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "canplaythrough_event": {
+        "__compat": {
+          "description": "<code>canplaythrough</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/canplaythrough_event",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "canPlayType": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/canPlayType",
@@ -861,6 +965,110 @@
           }
         }
       },
+      "durationchange_event": {
+        "__compat": {
+          "description": "<code>durationchange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/durationchange_event",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "emptied_event": {
+        "__compat": {
+          "description": "<code>emptied</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/emptied_event",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "ended": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/ended",
@@ -900,6 +1108,58 @@
             },
             "webview_android": {
               "version_added": "43"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ended_event": {
+        "__compat": {
+          "description": "<code>ended</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/ended_event",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "3"
             }
           },
           "status": {
@@ -1070,6 +1330,110 @@
             },
             "webview_android": {
               "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadeddata_event": {
+        "__compat": {
+          "description": "<code>loadeddata</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/loadeddata_event",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadedmetadata_event": {
+        "__compat": {
+          "description": "<code>loadedmetadata</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/loadedmetadata_event",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "3"
             }
           },
           "status": {
@@ -1856,6 +2220,58 @@
           }
         }
       },
+      "pause_event": {
+        "__compat": {
+          "description": "<code>pause</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/pause_event",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "paused": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/paused",
@@ -1952,6 +2368,58 @@
           }
         }
       },
+      "play_event": {
+        "__compat": {
+          "description": "<code>play</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/play_event",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "playbackRate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/playbackRate",
@@ -2027,6 +2495,58 @@
             },
             "webview_android": {
               "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "playing_event": {
+        "__compat": {
+          "description": "<code>playing</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/playing_event",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "3"
             }
           },
           "status": {
@@ -2128,6 +2648,58 @@
           }
         }
       },
+      "ratechange_event": {
+        "__compat": {
+          "description": "<code>ratechange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/ratechange_event",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "readyState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/readyState",
@@ -2167,6 +2739,110 @@
             },
             "webview_android": {
               "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "seeked_event": {
+        "__compat": {
+          "description": "<code>seeked</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/seeked_event",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "seeking_event": {
+        "__compat": {
+          "description": "<code>seeking</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/seeking_event",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "3"
             }
           },
           "status": {
@@ -2572,6 +3248,110 @@
           }
         }
       },
+      "stalled_event": {
+        "__compat": {
+          "description": "<code>stalled</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/stalled_event",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "suspend_event": {
+        "__compat": {
+          "description": "<code>suspend</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/suspend_event",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "textTracks": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/textTracks",
@@ -2596,6 +3376,58 @@
             },
             "safari": {
               "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "timeupdate_event": {
+        "__compat": {
+          "description": "<code>timeupdate</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/timeupdate_event",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "3"
             }
           },
           "status": {
@@ -2690,6 +3522,110 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "volumechange_event": {
+        "__compat": {
+          "description": "<code>volumechange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/volumechange_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "waiting_event": {
+        "__compat": {
+          "description": "<code>waiting</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/waiting_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {


### PR DESCRIPTION
Summary of changes:
Addition of HTMLMediaEvents (inherited from global events, but, other than 2, only relevant to HTMLMediaEvents). Done in alphabetical order, assuming '_' comes before 'a'

Basis for Results: 
For the most part, assumed to be the same as the onX events. volumechange and waiting - could not find the onX BCD, so listed as true.

Linter: 
passed.

Ticket:
https://app.zenhub.com/workspace/o/mdn/sprints/issues/685