### PR TITLE
Fix issue 3452

### DIFF
--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -55,7 +55,7 @@
               "alternative_name": ":-moz-any()",
               "notes": [
                 "Doesn't support combinators.",
-                "See <a href='https://bugzil.la/906353>bug 906353</a>"
+                "See <a href='https://bugzil.la/906353'>bug 906353</a>"
               ]
             },
             "firefox_android": {
@@ -63,7 +63,7 @@
               "alternative_name": ":-moz-any()",
               "notes": [
                 "Doesn't support combinators.",
-                "See <a href='https://bugzil.la/906353>bug 906353</a>"
+                "See <a href='https://bugzil.la/906353'>bug 906353</a>"
               ]
             },
             "ie": {


### PR DESCRIPTION
Fixes https://github.com/mdn/browser-compat-data/issues/3452

This is another problem when not linting the HTML in notes which we have filed as https://github.com/mdn/browser-compat-data/issues/2799 I believe.