### PR TITLE
Add WebGL extension EXT_float_blend

### DIFF
--- a/api/EXT_float_blend.json
+++ b/api/EXT_float_blend.json
@@ -1,0 +1,62 @@
+{
+  "api": {
+    "EXT_float_blend": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_float_blend",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "67",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "webgl.enable-draft-extensions",
+                "value_to_set": "true"
+              }
+            ]
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Docs: https://developer.mozilla.org/en-US/docs/Web/API/EXT_float_blend
Spec: https://www.khronos.org/registry/webgl/extensions/EXT_float_blend/
Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1522018 (in 67 behind draft extension flag)
Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=678064 (not implemented)