### PR TITLE
Add WebGL extension OES_fbo_render_mipmap

### DIFF
--- a/api/OES_fbo_render_mipmap.json
+++ b/api/OES_fbo_render_mipmap.json
@@ -1,0 +1,62 @@
+{
+  "api": {
+    "OES_fbo_render_mipmap": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_fbo_render_mipmap",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "67",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "webgl.enable-draft-extensions",
+                "value_to_set": "true"
+              }
+            ]
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Docs: https://developer.mozilla.org/en-US/docs/Web/API/OES_fbo_render_mipmap
Spec: https://www.khronos.org/registry/webgl/extensions/OES_fbo_render_mipmap/

Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1129354 (in 67 and behind a flag)
Safari: https://bugs.webkit.org/show_bug.cgi?id=141242 (not implemented)
Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=455150 (not implemented)