### PR TITLE
Animation support for grid-template properties

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -369,6 +369,58 @@
               "deprecated": false
             }
           }
+        },
+        "animation": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template-columns",
+            "description": "animation of tracks",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -373,7 +373,7 @@
         "animation": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template-columns",
-            "description": "animation of tracks",
+            "description": "Animation of tracks",
             "support": {
               "chrome": {
                 "version_added": false

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -357,6 +357,58 @@
               "deprecated": false
             }
           }
+        },
+        "animation": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template-rows",
+            "description": "animation of tracks",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -361,7 +361,7 @@
         "animation": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template-rows",
-            "description": "animation of tracks",
+            "description": "Animation of tracks",
             "support": {
               "chrome": {
                 "version_added": false


### PR DESCRIPTION
I've added a section for animation of grid-template-columns and grid-template-rows, this is in order to support docs for Firefox 66 https://bugzilla.mozilla.org/show_bug.cgi?id=1348519#c18
