### PR TITLE
Firefox 66 implements overflow-anchor

### DIFF
--- a/css/properties/overflow-anchor.json
+++ b/css/properties/overflow-anchor.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1305957

Updated the file to show support for the property in 66.