### PR TITLE
Add compat info for legacy RTCPeerConnection.getStats()

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1633,7 +1633,7 @@
             "deprecated": false
           }
         },
-        "With_callbacks": {
+        "with_callbacks": {
           "__compat": {
             "description": "Uses callbacks instead of promises",
             "support": {

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1596,7 +1596,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "45"
@@ -1631,6 +1631,58 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "Legacy_getStats": {
+          "__compat": {
+            "description": "Legacy (callback-based) <code>getStats()</code> method",
+            "support": {
+              "chrome": {
+                "version_added": "24"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "27",
+                "version_removed": "66"
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "45"
+              },
+              "opera_android": {
+                "version_added": "45"
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": "37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
           }
         },
         "MediaStreamTrack_argument": {

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1633,9 +1633,9 @@
             "deprecated": false
           }
         },
-        "Legacy_getStats": {
+        "With_callbacks": {
           "__compat": {
-            "description": "Legacy (callback-based) <code>getStats()</code> method",
+            "description": "Uses callbacks instead of promises",
             "support": {
               "chrome": {
                 "version_added": "24"


### PR DESCRIPTION
This adds a row to the compatibility info for getStats() to cover the
legacy (callback-based) version of getStats(). The numbers for Firefox
are taken directly from existing information and bug 1328194, which
removes this version of getStats().

For Chrome, I used the same introduction version and no removal, as
the IDL indicates this form is still present. I left all the other
versions the same as they are for the top-level getStats() feature.

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
