### PR TITLE
String#matchAll ships in Firefox 67

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1884,10 +1884,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "67"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "67"
               },
               "ie": {
                 "version_added": false

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1631,10 +1631,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "67"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "67"
               },
               "ie": {
                 "version_added": false

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -523,10 +523,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "67"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "67"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1531830
https://groups.google.com/forum/#!topic/mozilla.dev.platform/BTnxShq-LQc