### PR TITLE
adding web components-related changes found so far in 2019

### DIFF
--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -460,6 +460,112 @@
           }
         }
       },
+      "nodeFromPoint": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/nodeFromPoint",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Implemented in Firefox but currently only works in chrome code."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Implemented in Firefox but currently only works in chrome code."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "nodesFromPoint": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/nodesFromPoint",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Implemented in Firefox but currently only works in chrome code."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Implemented in Firefox but currently only works in chrome code."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "pointerLockElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/pointerLockElement",

--- a/api/Element.json
+++ b/api/Element.json
@@ -336,6 +336,57 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "delegatesFocus": {
+          "__compat": {
+            "description": "<code>delegatesFocus</code> option of <code>ShadowRootInit</code> dictionary.",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
         }
       },
       "attributes": {

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -238,10 +238,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "66"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
There are a few things being added here:

1. [HTMLSlotElement.assignedElements()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedElements) is now supported as of Firefox 66, as per https://bugzilla.mozilla.org/show_bug.cgi?id=1425685.
2. [DocumentOrShadowRoot.nodeFromPoint](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/nodeFromPoint) and [DocumentOrShadowRoot.nodesFromPoint](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/nodesFromPoint) are supported as of Firefox 66, as per https://bugzilla.mozilla.org/show_bug.cgi?id=1513658. After writing all the pages and creating the PR, I realised that they are chrome code-only, but I thought that since they are on the radar now, we ought to clarify what the situation is.
3. The `delegatesFocus` option of [Element.attachShadow](https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow)  is available to Chrome only for now, but we've never mentioned it. I thought we should, so I've added an entry to the BCD about it, as well as some information on the ref page. It would be good for @jpmedley to check/pass comment on this  particular bit (cheers Joe!)