### PR TITLE
Adding compat data for TextEncoder.encodeInto() method

### DIFF
--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -332,6 +332,57 @@
             "deprecated": false
           }
         }
+      },
+      "encodeInto": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextEncoder/encodeInto",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "66"
+            },
+            "firefox_android": {
+              "version_added": "66"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1514664

Pretty simple for now — It indeed works in Firefox 66. I also tested it in Safari, Chrome, and Opera on desktop, and it didn't work in any of those. It won't be implemented in IE or Edge (until later on when it gets implemented in chromium).