### PR TITLE
[Chrome] Correct animation event corrections.

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -408,10 +408,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/animationend_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": null
@@ -444,7 +444,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -460,10 +460,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/animationiteration_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": null
@@ -496,7 +496,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -512,10 +512,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/animationstart_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": null
@@ -548,7 +548,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -8919,6 +8919,214 @@
           }
         }
       },
+      "transitioncancel_event": {
+        "__compat": {
+          "description": "<code>transitioncancel</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/transitioncancel_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionend_event": {
+        "__compat": {
+          "description": "<code>transitionend</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/transitionend_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "51"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionrun_event": {
+        "__compat": {
+          "description": "<code>transitionrun</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/transitionrun_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionstart_event": {
+        "__compat": {
+          "description": "<code>transitionstart</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/transitionstart_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "undoManager": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/undoManager",

--- a/api/Document.json
+++ b/api/Document.json
@@ -407,24 +407,12 @@
           "description": "<code>animationend</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/animationend_event",
           "support": {
-            "chrome": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": true,
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": true,
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": null
             },
@@ -455,15 +443,9 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": true,
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -477,24 +459,12 @@
           "description": "<code>animationiteration</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/animationiteration_event",
           "support": {
-            "chrome": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": true,
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": true,
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": null
             },
@@ -525,15 +495,9 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": true,
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -547,24 +511,12 @@
           "description": "<code>animationstart</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/animationstart_event",
           "support": {
-            "chrome": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": true,
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": true,
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": null
             },
@@ -595,15 +547,9 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": true,
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Document.json
+++ b/api/Document.json
@@ -407,12 +407,24 @@
           "description": "<code>animationend</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/animationend_event",
           "support": {
-            "chrome": {
-              "version_added": "43"
-            },
-            "chrome_android": {
-              "version_added": "43"
-            },
+            "chrome": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -443,9 +455,15 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": {
-              "version_added": "43"
-            }
+            "webview_android": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -459,12 +477,24 @@
           "description": "<code>animationiteration</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/animationiteration_event",
           "support": {
-            "chrome": {
-              "version_added": "43"
-            },
-            "chrome_android": {
-              "version_added": "43"
-            },
+            "chrome": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -495,9 +525,15 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": {
-              "version_added": "43"
-            }
+            "webview_android": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -511,12 +547,24 @@
           "description": "<code>animationstart</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/animationstart_event",
           "support": {
-            "chrome": {
-              "version_added": "43"
-            },
-            "chrome_android": {
-              "version_added": "43"
-            },
+            "chrome": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -547,9 +595,15 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": {
-              "version_added": "43"
-            }
+            "webview_android": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/api/Document.json
+++ b/api/Document.json
@@ -350,8 +350,9 @@
           }
         }
       },
-      "animationcancel": {
+      "animationcancel_event": {
         "__compat": {
+          "description": "<code>animationcancel</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/animationcancel_event",
           "support": {
             "chrome": {
@@ -401,8 +402,9 @@
           }
         }
       },
-      "animationend": {
+      "animationend_event": {
         "__compat": {
+          "description": "<code>animationend</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/animationend_event",
           "support": {
             "chrome": {
@@ -452,8 +454,9 @@
           }
         }
       },
-      "animationiteration": {
+      "animationiteration_event": {
         "__compat": {
+          "description": "<code>animationiteration</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/animationiteration_event",
           "support": {
             "chrome": {
@@ -503,8 +506,9 @@
           }
         }
       },
-      "animationstart": {
+      "animationstart_event": {
         "__compat": {
+          "description": "<code>animationstart</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/animationstart_event",
           "support": {
             "chrome": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -350,6 +350,210 @@
           }
         }
       },
+      "animationcancel": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/animationcancel_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "54"
+            },
+            "firefox_android": {
+              "version_added": "54"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationend": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/animationend_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationiteration": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/animationiteration_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "51"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationstart": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/animationstart_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "51"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "applets": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/applets",

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -143,8 +143,9 @@
           }
         }
       },
-      "animationcancel": {
+      "animationcancel_event": {
         "__compat": {
+          "description": "<code>animationcancel</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/animationcancel_event",
           "support": {
             "chrome": {
@@ -194,8 +195,9 @@
           }
         }
       },
-      "animationend": {
+      "animationend_event": {
         "__compat": {
+          "description": "<code>animationend</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/animationend_event",
           "support": {
             "chrome": {
@@ -245,8 +247,9 @@
           }
         }
       },
-      "animationiteration": {
+      "animationiteration_event": {
         "__compat": {
+          "description": "<code>animationiteration</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/animationiteration_event",
           "support": {
             "chrome": {
@@ -296,8 +299,9 @@
           }
         }
       },
-      "animationstart": {
+      "animationstart_event": {
         "__compat": {
+          "description": "<code>animationstart</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/animationstart_event",
           "support": {
             "chrome": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -201,10 +201,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/animationend_event",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -237,7 +237,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": false
             }
           },
           "status": {
@@ -253,10 +253,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/animationiteration_event",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -289,7 +289,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": false
             }
           },
           "status": {
@@ -305,10 +305,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/animationstart_event",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -341,7 +341,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": false
             }
           },
           "status": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -143,6 +143,210 @@
           }
         }
       },
+      "animationcancel": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/animationcancel_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "54"
+            },
+            "firefox_android": {
+              "version_added": "54"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationend": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/animationend_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationiteration": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/animationiteration_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "51"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationstart": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/animationstart_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "51"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "autoCapitalize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/autoCapitalize",

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -3035,6 +3035,214 @@
           }
         }
       },
+      "transitioncancel_event": {
+        "__compat": {
+          "description": "<code>transitioncancel</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/transitioncancel_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionend_event": {
+        "__compat": {
+          "description": "<code>transitionend</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/transitionend_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "51"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionrun_event": {
+        "__compat": {
+          "description": "<code>transitionrun</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/transitionrun_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionstart_event": {
+        "__compat": {
+          "description": "<code>transitionstart</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/transitionstart_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "translate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/translate",

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -201,10 +201,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/animationend_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": null
@@ -237,7 +237,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -253,10 +253,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/animationiteration_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": null
@@ -289,7 +289,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -305,10 +305,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/animationstart_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": null
@@ -341,7 +341,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -106,6 +106,210 @@
           }
         }
       },
+      "animationcancel": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/animationcancel_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "54"
+            },
+            "firefox_android": {
+              "version_added": "54"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationend": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/animationend_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationiteration": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/animationiteration_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "51"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationstart": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/animationstart_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "51"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "blur": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/blur",

--- a/api/Window.json
+++ b/api/Window.json
@@ -164,10 +164,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/animationend_event",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -200,7 +200,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": false
             }
           },
           "status": {
@@ -216,10 +216,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/animationiteration_event",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -252,7 +252,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": false
             }
           },
           "status": {
@@ -268,10 +268,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/animationstart_event",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -304,7 +304,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": false
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -106,8 +106,9 @@
           }
         }
       },
-      "animationcancel": {
+      "animationcancel_event": {
         "__compat": {
+          "description": "<code>animationcancel</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/animationcancel_event",
           "support": {
             "chrome": {
@@ -157,8 +158,9 @@
           }
         }
       },
-      "animationend": {
+      "animationend_event": {
         "__compat": {
+          "description": "<code>animationend</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/animationend_event",
           "support": {
             "chrome": {
@@ -208,8 +210,9 @@
           }
         }
       },
-      "animationiteration": {
+      "animationiteration_event": {
         "__compat": {
+          "description": "<code>animationiteration</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/animationiteration_event",
           "support": {
             "chrome": {
@@ -259,8 +262,9 @@
           }
         }
       },
-      "animationstart": {
+      "animationstart_event": {
         "__compat": {
+          "description": "<code>animationstart</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/animationstart_event",
           "support": {
             "chrome": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -7643,6 +7643,214 @@
           }
         }
       },
+      "transitioncancel_event": {
+        "__compat": {
+          "description": "<code>transitioncancel</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/transitioncancel_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionend_event": {
+        "__compat": {
+          "description": "<code>transitionend</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/transitionend_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "51"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionrun_event": {
+        "__compat": {
+          "description": "<code>transitionrun</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/transitionrun_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionstart_event": {
+        "__compat": {
+          "description": "<code>transitionstart</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/transitionstart_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "updateCommands": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/updateCommands",

--- a/api/Window.json
+++ b/api/Window.json
@@ -164,10 +164,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/animationend_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": null
@@ -200,7 +200,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -216,10 +216,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/animationiteration_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": null
@@ -252,7 +252,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -268,10 +268,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/animationstart_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": null
@@ -304,7 +304,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -163,12 +163,24 @@
           "description": "<code>animationend</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/animationend_event",
           "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": "1",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": "18",
+                "prefix": "webkit"
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -199,9 +211,15 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -215,12 +233,24 @@
           "description": "<code>animationiteration</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/animationiteration_event",
           "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": "1",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": "18",
+                "prefix": "webkit"
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -251,9 +281,15 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -267,12 +303,24 @@
           "description": "<code>animationstart</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/animationstart_event",
           "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": "1",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": "18",
+                "prefix": "webkit"
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -303,9 +351,15 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": [
+              {
+                "version_added": "43"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
@wbamberg I apologize. I gave you incomplete information yesterday. The animation events in your PR are only supported in Chrome on Window. I've made the corrections for you and they are in this PR.

One more thing. Chrome still supports webkit versions of some events. I've noted that as well.