### PR TITLE
Invert SVG and HTML support data in css/properties/clip-path.json

### DIFF
--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -4,40 +4,31 @@
       "clip-path": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clip-path",
-          "description": "On HTML elements",
+          "description": "On SVG elements",
           "support": {
-            "chrome": [
-              {
-                "version_added": "55"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "24"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "55"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "55"
+            },
             "edge": {
-              "version_added": false
+              "version_added": "15",
+              "notes": "Edge only supports clip paths defined by <code>url()</code>."
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": "12",
+              "notes": "Edge only supports clip paths defined by <code>url()</code>."
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "52"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "52"
             },
             "ie": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Internet Explorer only supports clip paths defined by <code>url()</code>."
             },
             "opera": {
               "version_added": "42"
@@ -51,52 +42,55 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "6.0"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
             "webview_android": {
               "version_added": "55"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
         },
-        "svg": {
+        "html": {
           "__compat": {
-            "description": "On SVG elements",
+            "description": "On HTML elements",
             "support": {
-              "chrome": {
-                "version_added": "55"
-              },
-              "chrome_android": {
-                "version_added": "55"
-              },
+              "chrome": [
+                {
+                  "version_added": "55"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "24"
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "55"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": true
+                }
+              ],
               "edge": {
-                "version_added": "15",
-                "notes": "Edge only supports clip paths defined by <code>url()</code>."
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12",
-                "notes": "Edge only supports clip paths defined by <code>url()</code>."
+                "version_added": false
               },
               "firefox": {
-                "version_added": "52"
+                "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "52"
+                "version_added": "4"
               },
               "ie": {
-                "version_added": true,
-                "notes": "Internet Explorer only supports clip paths defined by <code>url()</code>."
+                "version_added": false
               },
               "opera": {
                 "version_added": "42"
@@ -110,15 +104,21 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": "6.0"
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "6.0"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": true
+                }
+              ],
               "webview_android": {
                 "version_added": "55"
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -348,7 +348,7 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": false


### PR DESCRIPTION
clip-path was originally only supported on SVG elements, and then later extended to support HTML elements.  However, we're listing SVG as a subfeature, and HTML as the primary feature.  During review of #3376, @ddbeck suggested to [swap the features](https://github.com/mdn/browser-compat-data/pull/3376#discussion_r263444993), which is what this PR does.