### PR TITLE
Add real values for all MathML features

### DIFF
--- a/mathml/elements/maction.json
+++ b/mathml/elements/maction.json
@@ -33,8 +33,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true,
-              "notes": "See <a href='https://webkit.org/b/85734'>WebKit bug 85734</a>."
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -65,11 +64,11 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true,
+                "version_added": "1",
                 "notes": "<code>statusline</code> and <code>toggle</code> are supported, <code>tooltip</code> is not implemented, see <a href='https://bugzil.la/544001'>bug 544001</a>."
               },
               "firefox_android": {
-                "version_added": true,
+                "version_added": "4",
                 "notes": "<code>statusline</code> and <code>toggle</code> are supported, <code>tooltip</code> is not implemented, see <a href='https://bugzil.la/544001'>bug 544001</a>."
               },
               "ie": {
@@ -82,7 +81,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true,
+                "version_added": "8",
                 "notes": "<code>toggle</code> is supported, <code>statusline</code> and <code>tooltip</code> are not implemented, see <a href='https://webkit.org/b/120059'>WebKit bug 120059</a>."
               },
               "safari_ios": {
@@ -177,7 +176,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "5.1"
+                "version_added": "8"
               },
               "safari_ios": {
                 "version_added": false
@@ -224,7 +223,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "5.1"
+                "version_added": "8"
               },
               "safari_ios": {
                 "version_added": false

--- a/mathml/elements/maction.json
+++ b/mathml/elements/maction.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -62,7 +62,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": true,
@@ -112,7 +112,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -159,7 +159,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -206,7 +206,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"

--- a/mathml/elements/maction.json
+++ b/mathml/elements/maction.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -59,7 +59,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -109,7 +109,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -156,7 +156,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -203,7 +203,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/menclose.json
+++ b/mathml/elements/menclose.json
@@ -33,10 +33,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -174,7 +174,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "7"
               },
               "safari_ios": {
                 "version_added": false
@@ -221,7 +221,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "7"
               },
               "safari_ios": {
                 "version_added": false

--- a/mathml/elements/menclose.json
+++ b/mathml/elements/menclose.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -106,7 +106,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -153,7 +153,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -200,7 +200,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/menclose.json
+++ b/mathml/elements/menclose.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -109,7 +109,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -156,7 +156,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -203,7 +203,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"

--- a/mathml/elements/merror.json
+++ b/mathml/elements/merror.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"

--- a/mathml/elements/merror.json
+++ b/mathml/elements/merror.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/merror.json
+++ b/mathml/elements/merror.json
@@ -36,7 +36,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "webview_android": {
               "version_added": false

--- a/mathml/elements/mfenced.json
+++ b/mathml/elements/mfenced.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"

--- a/mathml/elements/mfenced.json
+++ b/mathml/elements/mfenced.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/mfenced.json
+++ b/mathml/elements/mfenced.json
@@ -36,7 +36,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "webview_android": {
               "version_added": false

--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"

--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -36,7 +36,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "webview_android": {
               "version_added": false

--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/mglyph.json
+++ b/mathml/elements/mglyph.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/mathml/elements/mglyph.json
+++ b/mathml/elements/mglyph.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false

--- a/mathml/elements/mi.json
+++ b/mathml/elements/mi.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/mi.json
+++ b/mathml/elements/mi.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "12"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "28"

--- a/mathml/elements/mlabeledtr.json
+++ b/mathml/elements/mlabeledtr.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/mathml/elements/mlabeledtr.json
+++ b/mathml/elements/mlabeledtr.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false

--- a/mathml/elements/mmultiscripts.json
+++ b/mathml/elements/mmultiscripts.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/mmultiscripts.json
+++ b/mathml/elements/mmultiscripts.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "12"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "28"

--- a/mathml/elements/mn.json
+++ b/mathml/elements/mn.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/mn.json
+++ b/mathml/elements/mn.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "12"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "28"

--- a/mathml/elements/mo.json
+++ b/mathml/elements/mo.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "12"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -249,7 +249,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -296,7 +296,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -343,7 +343,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -390,7 +390,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -437,7 +437,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "28"
@@ -484,7 +484,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -531,7 +531,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -578,7 +578,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -625,7 +625,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -672,7 +672,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"

--- a/mathml/elements/mo.json
+++ b/mathml/elements/mo.json
@@ -314,7 +314,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": {
                 "version_added": false
@@ -361,7 +361,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": {
                 "version_added": false

--- a/mathml/elements/mo.json
+++ b/mathml/elements/mo.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -246,7 +246,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -293,7 +293,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -340,7 +340,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -387,7 +387,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -434,7 +434,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -481,7 +481,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -528,7 +528,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -575,7 +575,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -622,7 +622,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -669,7 +669,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/mover.json
+++ b/mathml/elements/mover.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -246,7 +246,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/mover.json
+++ b/mathml/elements/mover.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "12"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -249,7 +249,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"

--- a/mathml/elements/mpadded.json
+++ b/mathml/elements/mpadded.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1",
@@ -62,7 +62,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -109,7 +109,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -156,7 +156,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -203,7 +203,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"

--- a/mathml/elements/mpadded.json
+++ b/mathml/elements/mpadded.json
@@ -127,7 +127,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": {
                 "version_added": false
@@ -174,7 +174,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": {
                 "version_added": false

--- a/mathml/elements/mpadded.json
+++ b/mathml/elements/mpadded.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -59,7 +59,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -106,7 +106,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -153,7 +153,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -200,7 +200,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/mphantom.json
+++ b/mathml/elements/mphantom.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"

--- a/mathml/elements/mphantom.json
+++ b/mathml/elements/mphantom.json
@@ -79,7 +79,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": {
                 "version_added": false

--- a/mathml/elements/mphantom.json
+++ b/mathml/elements/mphantom.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/mroot.json
+++ b/mathml/elements/mroot.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"

--- a/mathml/elements/mroot.json
+++ b/mathml/elements/mroot.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/mroot.json
+++ b/mathml/elements/mroot.json
@@ -126,7 +126,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": {
                 "version_added": false
@@ -173,7 +173,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": {
                 "version_added": false

--- a/mathml/elements/mrow.json
+++ b/mathml/elements/mrow.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/mrow.json
+++ b/mathml/elements/mrow.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "12"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"

--- a/mathml/elements/mrow.json
+++ b/mathml/elements/mrow.json
@@ -173,7 +173,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": {
                 "version_added": false
@@ -220,7 +220,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": {
                 "version_added": false

--- a/mathml/elements/ms.json
+++ b/mathml/elements/ms.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/ms.json
+++ b/mathml/elements/ms.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "12"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "28"

--- a/mathml/elements/mspace.json
+++ b/mathml/elements/mspace.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"

--- a/mathml/elements/mspace.json
+++ b/mathml/elements/mspace.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/msqrt.json
+++ b/mathml/elements/msqrt.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"

--- a/mathml/elements/msqrt.json
+++ b/mathml/elements/msqrt.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/msub.json
+++ b/mathml/elements/msub.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"

--- a/mathml/elements/msub.json
+++ b/mathml/elements/msub.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/msubsup.json
+++ b/mathml/elements/msubsup.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -246,7 +246,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/msubsup.json
+++ b/mathml/elements/msubsup.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -249,7 +249,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"

--- a/mathml/elements/msup.json
+++ b/mathml/elements/msup.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"

--- a/mathml/elements/msup.json
+++ b/mathml/elements/msup.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/mtable.json
+++ b/mathml/elements/mtable.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -249,7 +249,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "33"
@@ -296,7 +296,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -343,7 +343,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -390,7 +390,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -437,7 +437,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -484,7 +484,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -531,7 +531,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "33"
@@ -578,7 +578,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -625,7 +625,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -672,7 +672,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -719,7 +719,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -766,7 +766,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -813,7 +813,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -860,7 +860,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -907,7 +907,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "33"
@@ -954,7 +954,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -1001,7 +1001,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "13"

--- a/mathml/elements/mtable.json
+++ b/mathml/elements/mtable.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -246,7 +246,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -293,7 +293,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -340,7 +340,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -387,7 +387,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -434,7 +434,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -481,7 +481,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -528,7 +528,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -575,7 +575,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -622,7 +622,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -669,7 +669,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -716,7 +716,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -763,7 +763,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -810,7 +810,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -857,7 +857,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -904,7 +904,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -951,7 +951,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -998,7 +998,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/mtd.json
+++ b/mathml/elements/mtd.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -249,7 +249,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -296,7 +296,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"

--- a/mathml/elements/mtd.json
+++ b/mathml/elements/mtd.json
@@ -126,7 +126,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "5.1"
               },
               "safari_ios": {
                 "version_added": false
@@ -314,7 +314,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "5.1"
               },
               "safari_ios": {
                 "version_added": false

--- a/mathml/elements/mtd.json
+++ b/mathml/elements/mtd.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -246,7 +246,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -293,7 +293,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/mtext.json
+++ b/mathml/elements/mtext.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/mtext.json
+++ b/mathml/elements/mtext.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "12"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "28"

--- a/mathml/elements/mtr.json
+++ b/mathml/elements/mtr.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"

--- a/mathml/elements/mtr.json
+++ b/mathml/elements/mtr.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/munder.json
+++ b/mathml/elements/munder.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -246,7 +246,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/munder.json
+++ b/mathml/elements/munder.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "12"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -249,7 +249,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"

--- a/mathml/elements/munderover.json
+++ b/mathml/elements/munderover.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -61,7 +61,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -108,7 +108,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "12"
@@ -202,7 +202,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "7"
@@ -249,7 +249,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -296,7 +296,7 @@
                 "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"

--- a/mathml/elements/munderover.json
+++ b/mathml/elements/munderover.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -58,7 +58,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -105,7 +105,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -246,7 +246,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -293,7 +293,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/mathml/elements/semantics.json
+++ b/mathml/elements/semantics.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/mathml/elements/semantics.json
+++ b/mathml/elements/semantics.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"


### PR DESCRIPTION
The first two commits indicate no MathML support at all in Edge or Edge Mobile
See https://developer.microsoft.com/en-us/microsoft-edge/platform/status/mathml/

The third commit also updates the few Firefox and Safari values with real values.

With this PR, 100% of the data in the mathml/ folder has real values for the 8 tracked browsers.

Overall, it changes the stats a bit as well:

Before (current master):

| browser | real values | `true` values | `null` values |
| --- | --- | --- | --- |
| total | 55.26% | 22.23% | 22.51% |
| edge | 53.23% | 20.25% | 26.53% |

After this PR:

| browser | real values | `true` values | `null` values |
| --- | --- | --- | --- |
| total | 55.49% | 22.20% | 22.32% |
| edge | 54.83% | 20.25% | 24.93% |