### PR TITLE
Add qpSum to Firefox 66

### DIFF
--- a/api/RTCRtpStreamStats.json
+++ b/api/RTCRtpStreamStats.json
@@ -489,10 +489,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Updates RTCRtpStreamStats to include qpSum for Firefox 66,
per https://bugzilla.mozilla.org/show_bug.cgi?id=1347070.

Tested using `npm test` and loading the output of `npm run render api.RTCRtpStreamStats` in a browser.
