### PR TITLE
Adding protocol property to FederatedCredential

### DIFF
--- a/api/FederatedCredential.json
+++ b/api/FederatedCredential.json
@@ -139,10 +139,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FederatedCredential/protocol",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "51"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "51"
             },
             "edge": {
               "version_added": null
@@ -169,7 +169,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "51"
             }
           },
           "status": {

--- a/api/FederatedCredential.json
+++ b/api/FederatedCredential.json
@@ -133,6 +133,51 @@
             "deprecated": false
           }
         }
+      },
+      "protocol": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FederatedCredential/protocol",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Part of updating Credential Management API docs (cf. https://github.com/mdn/sprints/issues/976#issuecomment-470723248 and https://developer.mozilla.org/en-US/docs/Web/API/FederatedCredential/protocol )
Contrary to `provider`, I set Chrome compatibility to `null` for now as I tested on the latest release and this only returns an empty string. Also confirmed by the current state of the Chromium code https://cs.chromium.org/chromium/src/third_party/blink/renderer/modules/credentialmanager/federated_credential.h?q=FederatedCr&sq=package:chromium&g=0&l=51

This PR is only intended for the initial addition of this property. I'll do some more test on Firefox Nightly and Chrome Canary to fill in the missing info.