### PR TITLE
Re-add data regarding constant() alias to env()

### DIFF
--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -208,12 +208,26 @@
               "opera": {
                 "version_added": null
               },
-              "safari": {
-                "version_added": "11.1"
-              },
-              "safari_ios": {
-                "version_added": "11.1"
-              }
+              "safari": [
+                {
+                  "version_added": "11.1"
+                },
+                {
+                  "version_added": "11",
+                  "version_removed": "11.1",
+                  "alternative_name": "constant"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "11.1"
+                },
+                {
+                  "version_added": "11",
+                  "version_removed": "11.1",
+                  "alternative_name": "constant"
+                }
+              ]
             },
             "status": {
               "experimental": true,


### PR DESCRIPTION
This reverts some of the changes presented by #3546 that, upon research, proved incorrect.  The [WebKit blog](https://webkit.org/blog/7929/designing-websites-for-iphone-x/), [Safari TP Release Notes](https://developer.apple.com/safari/technology-preview/release-notes/) (see releases 41 and 42), and [CanIUse](https://caniuse.com/#feat=css-env-function) confirm the existence of `constant()`, which was then entirely replaced by `env()`.