### PR TITLE
Microsoft Edge does not support BatteryManager

### DIFF
--- a/api/BatteryManager.json
+++ b/api/BatteryManager.json
@@ -12,7 +12,7 @@
             "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "edge_mobile": {
             "version_added": false
@@ -105,7 +105,7 @@
               "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": false
@@ -199,7 +199,7 @@
               "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": false
@@ -293,7 +293,7 @@
               "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": false
@@ -387,7 +387,7 @@
               "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": false
@@ -481,7 +481,7 @@
               "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": false
@@ -575,7 +575,7 @@
               "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": false
@@ -669,7 +669,7 @@
               "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": false
@@ -763,7 +763,7 @@
               "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime' title='Indicates the amount of time, in seconds, that remain until the battery is fully charged.'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime' title='Indicates the amount of time, in seconds, that remains until the battery is fully discharged.'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -192,10 +192,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -778,10 +778,10 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "43",


### PR DESCRIPTION
Update compatibility tables for `BatteryManager` and `navigator.getBattery()` with information that Microsoft Edge never added support for Battery Status API and BatteryManager.

Sources:
1. Microsoft official docs say BatteryManager and getBattery() are not supported:
    https://developer.microsoft.com/en-us/microsoft-edge/platform/catalog/?q=specName%3Abattery-status
2. Manual testing
    Method:
    Check for existence of APIs `navigator.battery` and `navigator.getBattery` in console -- they both are `undefined`.
    Version tested:
    ```
    Windows 10 1809
    Microsoft Edge 44.17763.1.0
    Microsoft EdgeHTML 18.17763
    ```

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!) - Not applicable
- [x] Link to related issues or pull requests, if any  - Not applicable