### PR TITLE
Fix wrong mdn_url entries in RTCIceCandidateStats

### DIFF
--- a/api/RTCIceCandidateStats.json
+++ b/api/RTCIceCandidateStats.json
@@ -52,7 +52,7 @@
       },
       "address": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/address",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/address",
           "support": {
             "chrome": {
               "version_added": false
@@ -115,7 +115,7 @@
       },
       "candidateType": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/candidateType",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/candidateType",
           "support": {
             "chrome": {
               "version_added": false
@@ -166,7 +166,7 @@
       },
       "componentId": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/componentId",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/componentId",
           "support": {
             "chrome": {
               "version_added": false
@@ -219,7 +219,7 @@
       },
       "deleted": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/deleted",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/deleted",
           "support": {
             "chrome": {
               "version_added": false
@@ -270,7 +270,7 @@
       },
       "networkType": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/networkType",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/networkType",
           "support": {
             "chrome": {
               "version_added": false
@@ -321,7 +321,7 @@
       },
       "port": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/port",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/port",
           "support": {
             "chrome": {
               "version_added": false
@@ -374,7 +374,7 @@
       },
       "priority": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/priority",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/priority",
           "support": {
             "chrome": {
               "version_added": false
@@ -425,7 +425,7 @@
       },
       "protocol": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/protocol",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/protocol",
           "support": {
             "chrome": {
               "version_added": false
@@ -488,7 +488,7 @@
       },
       "relayProtocol": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/relayProtocol",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/relayProtocol",
           "support": {
             "chrome": {
               "version_added": false
@@ -551,7 +551,7 @@
       },
       "transportId": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/transportId",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/transportId",
           "support": {
             "chrome": {
               "version_added": false
@@ -604,7 +604,7 @@
       },
       "url": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/url",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/url",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
Most of the members were linked to RTCIceCandidate/foo instead of
to RTCIceCandidateStats/foo. Fixed.
