### PR TITLE
chrome for android does not support mix-blend-mode as of crhome 72

### DIFF
--- a/css/properties/mix-blend-mode.json
+++ b/css/properties/mix-blend-mode.json
@@ -59,7 +59,7 @@
                 "version_added": "41"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": false

--- a/css/properties/mix-blend-mode.json
+++ b/css/properties/mix-blend-mode.json
@@ -9,7 +9,7 @@
               "version_added": "41"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": false


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
**Summarize your changes**

- indicate that chrome for android does not support mix-blend-mode css property

 **link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)**

- https://www.chromestatus.com/feature/5768037999312896 (Desktop release only, no mobile release)
- https://photos.app.goo.gl/kiLw3nGy2kY5my9U6 (pixel 3, chrome for android 72, feature not working in example: https://codepen.io/luclemo/pen/xMpory?editors=1100)

