### PR TITLE
PushSubscription: Update compatibility for Firefox

### DIFF
--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -46,7 +46,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -97,7 +97,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -120,10 +120,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -148,7 +148,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -200,7 +200,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -223,11 +223,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "Service workers (and Push) have been disabled in the Firefox 45 & 52 Extended Support Releases (ESR)."
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "48"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -252,7 +251,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -261,6 +260,7 @@
       "getKey": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushSubscription/getKey",
+          "description": "<code>getKey()</code>",
           "support": {
             "chrome": {
               "version_added": "42"
@@ -304,7 +304,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -313,6 +313,7 @@
       "toJSON": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushSubscription/toJSON",
+          "description": "<code.toJSON()</code>",
           "support": {
             "chrome": {
               "version_added": "42"
@@ -327,10 +328,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "46"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "46"
             },
             "ie": {
               "version_added": false
@@ -355,7 +356,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -364,6 +365,7 @@
       "unsubscribe": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushSubscription/unsubscribe",
+          "description": "<code>unsubscribe()</code>",
           "support": {
             "chrome": {
               "version_added": "42"
@@ -378,10 +380,11 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "44",
+              "notes": "Service workers (and Push) have been disabled in the Firefox 45 & 52 Extended Support Releases (ESR)."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "ie": {
               "version_added": false
@@ -406,7 +409,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
There were lots of incomplete bits in here for Firefox, as well
as things listed as implemented that are not. These should now
be accurate.

Blame of the WebIDL:
https://hg.mozilla.org/mozilla-central/annotate/0bf136f3ac45ce5e1c5d76c9c89d2fed6d15d0c4/dom/webidl/PushSubscription.webidl#l

Basic implementation:
https://hg.mozilla.org/mozilla-central/annotate/b277f825bc83/dom/webidl/PushSubscription.webidl#l12

Addition of serializer (toJSON()):
https://hg.mozilla.org/mozilla-central/annotate/dda92c46bb23/dom/webidl/PushSubscription.webidl#l39
