### PR TITLE
Update Media Capabilities API data

### DIFF
--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -42,8 +42,8 @@
           }
         },
         "status": {
-          "experimental": false,
-          "standard_track": false,
+          "experimental": true,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -110,8 +110,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": false,
+            "experimental": true,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -158,8 +158,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": false,
+            "experimental": true,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -20,7 +20,7 @@
             "version_added": "63"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "63"
           },
           "ie": {
             "version_added": null
@@ -81,7 +81,7 @@
               "version_added": "63"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "ie": {
               "version_added": null
@@ -136,7 +136,7 @@
               "version_added": "63"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "ie": {
               "version_added": null

--- a/api/MediaCapabilitiesInfo.json
+++ b/api/MediaCapabilitiesInfo.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": "63"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "63"
           },
           "ie": {
             "version_added": null
@@ -67,10 +67,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "ie": {
               "version_added": null
@@ -118,10 +118,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "ie": {
               "version_added": null
@@ -169,10 +169,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This updates the Media Capabilities API data, filling in some details about Firefox (from https://bugzil.la/1409664) and reflecting that the API is in a draft spec.

Some things I noticed while reviewing #3518.