### PR TITLE
Edge supports -ms-input- prefix for ::placeholder

### DIFF
--- a/css/selectors/placeholder.json
+++ b/css/selectors/placeholder.json
@@ -32,7 +32,7 @@
               {
                 "prefix": "-ms-input-",
                 "version_added": true
-              },
+              }
             ],
             "edge_mobile": [
               {
@@ -42,7 +42,7 @@
               {
                 "prefix": "-ms-input-",
                 "version_added": true
-              },
+              }
             ],
             "firefox": [
               {

--- a/css/selectors/placeholder.json
+++ b/css/selectors/placeholder.json
@@ -24,16 +24,26 @@
                 "version_added": true
               }
             ],
-            "edge": {
-              "prefix": "-webkit-input-",
-              "version_added": true,
-              "notes": "Also supports the <code>-ms-input-</code> prefix."
-            },
-            "edge_mobile": {
-              "prefix": "-webkit-input-",
-              "version_added": true,
-              "notes": "Also supports the <code>-ms-input-</code> prefix."
-            },
+            "edge": [
+              {
+                "prefix": "-webkit-input-",
+                "version_added": true
+              },
+              {
+                "prefix": "-ms-input-",
+                "version_added": true
+              },
+            ],
+            "edge_mobile": [
+              {
+                "prefix": "-webkit-input-",
+                "version_added": true
+              },
+              {
+                "prefix": "-ms-input-",
+                "version_added": true
+              },
+            ],
             "firefox": [
               {
                 "version_added": "51"

--- a/css/selectors/placeholder.json
+++ b/css/selectors/placeholder.json
@@ -26,11 +26,13 @@
             ],
             "edge": {
               "prefix": "-webkit-input-",
-              "version_added": true
+              "version_added": true,
+              "notes": "Also supports the <code>-ms-input-</code> prefix."
             },
             "edge_mobile": {
               "prefix": "-webkit-input-",
-              "version_added": true
+              "version_added": true,
+              "notes": "Also supports the <code>-ms-input-</code> prefix."
             },
             "firefox": [
               {


### PR DESCRIPTION
Fixes #3578.  Edge supports `-ms-input-` as a prefix.  This adds a note stating just that.