### PR TITLE
Add new SVG attribute data from old browser compat tables

### DIFF
--- a/svg/attributes/data.json
+++ b/svg/attributes/data.json
@@ -27,7 +27,7 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "41"
+              "version_added": "42"
             },
             "opera_android": {
               "version_added": "41"

--- a/svg/attributes/data.json
+++ b/svg/attributes/data.json
@@ -30,7 +30,7 @@
               "version_added": "42"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "42"
             },
             "safari": {
               "version_added": "10"

--- a/svg/attributes/data.json
+++ b/svg/attributes/data.json
@@ -1,0 +1,54 @@
+{
+  "svg": {
+    "attributes": {
+      "data": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/data-*",
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "55"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "51"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "41"
+            },
+            "opera_android": {
+              "version_added": "41"
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": "10"
+            },
+            "webview_android": {
+              "version_added": "55"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/svg/attributes/href.json
+++ b/svg/attributes/href.json
@@ -1,0 +1,54 @@
+{
+  "svg": {
+    "attributes": {
+      "href": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/href",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "51"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/svg/attributes/paint-order.json
+++ b/svg/attributes/paint-order.json
@@ -1,0 +1,54 @@
+{
+  "svg": {
+    "attributes": {
+      "paint-order": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/paint-order",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/svg/attributes/textLength.json
+++ b/svg/attributes/textLength.json
@@ -1,0 +1,54 @@
+{
+  "svg": {
+    "attributes": {
+      "textLength": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/textLength",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Based upon [this gist](https://gist.github.com/Elchi3/b6863aa227fc4cd51a247957380eca5e), this PR continues some of last year's goal, adding in the last SVG attribute tables.  The `paint-order` data, however, varies from the original data, as the table states false for all compatibility, yet the attribute functioned perfectly in Chrome, Firefox, and Safari.