### PR TITLE
Fix compat data for api.CanvasRenderingContext2D

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -20,7 +20,7 @@
             "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -4064,7 +4064,7 @@
               "version_added": "27"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "ie": {
               "version_added": "11"

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -20,7 +20,7 @@
             "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": "9"
@@ -29,13 +29,13 @@
             "version_added": "9"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": "2"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -4064,7 +4064,7 @@
               "version_added": "27"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true
             },
             "ie": {
               "version_added": "11"


### PR DESCRIPTION
Fixes #3554 and provides a few consistency fixes (browsers show support for subfeatures when parent feature had null).