### PR TITLE
Add data for AudioWorkletNode.

### DIFF
--- a/api/AudioWorkletNode.json
+++ b/api/AudioWorkletNode.json
@@ -50,6 +50,57 @@
           "deprecated": false
         }
       },
+      "onprocessorerror": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/onprocessorstatechange",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "onprocessorstatechange": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/onprocessorstatechange",


### PR DESCRIPTION
This is a resubmit of #3508. It contains fewer items because some of the needed changes were picked up by other commits since the earlier commit was submitted.

The previous number, version 61 was for a Chrome origin trial. The origin trial was removed and [`AudioParamMap` was enabled by default in Chrome 66](https://storage.googleapis.com/chromium-find-releases-static/b38.html#b38d192d113384bc10627d88094aa43ed4541cb0).