### PR TITLE
Add Firefox versions for css.inset-inline and css.inset-block

### DIFF
--- a/css/properties/inset-block-end.json
+++ b/css/properties/inset-block-end.json
@@ -6,16 +6,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-block-end",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "69",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "69",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -63,10 +77,24 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
               "version_added": false

--- a/css/properties/inset-block-start.json
+++ b/css/properties/inset-block-start.json
@@ -6,16 +6,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-block-start",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "69",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "69",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -63,10 +77,24 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
               "version_added": false

--- a/css/properties/inset-block.json
+++ b/css/properties/inset-block.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "38"
             },
             "ie": {
               "version_added": false

--- a/css/properties/inset-block.json
+++ b/css/properties/inset-block.json
@@ -6,10 +6,24 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-block",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "69",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "edge": {
               "version_added": false
@@ -17,20 +31,70 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "38"
-            },
-            "firefox_android": {
-              "version_added": "38"
-            },
+            "firefox": [
+              {
+                "version_added": "63"
+              },
+              {
+                "alternative_name": "offset-block",
+                "version_added": "41",
+                "version_removed": "63"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63"
+              },
+              {
+                "alternative_name": "offset-block",
+                "version_added": "41",
+                "version_removed": "63"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
               "version_added": false

--- a/css/properties/inset-inline-end.json
+++ b/css/properties/inset-inline-end.json
@@ -6,16 +6,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-inline-end",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "69",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "69",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -63,10 +77,24 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
               "version_added": false

--- a/css/properties/inset-inline-start.json
+++ b/css/properties/inset-inline-start.json
@@ -4,7 +4,8 @@
       "inset-inline-start": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-inline-start",
-          "chrome": {
+          "support": {
+            "chrome": {
               "version_added": "69",
               "flags": [
                 {

--- a/css/properties/inset-inline-start.json
+++ b/css/properties/inset-inline-start.json
@@ -4,18 +4,31 @@
       "inset-inline-start": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-inline-start",
-          "support": {
-            "chrome": {
-              "version_added": false
+          "chrome": {
+              "version_added": "69",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "69",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -63,10 +76,24 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
               "version_added": false

--- a/css/properties/inset-inline.json
+++ b/css/properties/inset-inline.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "38"
             },
             "ie": {
               "version_added": false

--- a/css/properties/inset-inline.json
+++ b/css/properties/inset-inline.json
@@ -6,10 +6,24 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-inline",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "69",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "edge": {
               "version_added": false
@@ -17,20 +31,70 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "38"
-            },
-            "firefox_android": {
-              "version_added": "38"
-            },
+            "firefox": [
+              {
+                "version_added": "63"
+              },
+              {
+                "alternative_name": "offset-inline",
+                "version_added": "41",
+                "version_removed": "63"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63"
+              },
+              {
+                "alternative_name": "offset-inline",
+                "version_added": "41",
+                "version_removed": "63"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "51",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.vertical-text.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
Fixes #3443 and fixes #3444 based upon data already in `inset-inline-start`, Bugzilla, and the report of #3443.

Data sources:
https://bugzilla.mozilla.org/show_bug.cgi?id=1120283 (initial implementation as offset-*)
https://bugzilla.mozilla.org/show_bug.cgi?id=1464782 (rename from offset-* to inset-*)