### PR TITLE
tweaking CSS max-content and min-content support info

### DIFF
--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -93,12 +93,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -144,12 +156,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -195,6 +195,130 @@
             }
           }
         },
+        "max-content": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "min-content": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "content": {
           "__compat": {
             "description": "<code>content</code>",

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -199,10 +199,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": null
@@ -247,7 +247,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {
@@ -261,10 +261,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": null
@@ -309,7 +309,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -67,12 +67,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": "3",
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -118,12 +130,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": "3",
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/inline-size.json
+++ b/css/properties/inline-size.json
@@ -93,12 +93,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -144,12 +156,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/max-block-size.json
+++ b/css/properties/max-block-size.json
@@ -93,12 +93,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -144,12 +156,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -69,12 +69,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": "3",
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -120,12 +132,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": "3",
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -237,7 +261,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": false
+                  "partial_implementation": true,
+                  "prefix": "-moz-",
+                  "version_added": "3",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
                 },
                 "firefox_android": {
                   "version_added": false

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -95,12 +95,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -146,12 +158,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -80,13 +80,19 @@
                   "version_added": "66"
                 },
                 {
-                  "prefix": "-moz-",
-                  "version_added": "3"
+                  "version_added": "3",
+                  "prefix": "-moz-"
                 }
               ],
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -156,13 +162,19 @@
                   "version_added": "66"
                 },
                 {
-                  "prefix": "-moz-",
-                  "version_added": "3"
+                  "version_added": "3",
+                  "prefix": "-moz-"
                 }
               ],
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -275,8 +287,10 @@
                   "version_added": false
                 },
                 "firefox": {
+                  "partial_implementation": true,
                   "prefix": "-moz-",
-                  "version_added": "3"
+                  "version_added": "3",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
                 },
                 "firefox_android": {
                   "version_added": null

--- a/css/properties/min-block-size.json
+++ b/css/properties/min-block-size.json
@@ -93,12 +93,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -144,12 +156,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -70,12 +70,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": "3",
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -121,12 +133,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": "3",
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -237,7 +261,9 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "prefix": "-moz-",
+                "version_added": "3",
+                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
               },
               "firefox_android": {
                 "version_added": false

--- a/css/properties/min-inline-size.json
+++ b/css/properties/min-inline-size.json
@@ -93,12 +93,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -145,12 +157,24 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66"
-              },
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -80,13 +80,19 @@
                   "version_added": "66"
                 },
                 {
-                  "prefix": "-moz-",
-                  "version_added": "3"
+                  "version_added": "3",
+                  "prefix": "-moz-"
                 }
               ],
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -160,13 +166,19 @@
                   "version_added": "66"
                 },
                 {
-                  "prefix": "-moz-",
-                  "version_added": "3"
+                  "version_added": "3",
+                  "prefix": "-moz-"
                 }
               ],
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -286,7 +298,8 @@
               },
               "firefox": {
                 "prefix": "-moz-",
-                "version_added": "3"
+                "version_added": "3",
+                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
               },
               "firefox_android": {
                 "version_added": null

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -129,13 +129,19 @@
                   "version_added": "66"
                 },
                 {
-                  "prefix": "-moz-",
-                  "version_added": "3"
+                  "version_added": "3",
+                  "prefix": "-moz-"
                 }
               ],
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -198,13 +204,19 @@
                   "version_added": "66"
                 },
                 {
-                  "prefix": "-moz-",
-                  "version_added": "3"
+                  "version_added": "3",
+                  "prefix": "-moz-"
                 }
               ],
-              "firefox_android": {
-                "version_added": "66"
-              },
+              "firefox_android": [
+                {
+                  "version_added": "66"
+                },
+                {
+                  "version_added": true,
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
@rachelandrew updated the support data for `min-content` and `max-content` in https://github.com/mdn/browser-compat-data/pull/3457.

I also updated it in https://github.com/mdn/browser-compat-data/pull/3573, but I wanted Rachel's work to be merged as it included some really useful support info that mine missed.

This PR adds in some of the prefixing information that I included, which was missing from Rachel's PR.