### PR TITLE
Set true/false values in CSS for Firefox with version_added: null

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -223,10 +223,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": true
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": true
               },
               "ie": {
                 "version_added": null
@@ -1731,10 +1731,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": null

--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -70,10 +70,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": null
@@ -174,10 +174,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": null

--- a/css/properties/box-flex-group.json
+++ b/css/properties/box-flex-group.json
@@ -22,10 +22,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/css/properties/line-height-step.json
+++ b/css/properties/line-height-step.json
@@ -30,10 +30,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null

--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -71,10 +71,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -122,10 +122,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -173,10 +173,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -224,10 +224,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/properties/offset-distance.json
+++ b/css/properties/offset-distance.json
@@ -30,10 +30,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -119,10 +119,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": true
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": true
               },
               "ie": {
                 "version_added": null

--- a/css/properties/offset-rotate.json
+++ b/css/properties/offset-rotate.json
@@ -38,10 +38,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null

--- a/css/properties/offset.json
+++ b/css/properties/offset.json
@@ -30,10 +30,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null

--- a/css/properties/outline-style.json
+++ b/css/properties/outline-style.json
@@ -75,10 +75,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": null
+                "version_added": true
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": true
               },
               "ie": {
                 "version_added": null

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -481,10 +481,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": null

--- a/css/types/clamp.json
+++ b/css/types/clamp.json
@@ -19,10 +19,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1751,11 +1751,11 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null,
+                "version_added": false,
                 "notes": "The <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-image-rect'><code>-moz-image-rect()</code></a> function supports fragments as of Firefox 4."
               },
               "firefox_android": {
-                "version_added": null,
+                "version_added": false,
                 "notes": "The <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-image-rect'><code>-moz-image-rect()</code></a> function supports fragments as of Firefox 4."
               },
               "ie": {
@@ -1875,10 +1875,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/types/max.json
+++ b/css/types/max.json
@@ -19,10 +19,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null

--- a/css/types/min.json
+++ b/css/types/min.json
@@ -19,10 +19,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
All true/false values were tested in Firefox 65.0.2 on macOS, all with the default flags.  This PR is intended to remove as many null values as possible, and lead towards producing "real" values down the line.