### PR TITLE
Add Chrome support for Object.fromEntries

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -776,7 +776,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "73"
               }
             },
             "status": {

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -737,10 +737,10 @@
             "spec_url": "https://tc39.github.io/proposal-object-from-entries/#sec-object.fromentries",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "73"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "73"
               },
               "edge": {
                 "version_added": false


### PR DESCRIPTION
Chrome 73 was released yesterday. 

- [V8 release notes](https://v8.dev/blog/v8-release-73)
- [Platform status](https://www.chromestatus.com/features/5747878282657792)

Confirmed on MacOS Chrome 73.0.3683.75
Pending confirmation on Android; the update is not yet available to my device.

Other V8 changes in this release are already merged in:
- [String.matchAll](https://github.com/mdn/browser-compat-data/pull/3289)
- [Atomics.notify rename](https://github.com/mdn/browser-compat-data/pull/2694)

A checklist to help your pull request get merged faster:
- [X] Summarize your changes
- [X] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [X] Data: if you tested something, describe how you tested with details like browser and version
- [X] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [X] Link to related issues or pull requests, if any
