### PR TITLE
Fix incomplete Request constructor notes

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -88,24 +88,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/Request",
           "description": "<code>Request()</code> constructor",
           "support": {
-            "chrome": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "41",
-                "notes": "Some default values for the init parameter changed in Chrome 47. See the Properties section for details."
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "41",
-                "notes": "Some default values for the init parameter changed in Chrome 47. See the Properties section for details."
-              }
-            ],
+            "chrome": {
+              "version_added": "41",
+              "notes": "From Chrome 47, default values for the <code>init</code> argument's properties changed. <code>mode</code> defaults to <code>same-origin</code> (from <code>no-cors</code>). <code>credentials</code> defaults to <code>include</code> (from <code>same-origin</code>). <code>redirect</code> defaults to <code>follow</code> (from <code>manual</code>)."
+            },
+            "chrome_android": {
+              "version_added": "41",
+              "notes": "From Chrome 47, default values for the <code>init</code> argument's properties changed. <code>mode</code> defaults to <code>same-origin</code> (from <code>no-cors</code>). <code>credentials</code> defaults to <code>include</code> (from <code>same-origin</code>). <code>redirect</code> defaults to <code>follow</code> (from <code>manual</code>)."
+            },
             "edge": {
               "version_added": "15"
             },
@@ -166,7 +156,7 @@
             ],
             "webview_android": {
               "version_added": "42",
-              "notes": "Some default values for the init parameter changed in Chrome 47. See the Properties section for details."
+              "notes": "From WebView 47, default values for the <code>init</code> argument's properties changed. <code>mode</code> defaults to <code>same-origin</code> (from <code>no-cors</code>). <code>credentials</code> defaults to <code>include</code> (from <code>same-origin</code>). <code>redirect</code> defaults to <code>follow</code> (from <code>manual</code>)."
             }
           },
           "status": {


### PR DESCRIPTION
The notes on `Request()` referred to the MDN wiki page text, which doesn't make sense in contexts other than the compat tables. This change brings that info into the notes directly and restructures the data so that the note appears for the current version.

I noticed this minor issue while reviewing #3403.