### PR TITLE
Add feature matching hints to the schema

### DIFF
--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -470,6 +470,9 @@
         "alpha_hexadecimal_notation": {
           "__compat": {
             "description": "RGBA hexadecimal notation (<code>#RRGGBBAA</code>, <code>#RGBA</code>)",
+            "matches": {
+              "regex_token": "#[0-9a-fA-F]{4}(?:[0-9a-fA-F]{4})?\\b"
+            },
             "support": {
               "chrome": [
                 {

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -471,7 +471,7 @@
           "__compat": {
             "description": "RGBA hexadecimal notation (<code>#RRGGBBAA</code>, <code>#RGBA</code>)",
             "matches": {
-              "regex_token": "#[0-9a-fA-F]{4}(?:[0-9a-fA-F]{4})?\\b"
+              "regex_token": "^#[0-9a-fA-F]{4}(?:[0-9a-fA-F]{4})?$"
             },
             "support": {
               "chrome": [

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -123,7 +123,7 @@
           "__compat": {
             "description": "Three-value syntax",
             "matches": {
-              "regex_value": "^([\\d\\w%-]+|calc\\(.+\\)) +([\\d\\w%-]+|calc\\(.+\\)) +([\\d\\w-]+|calc\\(.+\\))+$"
+              "regex_value": "^([\\d\\w%-]+|calc\\(.+\\))\\s+([\\d\\w%-]+|calc\\(.+\\))\\s+([\\d\\w-]+|calc\\(.+\\))$"
             },
             "support": {
               "chrome": {

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -122,6 +122,9 @@
         "three_value_syntax": {
           "__compat": {
             "description": "Three-value syntax",
+            "matches": {
+              "regex_value": "^([\\d\\w%-]+|calc\\(.+\\)) +([\\d\\w%-]+|calc\\(.+\\)) +([\\d\\w-]+|calc\\(.+\\))+$"
+            },
             "support": {
               "chrome": {
                 "version_added": true

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -135,6 +135,20 @@
         "3d": {
           "__compat": {
             "description": "3D support",
+            "matches": {
+              "keywords": [
+                "matrix3d",
+                "translate3d",
+                "translateZ",
+                "scale3d",
+                "scaleZ",
+                "rotate3d",
+                "rotateX",
+                "rotateY",
+                "rotateZ",
+                "perspective"
+              ]
+            },
             "support": {
               "chrome": {
                 "version_added": "12"

--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -6,9 +6,7 @@
           "description": "<code>::backdrop</code>",
           "matches": {
             "keywords": [
-              "::backdrop",
-              "::-webkit-backdrop",
-              "::-ms-backdrop"
+              "::backdrop"
             ]
           },
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::backdrop",

--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -4,6 +4,13 @@
       "backdrop": {
         "__compat": {
           "description": "<code>::backdrop</code>",
+          "matches": {
+            "keywords": [
+              "::backdrop",
+              "::-webkit-backdrop",
+              "::-ms-backdrop"
+            ]
+          },
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::backdrop",
           "support": {
             "chrome": [

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -131,6 +131,9 @@ A string containing a human-readable description of the feature.
 It is intended to be used as a caption or title and should be kept short.
 The `<code>` and `<a>` HTML elements can be used.
 
+* An optional `matches` property to __help match the feature to source code__ ([see below](#the-matches-object))
+An object that contains a keyword list or regex that can match values or tokens which correspond to the feature.
+
 * An optional `status` property for __status information__.
 An object containing information about the stability of the feature:
 Is it a functionality that is standard? Is it stable? Has it been deprecated and shouldn't be used anymore? ([see below](#status-information))
@@ -371,6 +374,33 @@ Example:
 }
 ```
 The `<code>` and `<a>` HTML elements can be used.
+
+### The `matches` object
+
+A `matches` object contains hints to help automatically detect whether source code corresponds to a feature, such as a list of keywords or a regular expression. A `matches` object may have one of the following properties (in order of preference):
+
+* `keywords`: an array of one or more literal strings that correspond to the feature.
+
+  Examples:
+
+  - In CSS selector features, they can be literal selectors. See [`css.selectors.backdrop`](../css/selectors/backdrop.json)).
+  - In CSS property subfeatures, they can be data type keywords or function keywords. See [`css.properties.transform.3d`](../css/properties/transform.json)).
+
+* `regex_token`: a string containing a regular expression that matches a single token (i.e., text delimited by characters that are excluded from the text to be matched) corresponding to the feature.
+
+  Tests are required for all regular expressions. See [`test-regexes.js`](../tests/test-regexes.js).
+
+  Examples:
+
+  - In CSS property subfeatures, they can be regular expressions that match component value types. See [`css.properties.color.alpha_hexadecimal_notation`](../css/properties/color.json) and corresponding tests.
+
+* `regex_value`: a string containing a regular expression that matches a complete value corresponding to the feature.
+
+  Tests are required for all regular expressions. See [`test-regexes.js`](../tests/test-regexes.js).
+
+  Examples:
+
+  - In CSS property subfeatures, these can be regular expressions that match whole declaration values. See [`css.properties.transform-origin.three_value_syntax`](../css/properties/transform.json) and corresponding tests.
 
 ### Status information
 The status property contains information about stability of the feature. It is

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -99,7 +99,10 @@
         "keywords": {
           "type": "array",
           "minItems": 1,
-          "uniqueItems": true
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
         },
         "regex_token": {
           "type": "string"

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -91,6 +91,26 @@
       ]
     },
 
+    "matches_block": {
+      "type": "object",
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "keywords": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "regex_token": {
+          "type": "string"
+        },
+        "regex_value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+
     "status_block": {
       "type": "object",
       "properties": {
@@ -167,6 +187,7 @@
           ],
           "description": "An optional URL or array of URLs, each of which is for a specific part of a specification in which this feature is defined. Each URL must contain a fragment identifier."
         },
+        "matches": { "$ref": "#/definitions/matches_block" },
         "support": { "$ref": "#/definitions/support_block" },
         "status": { "$ref": "#/definitions/status_block" }
       },

--- a/test/test-regexes.js
+++ b/test/test-regexes.js
@@ -2,6 +2,12 @@ const assert = require('assert');
 
 const bcd = require('..');
 
+function lookup(dottedFeature) {
+  const x = dottedFeature.split('.');
+  const feature = x.reduce((prev, current) => prev[current], bcd);
+  return feature;
+}
+
 function testToken(feature, matches, misses) {
   const str = feature.__compat.matches.regex_token || feature.__compat.matches.regex_value;
   const regexp = new RegExp(str);
@@ -13,7 +19,7 @@ function testToken(feature, matches, misses) {
 const tests = [
   {
     features: [
-      bcd.css.properties.color.alpha_hexadecimal_notation
+      'css.properties.color.alpha_hexadecimal_notation'
     ],
     matches: [
       '#003399ff',
@@ -28,7 +34,7 @@ const tests = [
   },
   {
     features: [
-      css.properties['transform-origin'].three_value_syntax
+      'css.properties.transform-origin.three_value_syntax'
     ],
     matches: [
       '2px 30% 10px',  // length, percentage, length
@@ -44,5 +50,5 @@ const tests = [
 ];
 
 tests.forEach(({features, matches, misses}) => {
-  features.forEach(feature => testToken(feature, matches, misses));
+  features.forEach(feature => testToken(lookup(feature), matches, misses));
 });

--- a/test/test-regexes.js
+++ b/test/test-regexes.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+
+const bcd = require('..');
+
+function testToken(feature, matches, misses) {
+  const regexp = new RegExp(feature.__compat.matches.regex_token);
+  matches.forEach(match => assert.ok(regexp.test(match), `${regexp} did not match ${match}`));
+  misses.forEach(miss => assert.ok(!regexp.test(miss), `${regexp} erroneously matched ${miss}`));
+}
+
+const tests = [
+  {
+    features: [
+      bcd.css.properties.color.alpha_hexadecimal_notation
+    ],
+    matches: [
+      '#003399ff',
+      '#0af9',
+    ],
+    misses: [
+      '#00aaff',
+      '#0af',
+      'green',
+      '#greenish',
+    ]
+  }
+];
+
+tests.forEach(({features, matches, misses}) => {
+  features.forEach(feature => testToken(feature, matches, misses));
+});

--- a/test/test-regexes.js
+++ b/test/test-regexes.js
@@ -3,7 +3,9 @@ const assert = require('assert');
 const bcd = require('..');
 
 function testToken(feature, matches, misses) {
-  const regexp = new RegExp(feature.__compat.matches.regex_token);
+  const str = feature.__compat.matches.regex_token || feature.__compat.matches.regex_value;
+  const regexp = new RegExp(str);
+
   matches.forEach(match => assert.ok(regexp.test(match), `${regexp} did not match ${match}`));
   misses.forEach(miss => assert.ok(!regexp.test(miss), `${regexp} erroneously matched ${miss}`));
 }
@@ -22,6 +24,21 @@ const tests = [
       '#0af',
       'green',
       '#greenish',
+    ]
+  },
+  {
+    features: [
+      css.properties['transform-origin'].three_value_syntax
+    ],
+    matches: [
+      '2px 30% 10px',  // length, percentage, length
+      'right bottom -2cm',  // two keywords and length
+      'calc(50px - 25%) 2px 1px'  // lengths with calc
+    ],
+    misses: [
+      'center',  // one value syntax
+      'left 5px',  // two value syntax
+      'left calc(10px - 50%)'  // two value syntax with calc
     ]
   }
 ];


### PR DESCRIPTION
This PR introduces the feature matching hints to the schema that was discussed in #3366. Alerting @antross and @jpmedley, since you've already been active on this subject.

Here's a bit of a guided tour of the changes:

## Schema
`schemas/compat-data-schema.json` adds support for the `matches` block and specifies `keywords` (array), `regex_token` (string), and `regex_value` (string) as possible names for the member properties. Hopefully seeing some functioning examples (below) will help us see whether those names work or not.

## New data
The following features have new `matches` data:

- `css.properties.color.alpha_hexadecimal_notation`, which demonstrates `regex_token` matching for a CSS value token.
- `css.properties.transform-origin.three_value_syntax`, which demonstrates `regex_value` matching for a whole CSS declaration value.
- `css.properties.transform.3d`, which demonstrates `keywords` matching CSS value tokens.
- `css.selectors.backdrop` which demonsrates `keywords` matching CSS selector tokens.

I tried to write some functional regexes and keyword lists. Hopefully this will give you a sense of what data consumers will actually get.

## Tests

`test/test-regexes.js` adds tests for the new regexes. It's pretty barebones at the moment: given a feature, and some example matching and non-matching strings, you can see whether the regex matches or misses appropriately.

There is one thing I'm not particularly sure about: I haven't really tested the beginning/end anchors in the regexes (e.g., I don't test a longer, non-token string against a `regex_token`). I wasn't sure if that would reinforce the intended scope for the regex types or if it would add pointless test cases. 🤷‍♂️ 

## Documentation
The changes in `schemas/compat-data-schema.md` document the new schema. It's a starting point. I'm open to suggestions on ways to improve it.