### PR TITLE
Add afterprint and beforeprint events

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -50,6 +50,55 @@
           "deprecated": false
         }
       },
+      "afterprint_event": {
+        "__compat": {
+          "description": "<code>afterprint</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/afterprint_event",
+          "support": {
+            "chrome": {
+              "version_added": "63"
+            },
+            "chrome_android": {
+              "version_added": "63"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "6"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "50"
+            },
+            "opera_android": {
+              "version_added": "50"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "63"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "alert": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/alert",
@@ -97,6 +146,55 @@
             "webview_android": {
               "version_added": true,
               "notes": "Starting with Chrome 46, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforeprint_event": {
+        "__compat": {
+          "description": "<code>beforeprint</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/beforeprint_event",
+          "support": {
+            "chrome": {
+              "version_added": "63"
+            },
+            "chrome_android": {
+              "version_added": "63"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "6"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "50"
+            },
+            "opera_android": {
+              "version_added": "50"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "63"
             }
           },
           "status": {


### PR DESCRIPTION
This is part of https://github.com/mdn/sprints/issues/1103.

Specifically it adds compat data for the [`afterprint`](https://developer.mozilla.org/en-US/docs/Web/API/Window/afterprint_event) and [`beforeprint`](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeprint_event) events. As far as I know these only target the `Window` interface.

I've taken the compat data itself from the data for the corresponding `on-` event handler properties, which is in [WindowEventHandlers.json](https://github.com/mdn/browser-compat-data/blob/master/api/WindowEventHandlers.json).
