### PR TITLE
Un-deprecate the CSP child-src directive

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -330,7 +330,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },


### PR DESCRIPTION
Per https://w3c.github.io/webappsec-csp/ (the current CSP spec), the CSP child-src directive is no longer deprecated.