### PR TITLE
Fixing Chrome version_added for pointer events from 35 to 55

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6613,10 +6613,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pointercancel_event",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -6674,7 +6674,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -6690,10 +6690,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pointerdown_event",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -6751,7 +6751,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -6767,10 +6767,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pointerenter_event",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -6828,7 +6828,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -6844,10 +6844,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pointerleave_event",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -6905,7 +6905,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -7067,10 +7067,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pointermove_event",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -7128,7 +7128,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -7144,10 +7144,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pointerout_event",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -7205,7 +7205,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -7221,10 +7221,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pointerover_event",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -7282,7 +7282,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -7298,10 +7298,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pointerup_event",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -7359,7 +7359,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -2769,10 +2769,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onpointercancel",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -2830,7 +2830,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -2845,10 +2845,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onpointerdown",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -2906,7 +2906,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -2921,10 +2921,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onpointerenter",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -2982,7 +2982,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -2997,10 +2997,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onpointerleave",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -3058,7 +3058,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -3175,10 +3175,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onpointermove",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -3236,7 +3236,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -3251,10 +3251,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onpointerout",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -3312,7 +3312,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -3327,10 +3327,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onpointerover",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -3388,7 +3388,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -3403,10 +3403,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onpointerup",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -3464,7 +3464,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2078,7 +2078,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -2155,7 +2155,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -2232,7 +2232,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -2309,7 +2309,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -2386,7 +2386,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -2463,7 +2463,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -2540,7 +2540,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {
@@ -2617,7 +2617,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "55"
             }
           },
           "status": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2017,10 +2017,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/pointercancel_event",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -2094,10 +2094,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/pointerdown_event",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -2171,10 +2171,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/pointerenter_event",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -2248,10 +2248,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/pointerleave_event",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -2325,10 +2325,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/pointermove_event",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -2402,10 +2402,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/pointerout_event",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -2479,10 +2479,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/pointerover_event",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true
@@ -2556,10 +2556,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/pointerup_event",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "55"
             },
             "edge": {
               "version_added": true


### PR DESCRIPTION
Pointer events (abstraction above mouse events and touch events) were added to Chrome at version 55, and not version 35 as in the current docs.

The doc of the containing class PointerEvent already shows version 55.
https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent#Browser_compatibility

Here is the announcement of the addition of pointer events to Chrome 55.
https://developers.google.com/web/updates/2016/10/pointer-events

Here is a small test that I used 
(I noticed the discrepancy in the docs when I needed to use pointer events on Chrome 44. And it didn't work).
https://codepen.io/ramtob/pen/rRpeoP
https://codepen.io/ramtob/full/rRpeoP
