### PR TITLE
Create basic support for css.clip-path

### DIFF
--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -56,9 +56,15 @@
             "samsunginternet_android": {
               "version_added": "6.0"
             },
-            "webview_android": {
-              "version_added": "55"
-            }
+            "webview_android": [
+              {
+                "version_added": "55"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -4,14 +4,25 @@
       "clip-path": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clip-path",
-          "description": "On SVG elements",
           "support": {
-            "chrome": {
-              "version_added": "55"
-            },
-            "chrome_android": {
-              "version_added": "55"
-            },
+            "chrome": [
+              {
+                "version_added": "55"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "24"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "55"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
             "edge": {
               "version_added": "15",
               "notes": "Edge only supports clip paths defined by <code>url()</code>."
@@ -21,10 +32,10 @@
               "notes": "Edge only supports clip paths defined by <code>url()</code>."
             },
             "firefox": {
-              "version_added": "52"
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "52"
+              "version_added": "4"
             },
             "ie": {
               "version_added": true,
@@ -53,6 +64,57 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "svg": {
+          "__compat": {
+            "description": "On SVG elements",
+            "support": {
+              "chrome": {
+                "version_added": "55"
+              },
+              "chrome_android": {
+                "version_added": "55"
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "edge_mobile": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "42"
+              },
+              "opera_android": {
+                "version_added": "42"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "55"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         },
         "html": {


### PR DESCRIPTION
This is a sub-PR of #3368.  @ddbeck suggested swapping the SVG and HTML support blocks in #3587 to make the SVG support as "basic support".  Unfortunately, it seems that HTML support was implemented earlier than SVG support (at least by what the data says), but Edge/IE only have SVG support, no HTML support. Either way, the linter will be yelling at us to fix it. I'm thinking that we should have a subfeature for SVG and HTML each, and then just set the "basic support" to whichever versions are earlier.

I'm not sure if this is the best solution or not.  Review and feedback is highly encouraged!