### PR TITLE
Add load and unload events

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -47,6 +47,58 @@
           "deprecated": false
         }
       },
+      "DOMContentLoaded_event": {
+        "__compat": {
+          "description": "<code>DOMContentLoaded</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/DOMContentLoaded_event",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "9"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "Document": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/Document",

--- a/api/Document.json
+++ b/api/Document.json
@@ -8604,6 +8604,55 @@
           }
         }
       },
+      "readystatechange_event": {
+        "__compat": {
+          "description": "<code>readystatechange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/readystatechange_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "referrer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/referrer",

--- a/api/Window.json
+++ b/api/Window.json
@@ -466,6 +466,255 @@
           }
         }
       },
+      "beforeunload_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/beforeunload_event",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": "4"
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "Implementation seems <a href='https://webkit.org/b/19324'>defect</a>."
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "custom_text_support": {
+          "__compat": {
+            "description": "Custom text support",
+            "support": {
+              "chrome": {
+                "version_added": true,
+                "version_removed": "51"
+              },
+              "chrome_android": {
+                "version_added": true,
+                "version_removed": "51"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true,
+                "version_removed": "44"
+              },
+              "firefox_android": {
+                "version_added": true,
+                "version_removed": "44"
+              },
+              "ie": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true,
+                "version_removed": "38"
+              },
+              "opera_android": {
+                "version_added": true,
+                "version_removed": "38"
+              },
+              "safari": {
+                "version_added": true,
+                "version_removed": "9"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": true,
+                "version_removed": "51"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "event_returnvalue_activation": {
+          "__compat": {
+            "description": "Activation using <code>event.returnValue = \"string\";</code>",
+            "support": {
+              "chrome": {
+                "version_added": "30"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "preventdefault_activation": {
+          "__compat": {
+            "description": "Activation using <code>event.preventDefault()</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "return_string_activation": {
+          "__compat": {
+            "description": "Activation using <code>return \"string\";</code>",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "12"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        }
+      },
       "blur": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/blur",
@@ -3508,6 +3757,58 @@
             },
             "samsunginternet_android": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "load_event": {
+        "__compat": {
+          "description": "<code>load</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/load_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -8304,6 +8605,58 @@
             },
             "webview_android": {
               "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unload_event": {
+        "__compat": {
+          "description": "<code>unload</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/unload_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -50,6 +50,58 @@
           "deprecated": false
         }
       },
+      "DOMContentLoaded_event": {
+        "__compat": {
+          "description": "<code>DOMContentLoaded</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/DOMContentLoaded_event",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "9"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "afterprint_event": {
         "__compat": {
           "description": "<code>afterprint</code> event",


### PR DESCRIPTION
This is part of https://github.com/mdn/sprints/issues/1103.

It adds:
* `load`, `unload`, `beforeunload` to Window.json. 

* `DOMContentLoaded` to Window.json and Document.json
* `readystatechange` to Document.json

For `load` and `unload` there's no table in the existing event pages, so I've used the BCD from the corresponding [`onload`](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload#Browser_compatibility) and [`onunload`](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onunload#Browser_compatibility) event handler properties.

The `beforeunload` event is a bit more involved: there's BCD for the [`onbeforeunload`](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload#Browser_compatibility) event handler property, but *also* an [old-style table in the event page](https://developer.mozilla.org/en-US/docs/Web/Events/beforeunload#Browser_compatibility): especially the stuff about activation seems quite important. So I've mashed these two tables together.

For `DOMContentLoaded` I've taken the data from the [old-style table in the event page](https://developer.mozilla.org/en-US/docs/Web/Events/DOMContentLoaded#Browser_compatibility), although I did remove a couple of old IE notes that just didn't look useful.

For `readystatechange` I couldn't find any data, but I checked it was supported by all the browsers I could test with.


