### PR TITLE
[Chrome][Immediate Action Requested] 73 does not include fromEntries().

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -737,10 +737,10 @@
             "spec_url": "https://tc39.github.io/proposal-object-from-entries/#sec-object.fromentries",
             "support": {
               "chrome": {
-                "version_added": "73"
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": "73"
+                "version_added": false
               },
               "edge": {
                 "version_added": false
@@ -776,7 +776,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": "73"
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
PR #3627 added Chrome support for `fromEntries()` in version 73. It's actually behind a flag in 73. The way the earlier PR was written suggestions it's on by default. This PR sets the values back to false because I've been asked not submit flagged items to BCD. Regardless of what's done, the existing data is incorrect.