### PR TITLE
Update IE support for Node.appendChild

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -80,7 +80,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "7"
+              "version_added": "5"
             },
             "opera": {
               "version_added": true

--- a/api/Node.json
+++ b/api/Node.json
@@ -80,7 +80,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": 7
+              "version_added": "7"
             },
             "opera": {
               "version_added": true

--- a/api/Node.json
+++ b/api/Node.json
@@ -80,7 +80,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "9"
+              "version_added": true
             },
             "opera": {
               "version_added": true

--- a/api/Node.json
+++ b/api/Node.json
@@ -80,7 +80,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": 7
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
Node.appendChild method was supported before IE9.
Edited 'api/Node.json' accordingly.