### PR TITLE
Reference crbug for "bookmark" context type in extensions API

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -68,6 +68,7 @@
             "__compat": {
               "support": {
                 "chrome": {
+                  "notes": "See <a href='https://crbug.com/825443'>bug 825443</a>",
                   "version_added": false
                 },
                 "edge": {


### PR DESCRIPTION
Added reference to the feature request at Chromium's issue tracker @ https://bugs.chromium.org/p/chromium/issues/detail?id=825443