### PR TITLE
Adds support information for DOMMatrixReadOnly.translate

### DIFF
--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -2073,10 +2073,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/translate",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "45"
             },
             "edge": {
               "version_added": false
@@ -2106,7 +2106,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "58"
+              "version_added": "45"
             }
           },
           "status": {

--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -2100,10 +2100,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "45"

--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -2085,10 +2085,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "33"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "ie": {
               "version_added": false

--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -2094,10 +2094,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "32"
             },
             "safari": {
               "version_added": "11"

--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -2068,6 +2068,54 @@
           }
         }
       },
+      "translate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/translate",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "58"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "transform": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/transform",


### PR DESCRIPTION
There's currently no data for this method, so I've tried to add what I can.

Chrome data pulled from https://www.chromestatus.com/features/6015941766807552

Other browsers I set to `true` if I could verify they are working right now by running
```new DOMMatrixReadOnly().translate```
and verifying that the console output is a function.

I struggled to find much version information specifically for the `translate` method and would definitely appreciate any help anyone can offer on how better to find this info!