### PR TITLE
[Chrome][Safari][FF] More TransitionEvent data.

### DIFF
--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -185,7 +185,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+               "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -11,7 +11,7 @@
             {
               "version_added": "2",
               "version_removed": "71",
-              "prefix": "Webkit"
+              "prefix": "WebKit"
             }
           ],
           "chrome_android": [

--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -185,7 +185,7 @@
               "version_added": true
             },
             "firefox_android": {
-               "version_added": true
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -4,12 +4,26 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/TransitionEvent",
         "support": {
-          "chrome": {
-            "version_added": "2"
-          },
-          "chrome_android": {
-            "version_added": "18"
-          },
+          "chrome": [
+            {
+              "version_added": "27"
+            },
+            {
+              "version_added": "2",
+              "version_removed": "71",
+              "prefix": "Webkit"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "27"
+            },
+            {
+              "version_added": "18",
+              "version_removed": "71",
+              "prefix": "Webkit"
+            }
+          ],
           "edge": {
             "version_added": true
           },
@@ -37,9 +51,16 @@
           "safari_ios": {
             "version_added": true
           },
-          "webview_android": {
-            "version_added": true
-          }
+          "webview_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "version_removed": "71",
+              "prefix": "Webkit"
+            }
+          ]
         },
         "status": {
           "experimental": true,
@@ -53,10 +74,10 @@
           "description": "<code>TransitionEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "27"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "edge": {
               "version_added": false
@@ -101,10 +122,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TransitionEvent/animationName",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -134,7 +155,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
@@ -161,7 +182,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -176,7 +197,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": null
@@ -197,10 +218,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TransitionEvent/elapsedTime",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -224,7 +245,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": true
@@ -245,10 +266,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TransitionEvent/pseudoElement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -272,7 +293,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": false

--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -58,7 +58,7 @@
             {
               "version_added": true,
               "version_removed": "71",
-              "prefix": "Webkit"
+              "prefix": "WebKit"
             }
           ]
         },

--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -21,7 +21,7 @@
             {
               "version_added": "18",
               "version_removed": "71",
-              "prefix": "Webkit"
+              "prefix": "WebKit"
             }
           ],
           "edge": {


### PR DESCRIPTION
Here are the Chrome improvements requested in #3525 with FF and Safari items found in confluence. Here's the support for the Chrome data:

* [Enabled unprefixed by default](https://chromium.googlesource.com/chromium/src/+/5f2186f4f96db86c2ef04c3fe50e7bfe04055870) in Feb 2013. This is not in Omaha Proxy, but this date puts it in Chrome 27.
* Removal of the prefixed version [happened in Chrome 71](https://storage.googleapis.com/chromium-find-releases-static/e1a.html#e1a49fefb6f55a8d36dc0dea99b2735f949fb063).
* The members of this interface were [never prefixed themselves](https://chromium.googlesource.com/chromium/src/+/ba105fc4c9465ac453bcced361e23cca83e6d498%5E%21/#F22) though the interface they belonged to where.

I'm unable to find a removal date for `initTransitionEvent`.