### PR TITLE
[Chrome][Safari] Update PaymentRequest.

### DIFF
--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -5,24 +5,11 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest",
         "support": {
           "chrome": {
-            "version_added": "60"
+            "version_added": "61"
           },
-          "chrome_android": [
-            {
-              "version_added": "56"
-            },
-            {
-              "version_added": "53",
-              "version_removed": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "chrome_android": {
+            "version_added": "53"
+          },
           "edge": {
             "version_added": true
           },
@@ -97,22 +84,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": true
             },
@@ -178,22 +152,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -232,7 +193,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.0"
             },
             "safari_ios": {
               "version_added": null
@@ -260,7 +221,7 @@
               "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "16"
@@ -300,7 +261,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.0"
             },
             "safari_ios": {
               "version_added": null
@@ -324,7 +285,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/id",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "61"
             },
             "chrome_android": {
               "version_added": "60"
@@ -367,7 +328,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.0"
             },
             "safari_ios": {
               "version_added": null
@@ -460,22 +421,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -514,7 +462,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.0"
             },
             "safari_ios": {
               "version_added": null
@@ -540,22 +488,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -594,7 +529,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.0"
             },
             "safari_ios": {
               "version_added": null
@@ -620,22 +555,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -769,22 +691,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -823,7 +732,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.0"
             },
             "safari_ios": {
               "version_added": null
@@ -850,7 +759,7 @@
               "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "55"
             },
             "edge": {
               "version_added": "15"
@@ -890,7 +799,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.0"
             },
             "safari_ios": {
               "version_added": null
@@ -916,22 +825,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -970,7 +866,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.0"
             },
             "safari_ios": {
               "version_added": null

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -1,4 +1,4 @@
-{
+11.111.1{
   "api": {
     "PaymentRequest": {
       "__compat": {
@@ -193,7 +193,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "11.0"
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": null
@@ -261,7 +261,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "11.0"
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": null
@@ -328,7 +328,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "11.0"
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": null
@@ -462,7 +462,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "11.0"
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": null
@@ -529,7 +529,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "11.0"
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": null
@@ -732,7 +732,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "11.0"
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": null
@@ -799,7 +799,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "11.0"
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": null
@@ -866,7 +866,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "11.0"
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": null

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -1,4 +1,4 @@
-11.111.1{
+{
   "api": {
     "PaymentRequest": {
       "__compat": {


### PR DESCRIPTION
* Safari data is from confluence.
* I’m breaking my personal rule and using Chrome Status as the [source for this](https://www.chromestatus.com/features/5639348045217792). It’s because there were 8 versions between Android and desktop. It was so unusual that I verified this with the dev team.
* `shippingType` [landed in 55](https://storage.googleapis.com/chromium-find-releases-static/ac3.html#ac3f96f1115b079eec5e48700588022673b9986d)