### PR TITLE
[Chrome] Add support for any-link.

### DIFF
--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -5,14 +5,24 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:any-link",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
+            "chrome": [
+              {
+                "version_added": "65"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "65"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
             "edge": {
               "version_added": false
             },
@@ -61,10 +71,15 @@
             "samsunginternet_android": {
               "version_added": true
             },
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "65"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ]
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
I’ve verified that this [landed in 65](https://storage.googleapis.com/chromium-find-releases-static/841.html#841a6d7660fd935b0a785c331b7d910bf2655c83). 

Partially addresses #3641.