### PR TITLE
Refine data for api.Element.setCapture

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -5305,7 +5305,8 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "5",
+              "notes": "The <code>retargetToElement</code> parameter to <code>Element.setCapture()</code> was introduced in Internet Explorer 5.5."
             },
             "opera": {
               "version_added": false
@@ -5329,7 +5330,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
I hope I did this right?

I got the IE support info from:
  http://web.archive.org/web/20100823121600/http://msdn.microsoft.com/en-us/library/ms536742(VS.85).aspx

Note: It looks like this data is also used on the Document.releaseCapture() page:
  https://developer.mozilla.org/docs/Web/API/Document/releaseCapture
This accounts for the verbosity of the "notes" property.

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
