### PR TITLE
Add BCD for focus events

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -440,6 +440,65 @@
           }
         }
       },
+      "blur_event": {
+        "__compat": {
+          "description": "<code>blur</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/blur_event",
+          "support": {
+            "chrome": {
+              "version_added": "5"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": true,
+                "version_removed": "24",
+                "notes": "The interface for this event is <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/FocusEvent'><code>FocusEvent</code></a>."
+              }
+            ],
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "5.1"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "classList": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/classList",
@@ -1556,6 +1615,65 @@
               "standard_track": true,
               "deprecated": false
             }
+          }
+        }
+      },
+      "focus_event": {
+        "__compat": {
+          "description": "<code>focus</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/focus_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": true,
+                "version_removed": "24",
+                "notes": "The interface for this event is <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/FocusEvent'><code>FocusEvent</code></a>."
+              }
+            ],
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/Element.json
+++ b/api/Element.json
@@ -449,7 +449,7 @@
               "version_added": "5"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": true

--- a/api/Element.json
+++ b/api/Element.json
@@ -1677,6 +1677,110 @@
           }
         }
       },
+      "focusin_event": {
+        "__compat": {
+          "description": "<code>focusin</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/focusin_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "focusout_event": {
+        "__compat": {
+          "description": "<code>focusout</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/focusout_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getAttribute": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/getAttribute",

--- a/api/Window.json
+++ b/api/Window.json
@@ -818,6 +818,65 @@
           }
         }
       },
+      "blur_event": {
+        "__compat": {
+          "description": "<code>blur</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/blur_event",
+          "support": {
+            "chrome": {
+              "version_added": "5"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": true,
+                "version_removed": "24",
+                "notes": "The interface for this event is <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/FocusEvent'><code>FocusEvent</code></a>."
+              }
+            ],
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "5.1"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "confirm": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/confirm",
@@ -1292,6 +1351,65 @@
             "firefox": {
               "version_added": true
             },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "focus_event": {
+        "__compat": {
+          "description": "<code>focus</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/focus_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": true,
+                "version_removed": "24",
+                "notes": "The interface for this event is <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/FocusEvent'><code>FocusEvent</code></a>."
+              }
+            ],
             "firefox_android": {
               "version_added": true
             },

--- a/api/Window.json
+++ b/api/Window.json
@@ -827,7 +827,7 @@
               "version_added": "5"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": true


### PR DESCRIPTION
This is part of https://github.com/mdn/sprints/issues/1101.

It updates:

* Element.json to add data for [`blur`](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event), [`focus`](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event), [`focusin`](https://developer.mozilla.org/en-US/docs/Web/API/Element/focusin_event) and [`focusout`](https://developer.mozilla.org/en-US/docs/Web/API/Element/focusout_event)

* Window.json to add data for [`blur`](https://developer.mozilla.org/en-US/docs/Web/API/Window/blur_event) and [`focus`](https://developer.mozilla.org/en-US/docs/Web/API/Window/focus_event)

The data's taken from the old tables, and I've made changes where I'm fairly sure about things (e.g. I'm pretty sure Firefox for Android supports `focus`).

The only real decision was whether to include the note from  the old data for `blur` about the value of `document.activeElement` while the event is being processed. I vacillated over this, but in the end thought it will be more compact and comprehensible to readers to deal with this in a short paragraph in the page, rather than adding a note to every browser describing how it might handle this case.