### PR TITLE
Mark `-moz-context-properties` as not supported in non-Gecko browsers

### DIFF
--- a/css/properties/-moz-context-properties.json
+++ b/css/properties/-moz-context-properties.json
@@ -6,16 +6,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-context-properties",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "55",
@@ -43,19 +43,19 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This was discovered by testing for the support of the property in
Chrome 16-57 and finding it not supported. The non-support of the
property in other browsers is assumed.