### PR TITLE
[All] Update DTMF-related interfaces.

### DIFF
--- a/api/RTCDTMFSender.json
+++ b/api/RTCDTMFSender.json
@@ -41,7 +41,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "37"
           }
         },
         "status": {
@@ -91,7 +91,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -245,7 +245,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {

--- a/api/RTCDTMFToneChangeEvent.json
+++ b/api/RTCDTMFToneChangeEvent.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDTMFToneChangeEvent",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "27"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "27"
           },
           "edge": {
             "version_added": true
@@ -41,7 +41,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "37"
           }
         },
         "status": {
@@ -55,10 +55,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDTMFToneChangeEvent/tone",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "27"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "edge": {
               "version_added": "12"
@@ -91,7 +91,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -107,10 +107,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDTMFToneChangeEvent/RTCDTMFToneChangeEvent",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "27"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "edge": {
               "version_added": true
@@ -143,7 +143,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {


### PR DESCRIPTION
Confluence erroneously shows these interfaces as having arrived in Chrome 66. They actually [landed in Chrome in February 2013](https://chromium.googlesource.com/chromium/src/+/87a94142bbc06d32cba1b7c84192b165bed34854).