### PR TITLE
Describing getTransports() method of AuthenticatorAttestationResponse

### DIFF
--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -136,10 +136,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse/getTransports",
           "support": {
             "chrome": {
-              "version_added": "73"
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": "73"
+              "version_added": "75"
             },
             "edge": {
               "version_added": null
@@ -172,7 +172,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "73"
+              "version_added": "75"
             }
           },
           "status": {

--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -133,13 +133,11 @@
       },
       "getTransports": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAttestationResponse/getTransports",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse/getTransports",
           "support": {
-            "chrome": [
-              {
-                "version_added": "73"
-              }
-            ],
+            "chrome": {
+              "version_added": "73"
+            },
             "chrome_android": {
               "version_added": "73"
             },

--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -136,10 +136,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse/getTransports",
           "support": {
             "chrome": {
-              "version_added": "75"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "75"
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -172,7 +172,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "75"
+              "version_added": false
             }
           },
           "status": {

--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -130,6 +130,59 @@
             "deprecated": false
           }
         }
+      },
+      "getTransports": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAttestationResponse/getTransports",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "73"
+              }
+            ],
+            "chrome_android": {
+              "version_added": "73"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "73"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Adding the `getTransports()` method which has been added in the ED of Web Authentication API (WebAuthn).
* Link to the spec / issues: https://w3c.github.io/webauthn/#dom-authenticatorattestationresponse-gettransports / https://github.com/w3c/webauthn/pull/1050
* Link to the corresponding MDN page: https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAttestationResponse/getTransports
* Tests done: Chrome Canary (OK without any flag) / Firefox Nightly (NOK, no mention in DXR either). I doubt it's in Edge but I'm not able to test/get a preview.
  * For Chrome, even if https://www.chromestatus.com/feature/6402602820435968 exists, I was not able to use the method on 73, even after enabling all of the possible flags related to WebAuthn (Win 10). It works on Canary though.
  * For Firefox, I did not file a bug yet.
* Linter applied, fixed the errors it detected

This is flagged as experimental as it's not part of Level 1 and does not have multiple implementations as far as I can tell. If being part of an ED is enough to remove this flag, please tell.

N.B. Cross-linking to https://github.com/mdn/sprints/issues/976