### PR TITLE
Add unprefixed support for Safari for :any-link

### DIFF
--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -50,14 +50,24 @@
               "prefix": "-webkit-",
               "version_added": true
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
             "samsunginternet_android": {
               "version_added": true
             },


### PR DESCRIPTION
This adds onto #3648 by addressing the other half of #3641.