### PR TITLE
Partial support for NetworkInformation API in Chromium

### DIFF
--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -5,11 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/NetworkInformation",
         "support": {
           "chrome": {
-            "version_added": "61",
-            "notes": "Partial Support: Only supports the <code>downlink</code>, <code>effectiveType</code> & <code>rtt</code> values"
+            "version_added": false
           },
           "chrome_android": {
-            "version_added": "38"
+            "version_added": false
           },
           "edge": {
             "version_added": false
@@ -24,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "48"
+            "version_added": false
           },
           "opera_android": {
-            "version_added": "37"
+            "version_added": false
           },
           "safari": {
             "version_added": false
@@ -36,7 +35,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": "50"
+            "version_added": false
           }
         },
         "status": {
@@ -140,10 +139,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NetworkInformation/downlinkMax",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "38"
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -158,10 +157,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "48"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "37"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -170,7 +169,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "50"
+              "version_added": false
             }
           },
           "status": {
@@ -411,10 +410,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NetworkInformation/type",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "38"
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -429,10 +428,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "48"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "37"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -441,7 +440,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "50"
+              "version_added": false
             }
           },
           "status": {

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -5,7 +5,8 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/NetworkInformation",
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": "61",
+            "notes": "Partial Support: Only supports the <code>downlink</code>, <code>effectiveType</code> & <code>rtt</code> values"
           },
           "chrome_android": {
             "version_added": "38"

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/NetworkInformation",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "61"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "38"
           },
           "edge": {
             "version_added": false
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "48"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "37"
           },
           "safari": {
             "version_added": false
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "50"
           }
         },
         "status": {
@@ -139,10 +139,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NetworkInformation/downlinkMax",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "61",
+              "notes": "Only supported in Chrome OS"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "38"
             },
             "edge": {
               "version_added": false
@@ -160,7 +161,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "37"
             },
             "safari": {
               "version_added": false
@@ -169,7 +170,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "50"
             }
           },
           "status": {
@@ -410,10 +411,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NetworkInformation/type",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "61",
+              "notes": "Only supported in Chrome OS"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "38"
             },
             "edge": {
               "version_added": false
@@ -431,7 +433,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "37"
             },
             "safari": {
               "version_added": false
@@ -440,7 +442,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "50"
             }
           },
           "status": {


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes

NetworkInformation page states that Chrome has full support beyond v61, however this is only partially true. Not all properties are currently supported or returned by the browser.


- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)

https://caniuse.com/#feat=netinfo


- [x] Data: if you tested something, describe how you tested with details like browser and version

In dev tools, observing the values within `navigator.connection` reveal only a limited subset of properties:

![image](https://user-images.githubusercontent.com/1036921/54573361-40625e80-49a9-11e9-94b0-5d1aed3779de.png)
