### PR TITLE
update notes on link rel=preload to reflect reality

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1024,12 +1024,12 @@
                 "firefox": {
                   "version_added": "56",
                   "version_removed": "57",
-                  "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>). An improved version that works for non-cacheable resources is expected to land soon."
+                  "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
                 },
                 "firefox_android": {
                   "version_added": "56",
                   "version_removed": "57",
-                  "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>). An improved version that works for non-cacheable resources is expected to land soon."
+                  "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
                 },
                 "ie": {
                   "version_added": null


### PR DESCRIPTION
The note on Firefox implementation says:

> An improved version that works for non-cacheable resources is expected to land soon.

However that "improved version" has never been enabled by default ( https://bugzil.la/1222633 ) and the work has been stalled ( https://bugzil.la/1394778#c65 ).

This patch removes the once-promising notes to reflect reality.