### PR TITLE
Expand -webkit-font-smoothing/-moz-osx-font-smoothing

### DIFF
--- a/css/properties/font-smooth.json
+++ b/css/properties/font-smooth.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": "5",
-              "prefix": "-webkit-"
+              "alternative_name": "-webkit-font-smoothing"
             },
             "chrome_android": {
               "version_added": true,
-              "prefix": "-webkit-"
+              "alternative_name": "-webkit-font-smoothing"
             },
             "edge": {
               "version_added": null
@@ -21,7 +21,7 @@
             },
             "firefox": {
               "version_added": "25",
-              "prefix": "-moz-osx-",
+              "alternative_name": "-moz-osx-font-smoothing",
               "notes": "Only works on MacOS X / macOS."
             },
             "firefox_android": {
@@ -32,15 +32,15 @@
             },
             "opera": {
               "version_added": true,
-              "prefix": "-webkit-"
+              "alternative_name": "-webkit-font-smoothing"
             },
             "opera_android": {
               "version_added": true,
-              "prefix": "-webkit-"
+              "alternative_name": "-webkit-font-smoothing"
             },
             "safari": {
               "version_added": "4",
-              "prefix": "-webkit-",
+              "alternative_name": "-webkit-font-smoothing",
               "notes": "Only works on Mac OS X/macOS."
             },
             "safari_ios": {
@@ -48,7 +48,7 @@
             },
             "webview_android": {
               "version_added": true,
-              "prefix": "-webkit-"
+              "alternative_name": "-webkit-font-smoothing"
             }
           },
           "status": {


### PR DESCRIPTION
Because the name of the main feature is `font-smooth` sans `ing`,
the use of `prefix` doesn't work.