### PR TITLE
Fix jump feature description consistency

### DIFF
--- a/api/EffectTiming.json
+++ b/api/EffectTiming.json
@@ -255,7 +255,7 @@
         },
         "jump": {
           "__compat": {
-            "description": "<code>step(jump-*)</code> keywords for <code>steps()</code>",
+            "description": "<code>jump-</code> keywords for <code>steps()</code>",
             "support": {
               "chrome": {
                 "version_added": false


### PR DESCRIPTION
This puts this `jump` feature's description in line with other jump features elsewhere. Follow up to #3524.