### PR TITLE
Mark transform as available unprefixed in Edge 12

### DIFF
--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -18,10 +18,15 @@
               "prefix": "-webkit-",
               "version_added": true
             },
-            "edge": {
-              "prefix": "-webkit-",
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
             "edge_mobile": {
               "prefix": "-webkit-",
               "version_added": true


### PR DESCRIPTION
The discrepency was found using results from Edge 12-18:
https://github.com/foolip/mdn-bcd-results/tree/e16e4ca1e51625a7d720dd926b0ab41268d8c11c

The code snippet `'transform' in document.body.style` was run and
found to return true in Edge 12.

The scripts for updating BCD based on the results are in development:
https://gist.github.com/foolip/982ba3e84ace2e6e469ce798001ec9d1