### PR TITLE
Mark column-rule/column-rule-width as available unprefixed in Edge 12

### DIFF
--- a/css/properties/column-rule-width.json
+++ b/css/properties/column-rule-width.json
@@ -23,10 +23,15 @@
                 "version_added": true
               }
             ],
-            "edge": {
-              "prefix": "-webkit-",
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
             "edge_mobile": {
               "prefix": "-webkit-",
               "version_added": true

--- a/css/properties/column-rule.json
+++ b/css/properties/column-rule.json
@@ -23,10 +23,15 @@
                 "version_added": true
               }
             ],
-            "edge": {
-              "prefix": "-webkit-",
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
             "edge_mobile": {
               "version_added": null
             },


### PR DESCRIPTION
This matches the structure already in column-rule-color.json and
column-rule-style.json.

The discrepency was found using results from Edge 12-18:
https://github.com/foolip/mdn-bcd-results/tree/e16e4ca1e51625a7d720dd926b0ab41268d8c11c

The code snippet `'columnRule' in document.body.style` (and similar)
was run and found to return true in Edge 12.

The scripts for updating BCD based on the results are in development:
https://gist.github.com/foolip/982ba3e84ace2e6e469ce798001ec9d1