### PR TITLE
Mark a bunch of CSS properties as unsupported in Edge

### DIFF
--- a/css/properties/-webkit-border-before.json
+++ b/css/properties/-webkit-border-before.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/-webkit-box-reflect.json
+++ b/css/properties/-webkit-box-reflect.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/-webkit-mask-attachment.json
+++ b/css/properties/-webkit-mask-attachment.json
@@ -13,7 +13,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/-webkit-mask-box-image.json
+++ b/css/properties/-webkit-mask-box-image.json
@@ -12,7 +12,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/-webkit-print-color-adjust.json
+++ b/css/properties/-webkit-print-color-adjust.json
@@ -16,7 +16,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/box-flex-group.json
+++ b/css/properties/box-flex-group.json
@@ -16,7 +16,7 @@
               "prefix": "-webkit-"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/box-lines.json
+++ b/css/properties/box-lines.json
@@ -16,7 +16,7 @@
               "prefix": "-webkit-"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/initial-letter.json
+++ b/css/properties/initial-letter.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -13,7 +13,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -14,7 +14,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/shape-image-threshold.json
+++ b/css/properties/shape-image-threshold.json
@@ -12,7 +12,7 @@
               "version_added": "37"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/text-decoration-color.json
+++ b/css/properties/text-decoration-color.json
@@ -12,7 +12,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/text-emphasis-color.json
+++ b/css/properties/text-emphasis-color.json
@@ -13,7 +13,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -18,7 +18,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/text-emphasis-style.json
+++ b/css/properties/text-emphasis-style.json
@@ -13,7 +13,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/text-emphasis.json
+++ b/css/properties/text-emphasis.json
@@ -13,7 +13,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/text-rendering.json
+++ b/css/properties/text-rendering.json
@@ -16,7 +16,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null


### PR DESCRIPTION
This is based on results from Edge 12-18:
https://github.com/foolip/mdn-bcd-results/tree/e16e4ca1e51625a7d720dd926b0ab41268d8c11c

Tests on the form `'propertyName' in document.body.style` were run and
found to return false consistently for these properties.

The script to update BCD is under development:
https://gist.github.com/foolip/eacef197c5ef52e85917dc64cf8d8358

These changes were hand picked from the output as similar and simple cases.