### PR TITLE
Mark some CSS properties as supported in specific versions of Edge

### DIFF
--- a/css/properties/counter-increment.json
+++ b/css/properties/counter-increment.json
@@ -12,7 +12,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/font-optical-sizing.json
+++ b/css/properties/font-optical-sizing.json
@@ -12,7 +12,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -18,7 +18,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": false

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -18,7 +18,8 @@
               "version_added": null
             },
             "edge": {
-              "version_added": "12"
+              "version_added": false,
+              "notes": "Although <code>'fontSizeAdjust' in element.style</code> returns <code>true</code>, this feature isn't supported."
             },
             "edge_mobile": {
               "version_added": false

--- a/css/properties/ime-mode.json
+++ b/css/properties/ime-mode.json
@@ -12,7 +12,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": "12"
+              "version_added": null
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/ime-mode.json
+++ b/css/properties/ime-mode.json
@@ -12,7 +12,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": true

--- a/css/properties/outline-offset.json
+++ b/css/properties/outline-offset.json
@@ -12,7 +12,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "15"
             },
             "edge_mobile": {
               "version_added": null

--- a/css/properties/paint-order.json
+++ b/css/properties/paint-order.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "17"
             },
             "edge_mobile": {
               "version_added": false


### PR DESCRIPTION
This is based on results from Edge 12-18:
https://github.com/foolip/mdn-bcd-results/tree/e16e4ca1e51625a7d720dd926b0ab41268d8c11c

Tests on the form `'propertyName' in document.body.style` were used.

The script to update BCD is under development:
https://gist.github.com/foolip/eacef197c5ef52e85917dc64cf8d8358

The earliest supported version was added `version_added`. These
changes were hand picked from the output.