### PR TITLE
update BCD for window.parent

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5442,7 +5442,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -5451,7 +5451,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null


### PR DESCRIPTION
I reviewed this compatibility on browser stack for both IE and Safari. For validation I used `window.parent === window => true` meant it was implemented. Safari was valid as far back as BrowserStack provides which is Safari 4 so I set it to `true`. IE 8 evaluated to `false` but every version above that evaluated to `true` so I've set the supported version to 9.

If you'd like additional testing let me know.

[Old documentation for IE listing `parent` property](https://msdn.microsoft.com/en-us/ie/ms534326(v=vs.94))

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
