### PR TITLE
Safari doesn't support EventTarget inheritance on MediaQueryList

### DIFF
--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -367,10 +367,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "45"


### PR DESCRIPTION
There have been several reports on the web about this issue, and also [the Apple documentation](https://developer.apple.com/documentation/webkitjs/mediaquerylist) doesn't list the add/removeEventListener methods. 