### PR TITLE
update Chrome support for browserAction.openPopup

### DIFF
--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -364,7 +364,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/openPopup",
             "support": {
               "chrome": {
-                "version_added": 67
+                "version_added": "67"
               },
               "edge": {
                 "version_added": false

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -364,7 +364,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/openPopup",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": 67
               },
               "edge": {
                 "version_added": false


### PR DESCRIPTION
Chrome supports browserAction.openPopup at least from version 67.