### PR TITLE
Standardize secure_context_required fields

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -715,9 +715,9 @@
             "deprecated": false
           }
         },
-        "secure_context_only": {
+        "secure_context_required": {
           "__compat": {
-            "description": "Secure context only",
+            "description": "Secure context required",
             "support": {
               "chrome": {
                 "version_added": "47"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1717,7 +1717,7 @@
         },
         "secure_context_required": {
           "__compat": {
-            "description": "Secure context required (HTTPS)",
+            "description": "Secure context required",
             "support": {
               "chrome": {
                 "version_added": null

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -120,9 +120,9 @@
           }
         }
       },
-      "secure_contexts_only": {
+      "secure_context_required": {
         "__compat": {
-          "description": "Secure contexts only",
+          "description": "Secure context required",
           "support": {
             "chrome": {
               "version_added": "62"

--- a/api/Position.json
+++ b/api/Position.json
@@ -49,7 +49,7 @@
       },
       "secure_context_required": {
         "__compat": {
-          "description": "Secure context required (HTTPS)",
+          "description": "Secure context required",
           "support": {
             "chrome": {
               "version_added": "47"

--- a/api/PositionError.json
+++ b/api/PositionError.json
@@ -49,7 +49,7 @@
       },
       "secure_context_required": {
         "__compat": {
-          "description": "Secure context required (HTTPS)",
+          "description": "Secure context required",
           "support": {
             "chrome": {
               "version_added": "47"

--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -66,7 +66,7 @@
       },
       "secure_context_required": {
         "__compat": {
-          "description": "Secure context required (HTTPS)",
+          "description": "Secure context required",
           "support": {
             "chrome": {
               "version_added": "61"

--- a/html/elements/html.json
+++ b/html/elements/html.json
@@ -110,7 +110,7 @@
           },
           "secure_context_required": {
             "__compat": {
-              "description": "Secure context required (HTTPS)",
+              "description": "Secure context required",
               "support": {
                 "chrome": {
                   "version_added": null


### PR DESCRIPTION
This PR updates the keys of two features that state the requirement of HTTPS to follow the typical name of "secure_context_required", as well as updates the descriptions of all the features to match each other.