### PR TITLE
Update api.WebSocket.readyState support on Edge and safari

### DIFF
--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -601,11 +601,9 @@
             "opera_android": {
               "version_added": null
             },
-            "safari": [
-              {
-                "version_added": "12"
-              }
-            ],
+            "safari": {
+              "version_added": "12"
+            },
             "safari_ios": {
               "version_added": null
             },

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -575,9 +575,14 @@
             "chrome_android": {
               "version_added": true
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "17"
+              }
+            ],
             "edge_mobile": {
               "version_added": null
             },
@@ -596,9 +601,11 @@
             "opera_android": {
               "version_added": null
             },
-            "safari": {
-              "version_added": null
-            },
+            "safari": [
+              {
+                "version_added": "12"
+              }
+            ],
             "safari_ios": {
               "version_added": null
             },


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
Edge 17.17134 support websocket readyState
mac safari 12.0.3 support websocket readyState

- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)

**Edge 17.17134**
![image](https://user-images.githubusercontent.com/11222746/54658762-107e9c80-4b0a-11e9-9d12-80a0c3456e01.png)

**mac safari 12.0.3 ** 
![image](https://user-images.githubusercontent.com/11222746/54658932-b6caa200-4b0a-11e9-80e4-9124d69439dd.png)

