### PR TITLE
Update DOMMatrix support for Safari

### DIFF
--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -944,7 +944,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -992,7 +992,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1040,7 +1040,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1088,7 +1088,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1136,7 +1136,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1184,7 +1184,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1280,7 +1280,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1328,7 +1328,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1376,7 +1376,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1424,7 +1424,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1472,7 +1472,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1520,7 +1520,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1568,7 +1568,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1616,7 +1616,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1668,7 +1668,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1812,7 +1812,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -1860,7 +1860,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -2004,7 +2004,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -2148,7 +2148,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false

--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -35,7 +35,7 @@
             "version_added": "11"
           },
           "safari_ios": {
-            "version_added": "11"
+            "version_added": "11.3"
           },
           "webview_android": {
             "version_added": "61"
@@ -82,7 +82,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -131,7 +131,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -179,7 +179,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -227,7 +227,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -275,7 +275,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -323,7 +323,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -371,7 +371,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -419,7 +419,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -467,7 +467,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -515,7 +515,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -563,7 +563,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -611,7 +611,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -659,7 +659,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -707,7 +707,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -755,7 +755,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -803,7 +803,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -851,7 +851,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -899,7 +899,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -947,7 +947,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -995,7 +995,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1043,7 +1043,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1091,7 +1091,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1139,7 +1139,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1187,7 +1187,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1235,7 +1235,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1283,7 +1283,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1331,7 +1331,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1379,7 +1379,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1427,7 +1427,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1475,7 +1475,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1523,7 +1523,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1571,7 +1571,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1619,7 +1619,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1671,7 +1671,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1719,7 +1719,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1815,7 +1815,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1863,7 +1863,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1911,7 +1911,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -1959,7 +1959,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -2007,7 +2007,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -2055,7 +2055,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -2151,7 +2151,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": "61"

--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -32,10 +32,10 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": false
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11"
           },
           "webview_android": {
             "version_added": "61"
@@ -79,10 +79,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -128,10 +128,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -176,10 +176,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -224,10 +224,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -272,10 +272,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -320,10 +320,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -368,10 +368,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -416,10 +416,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -464,10 +464,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -512,10 +512,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -560,10 +560,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -608,10 +608,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -656,10 +656,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -704,10 +704,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -752,10 +752,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -800,10 +800,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -848,10 +848,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -896,10 +896,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -947,7 +947,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -995,7 +995,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1043,7 +1043,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1091,7 +1091,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1139,7 +1139,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1187,7 +1187,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1232,10 +1232,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1283,7 +1283,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1331,7 +1331,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1379,7 +1379,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1427,7 +1427,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1475,7 +1475,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1523,7 +1523,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1571,7 +1571,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1619,7 +1619,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1671,7 +1671,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1716,10 +1716,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1815,7 +1815,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1863,7 +1863,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1908,10 +1908,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -1956,10 +1956,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -2007,7 +2007,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -2052,10 +2052,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -2151,7 +2151,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -84,6 +84,9 @@
         "11.1": {
           "status": "retired"
         },
+        "11.3": {
+          "status": "retired"
+        },
         "12": {
           "release_date": "2018-09-17",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_release_notes",


### PR DESCRIPTION
BCD for DOMMatrix in Safari currently shows a lot of inaccurate `false`s.

Confluence updated a lot of information for desktop Safari, I wrote a [test script here](https://codepen.io/gingerchris/pen/VRBqmw) to verify things are working in iOS Safari as well.

[Worker support was added here](https://trac.webkit.org/changeset/221512/webkit)
[`toFloat32/64Array` was added here](https://trac.webkit.org/changeset/217764/webkit)

I've done my best to track down the relevant WebKit / Safari release tag containing this these features and I think it's [this](https://trac.webkit.org/changeset/221375/webkit).  
From there I've cross referenced the dates with the [info from here](https://www.somegeekintn.com/blog/stuff/iosvers/) to determine the iOS Safari version numbers. 

It looks like elsewhere in this project when referring to iOS Safari we use the iOS version number rather than the Safari one? I.E `11` rather than `604.1`.  If that's not the case then I will need to change this.
