### PR TITLE
[Chrome] bug 818643: Implement `RTCSctpTransport`

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -3885,12 +3885,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/sctp",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/943976'>bug 943976</a>."
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/943976'>bug 943976</a>."
+              "version_added": "76"
             },
             "edge": {
               "version_added": false
@@ -3925,8 +3923,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/943976'>bug 943976</a>."
+              "version_added": "76"
             }
           },
           "status": {

--- a/api/RTCSctpTransport.json
+++ b/api/RTCSctpTransport.json
@@ -5,12 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSctpTransport",
         "support": {
           "chrome": {
-            "version_added": false,
-            "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
+            "version_added": "76"
           },
           "chrome_android": {
-            "version_added": false,
-            "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
+            "version_added": "76"
           },
           "edge": {
             "version_added": false
@@ -45,8 +43,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": false,
-            "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
+            "version_added": "76"
           }
         },
         "status": {
@@ -60,12 +57,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSctpTransport/maxChannels",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/943976'>bug 943976</a>."
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/943976'>bug 943976</a>."
+              "version_added": "76"
             },
             "edge": {
               "version_added": false
@@ -100,8 +95,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/943976'>bug 943976</a>."
+              "version_added": "76"
             }
           },
           "status": {
@@ -116,12 +110,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSctpTransport/maxMessageSize",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/943975'>bug 943975</a>."
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/943975'>bug 943975</a>."
+              "version_added": "76"
             },
             "edge": {
               "version_added": false
@@ -156,8 +148,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/943975'>bug 943975</a>."
+              "version_added": "76"
             }
           },
           "status": {
@@ -172,12 +163,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSctpTransport/onstatechange",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
+              "version_added": "76"
             },
             "edge": {
               "version_added": false
@@ -212,8 +201,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
+              "version_added": "76"
             }
           },
           "status": {
@@ -228,12 +216,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSctpTransport/transport",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
+              "version_added": "76"
             },
             "edge": {
               "version_added": false
@@ -268,8 +254,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
+              "version_added": "76"
             }
           },
           "status": {
@@ -284,12 +269,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSctpTransport/state",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
+              "version_added": "76"
             },
             "edge": {
               "version_added": false
@@ -324,8 +307,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
+              "version_added": "76"
             }
           },
           "status": {


### PR DESCRIPTION
See [Chrome bug 818643](https://bugs.chromium.org/p/chromium/issues/detail?id=818643) for details. The commit date indicates version 74.

review?(@jpmedley)