### PR TITLE
[Chrome] Add automationRate to AudioParam.

### DIFF
--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -52,7 +52,7 @@
       },
       "automationRate": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/atomationRate",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/automationRate",
           "support": {
             "chrome": {
               "version_added": "68"

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -101,210 +101,6 @@
           }
         }
       },
-      "defaultValue": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/defaultValue",
-          "support": {
-            "chrome": {
-              "version_added": "14"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": "25"
-            },
-            "firefox_android": {
-              "version_added": "26"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": "15"
-            },
-            "safari": {
-              "version_added": "6"
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "maxValue": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/maxValue",
-          "support": {
-            "chrome": {
-              "version_added": "52"
-            },
-            "chrome_android": {
-              "version_added": "52"
-            },
-            "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": "53"
-            },
-            "firefox_android": {
-              "version_added": "53"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "39"
-            },
-            "opera_android": {
-              "version_added": "39"
-            },
-            "safari": {
-              "version_added": "6"
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
-            "webview_android": {
-              "version_added": "52"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "minValue": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/minValue",
-          "support": {
-            "chrome": {
-              "version_added": "52"
-            },
-            "chrome_android": {
-              "version_added": "52"
-            },
-            "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": "53"
-            },
-            "firefox_android": {
-              "version_added": "53"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "39"
-            },
-            "opera_android": {
-              "version_added": "39"
-            },
-            "safari": {
-              "version_added": "6"
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
-            "webview_android": {
-              "version_added": "52"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "value": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/value",
-          "support": {
-            "chrome": {
-              "version_added": "14"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": "25"
-            },
-            "firefox_android": {
-              "version_added": "26"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": "15"
-            },
-            "safari": {
-              "version_added": "6"
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "cancelAndHoldAtTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/cancelAndHoldAtTime",
@@ -394,6 +190,57 @@
       "cancelScheduledValues": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/cancelScheduledValues",
+          "support": {
+            "chrome": {
+              "version_added": "14"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "25"
+            },
+            "firefox_android": {
+              "version_added": "26"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "defaultValue": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/defaultValue",
           "support": {
             "chrome": {
               "version_added": "14"
@@ -544,6 +391,108 @@
           }
         }
       },
+      "maxValue": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/maxValue",
+          "support": {
+            "chrome": {
+              "version_added": "52"
+            },
+            "chrome_android": {
+              "version_added": "52"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "39"
+            },
+            "opera_android": {
+              "version_added": "39"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "52"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "minValue": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/minValue",
+          "support": {
+            "chrome": {
+              "version_added": "52"
+            },
+            "chrome_android": {
+              "version_added": "52"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "39"
+            },
+            "opera_android": {
+              "version_added": "39"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "52"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "setTargetAtTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/setTargetAtTime",
@@ -649,6 +598,57 @@
       "setValueCurveAtTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/setValueCurveAtTime",
+          "support": {
+            "chrome": {
+              "version_added": "14"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "25"
+            },
+            "firefox_android": {
+              "version_added": "26"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "15"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "value": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/value",
           "support": {
             "chrome": {
               "version_added": "14"

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -50,7 +50,7 @@
           "deprecated": false
         }
       },
-      "atomationRate": {
+      "automationRate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/atomationRate",
           "support": {

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -52,7 +52,7 @@
       },
       "atomationRate": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/defaultValue",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/atomationRate",
           "support": {
             "chrome": {
               "version_added": "68"

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -50,6 +50,57 @@
           "deprecated": false
         }
       },
+      "atomationRate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/defaultValue",
+          "support": {
+            "chrome": {
+              "version_added": "68"
+            },
+            "chrome_android": {
+              "version_added": "68"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "68"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "defaultValue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/defaultValue",


### PR DESCRIPTION
`automationRate` [landed in 68](https://storage.googleapis.com/chromium-find-releases-static/596.html#59636b605b8e4b382a58a4bd8827a3a06d1df42d).

Notice that I've added and alphabetize in separate commits.