### PR TITLE
[Chrome] Add and correct some audio constructors.

### DIFF
--- a/api/AudioProcessingEvent.json
+++ b/api/AudioProcessingEvent.json
@@ -50,6 +50,58 @@
           "deprecated": true
         }
       },
+      "AudioProcessingEvent": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioProcessingEvent/AudioProcessingEvent",
+          "description": "<code>AudioProcessingEvent()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "57"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
       "inputBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioProcessingEvent/inputBuffer",

--- a/api/OfflineAudioCompletionEvent.json
+++ b/api/OfflineAudioCompletionEvent.json
@@ -56,11 +56,11 @@
           "description": "<code>OfflineAudioCompletionEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "55",
+              "version_added": "57",
               "notes": "Before Chrome 59, the default values were not supported."
             },
             "chrome_android": {
-              "version_added": "55",
+              "version_added": "57",
               "notes": "Before Chrome 59, the default values were not supported."
             },
             "edge": {
@@ -94,7 +94,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "55",
+              "version_added": "57",
               "notes": "Before version 59, the default values were not supported."
             }
           },


### PR DESCRIPTION
* Adds `AudioProcessingEvent()` constructor.
* Corrects version number for `OfflineAudioCompletionEvent()`.

Both come from [the same commit](https://chromium.googlesource.com/chromium/src/+/ba258a3d5e041db72953fd72f19e78747ef74602).