### PR TITLE
feat(api): #3686 safari support for replaceWith, remove experimental

### DIFF
--- a/api/ChildNode.json
+++ b/api/ChildNode.json
@@ -235,10 +235,10 @@
               "version_added": "39"
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -248,7 +248,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
- [x] Summarize your changes
  - Removes `Experimental` flag and set Safari support (`true`) for `api.ChildNode.replaceWith`
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
  - [caniuse](https://caniuse.com/#feat=dom-manip-convenience) list support starting at Safari@10
- [x] Data: if you tested something, describe how you tested with details like browser and version
  - Tested in Safari@12.0.3 using [this bin](http://jsbin.com/fiqacod/edit?html,js,output)
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
  - ✅ 
- [x] Link to related issues or pull requests, if any
  - fixes #3686 
