### PR TITLE
[Chrome] Corrections to AudioWorklet interfaces.

### DIFF
--- a/api/AudioWorkletNode.json
+++ b/api/AudioWorkletNode.json
@@ -50,9 +50,10 @@
           "deprecated": false
         }
       },
-      "onprocessorstatechange": {
+      "AudioWorkletNode": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/onprocessorstatechange",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/AudioWorkletNode",
+          "description": "<code>AudioWorkletNode()</code> constructor",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -152,9 +153,9 @@
           }
         }
       },
-      "port": {
+      "processorerror_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/port",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/processorerror_event",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -203,15 +204,15 @@
           }
         }
       },
-      "processorState": {
+      "port": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/processorState",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/port",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "edge": {
               "version_added": null
@@ -244,7 +245,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "66"
             }
           },
           "status": {

--- a/api/AudioWorkletProcessor.json
+++ b/api/AudioWorkletProcessor.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletProcessor",
         "support": {
           "chrome": {
-            "version_added": "66"
+            "version_added": "64"
           },
           "chrome_android": {
-            "version_added": "66"
+            "version_added": "64"
           },
           "edge": {
             "version_added": null
@@ -41,7 +41,7 @@
             "version_added": null
           },
           "webview_android": {
-            "version_added": "66"
+            "version_added": "64"
           }
         },
         "status": {
@@ -50,15 +50,16 @@
           "deprecated": false
         }
       },
-      "port": {
+      "AudioWorkletProcessor": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletProcessor/port",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletProcessor/AudioWorkletProcessor",
+          "description": "<code>AudioWorkletProcessor()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": "64"
             },
             "chrome_android": {
-              "version_added": "66"
+              "version_added": "64"
             },
             "edge": {
               "version_added": null
@@ -91,7 +92,58 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "66"
+              "version_added": "64"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "port": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletProcessor/port",
+          "support": {
+            "chrome": {
+              "version_added": "64"
+            },
+            "chrome_android": {
+              "version_added": "64"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "64"
             }
           },
           "status": {


### PR DESCRIPTION
`processorstatechange` `processorState` were add and [removed](https://storage.googleapis.com/chromium-find-releases-static/df8.html#df8a43ce8e32a77d676a4a2c1326a51559819c06) in the same version, which I failed to notice before. `onprocessorerror` was added in the same commit.

`AudioWorkletProcessor` [actually landed in 64](https://storage.googleapis.com/chromium-find-releases-static/d46.html#d4669e6295fdb410b85d385f20c280ba6bfb1dda).