### PR TITLE
Mark many interface members as not supported in Chrome

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -639,7 +639,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioContext/createMediaStreamTrackSource",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
               "version_added": null

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1326,7 +1326,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/fastSeek",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -3659,7 +3659,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/videoTracks",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": "12"

--- a/api/RTCCertificate.json
+++ b/api/RTCCertificate.json
@@ -157,7 +157,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCCertificate/getSupportedAlgorithms",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
               "version_added": null

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -1155,7 +1155,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/priority",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
               "version_added": null

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -770,7 +770,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/usernameFragment",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
               "version_added": null

--- a/api/RTCPeerConnectionIceEvent.json
+++ b/api/RTCPeerConnectionIceEvent.json
@@ -179,7 +179,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionIceEvent/url",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
               "version_added": null

--- a/api/Response.json
+++ b/api/Response.json
@@ -1177,7 +1177,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/trailer",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
               "version_added": null

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -54,7 +54,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
               "version_added": null

--- a/api/SVGUseElement.json
+++ b/api/SVGUseElement.json
@@ -51,7 +51,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
               "version_added": null
@@ -145,7 +145,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
               "version_added": null

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -571,7 +571,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/onmessageerror",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
               "version_added": null
@@ -622,7 +622,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/startMessages",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
               "version_added": null

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -622,7 +622,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/startMessages",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": null
             },
             "chrome_android": {
               "version_added": null

--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -615,7 +615,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/sourceBuffer",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
               "version_added": null


### PR DESCRIPTION
This is based on results from Chrome 73.0.3683.75 / Windows 10:
https://github.com/foolip/mdn-bcd-results/pull/100

Tests were generated from Web IDL, for example:
```js
bcd.test('api.Response.trailer', function() {
  return 'trailer' in Response.prototype;
});
```

The result will be false only if the `Response` interface is exposed but
`trailer` isn't in the prototype. If the interface is not exposed the test
would have thrown an exception and given a null result. Only false results
were used, makes false negatives unlikely.

The script used to update BCD was:
https://gist.github.com/foolip/bc55c2830cd9a730b0881fe181c4bdc0

The 14 entries changed from null to false for chrome are:
api.AudioContext.createMediaStreamTrackSource
api.HTMLMediaElement.fastSeek
api.HTMLMediaElement.videoTracks
api.Response.trailer
api.RTCCertificate.getSupportedAlgorithms
api.RTCDataChannel.priority
api.RTCIceCandidate.usernameFragment
api.RTCPeerConnectionIceEvent.url
api.ServiceWorkerContainer.onmessageerror
api.ServiceWorkerContainer.startMessages
api.SVGAElement.download
api.SVGUseElement.animatedInstanceRoot
api.SVGUseElement.instanceRoot
api.TextTrack.sourceBuffer