### PR TITLE
Add cross-origin resource policy compat data

### DIFF
--- a/http/headers/cross-origin-resource-policy.json
+++ b/http/headers/cross-origin-resource-policy.json
@@ -1,7 +1,7 @@
 {
   "http": {
     "headers": {
-      "corb": {
+      "Cross-Origin-Resource-Policy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy",
           "support": {

--- a/http/headers/cross-origin-resource-policy.json
+++ b/http/headers/cross-origin-resource-policy.json
@@ -1,0 +1,57 @@
+{
+  "http": {
+    "headers": {
+      "corb": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy",
+          "support": {
+            "chrome": {
+              "version_added": "73"
+            },
+            "chrome_android": {
+              "version_added": "73"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "12"
+            },
+            "safari_ios": {
+              "version_added": "12"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "73"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/cross-origin-resource-policy.json
+++ b/http/headers/cross-origin-resource-policy.json
@@ -47,7 +47,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
Refs: https://developer.apple.com/documentation/safari_release_notes/safari_12_release_notes https://www.chromestatus.com/feature/4647328103268352 https://webkit.org/blog/8332/release-notes-for-safari-technology-preview-59/

This PR adds compatibility data for the newish Cross-Origin-Resource-Policy header to prevent cross-origin/cross-site reads.
