### PR TITLE
Add data of passive true on document level wheel event

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -481,6 +481,57 @@
                 "deprecated": false
               }
             }
+          },
+          "passive_true_wheel": {
+            "__compat": {
+              "description": "<code>passive</code> option defaults to <code>true</code> for <code>wheel</code> and <code>mousewheel</code> events",
+              "support": {
+                "chrome": {
+                  "version_added": "73"
+                },
+                "chrome_android": {
+                  "version_added": "73"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "edge_mobile": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": "73"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
Since Chrome 73, the document level `wheel` and `mousewheel` event is set to passive by default. The compat data don't have this change. So I send this PR to fill it.

Only Chrome supports this now. Firefox is considering it[[1][]]

Refs:
* https://developers.google.com/web/updates/2019/02/scrolling-intervention
* https://www.chromestatus.com/features/6662647093133312
* https://github.com/WICG/interventions/issues/64

[1]:https://bugzilla.mozilla.org/show_bug.cgi?id=1526725
