### PR TITLE
Mark ServiceWorkerContainer.startMessages as shipping in Chromium 74

### DIFF
--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -622,10 +622,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/startMessages",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "74"
             },
             "edge": {
               "version_added": null
@@ -643,10 +643,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "61"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "61"
             },
             "safari": {
               "version_added": null
@@ -658,7 +658,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "74"
             }
           },
           "status": {


### PR DESCRIPTION
https://chromium.googlesource.com/chromium/src/+/1eef889053f1b30d62acccc34b1a3e66c5afd5e8
https://www.chromestatus.com/features/5751307839209472

There is no flag, so any Chromium-based browser will get this.