### PR TITLE
Add Chrome support for HTML data URLs

### DIFF
--- a/http/data-url.json
+++ b/http/data-url.json
@@ -122,7 +122,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": false
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null

--- a/http/data-url.json
+++ b/http/data-url.json
@@ -155,7 +155,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/http/data-url.json
+++ b/http/data-url.json
@@ -119,7 +119,7 @@
           "description": "HTML files",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
               "version_added": null


### PR DESCRIPTION
Added Chrome support for HTML data URLs.

Example: data:text/html;base64,PHA+SGVsbG8gV29ybGQ8L3A+