### PR TITLE
Change Safari macOS/iOS support from null to true based on tests

### DIFF
--- a/api/AnalyserNode.json
+++ b/api/AnalyserNode.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -137,7 +137,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -188,7 +188,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -239,7 +239,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -290,7 +290,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -341,7 +341,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -392,7 +392,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -443,7 +443,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -545,7 +545,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -207,7 +207,7 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/Attr.json
+++ b/api/Attr.json
@@ -81,10 +81,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -126,10 +126,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -171,10 +171,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/AudioBuffer.json
+++ b/api/AudioBuffer.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -142,7 +142,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -193,7 +193,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -244,7 +244,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -295,7 +295,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -448,7 +448,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -142,7 +142,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -244,7 +244,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -295,7 +295,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -346,7 +346,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -450,7 +450,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -502,7 +502,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/AudioDestinationNode.json
+++ b/api/AudioDestinationNode.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -85,7 +85,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/AudioListener.json
+++ b/api/AudioListener.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -678,7 +678,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -729,7 +729,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/AudioNode.json
+++ b/api/AudioNode.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -85,7 +85,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -136,7 +136,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -187,7 +187,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -238,7 +238,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -289,7 +289,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -340,7 +340,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -391,7 +391,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -442,7 +442,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -85,7 +85,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -136,7 +136,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -187,7 +187,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -238,7 +238,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -375,7 +375,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -426,7 +426,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -477,7 +477,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -528,7 +528,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -579,7 +579,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -630,7 +630,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/AudioProcessingEvent.json
+++ b/api/AudioProcessingEvent.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -85,7 +85,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -136,7 +136,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -187,7 +187,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/AudioTrack.json
+++ b/api/AudioTrack.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -82,10 +82,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -133,10 +133,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -184,10 +184,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -235,10 +235,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -286,10 +286,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -337,7 +337,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null

--- a/api/BiquadFilterNode.json
+++ b/api/BiquadFilterNode.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -142,7 +142,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -193,7 +193,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -244,7 +244,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -295,7 +295,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -346,7 +346,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -397,7 +397,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -35,7 +35,7 @@
             "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -257,7 +257,7 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/CSSKeyframeRule.json
+++ b/api/CSSKeyframeRule.json
@@ -48,7 +48,7 @@
             "version_added": "4"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "45"
@@ -95,7 +95,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "45"
@@ -143,7 +143,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "45"

--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -181,10 +181,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -229,10 +229,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -277,10 +277,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -325,10 +325,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/CSSMediaRule.json
+++ b/api/CSSMediaRule.json
@@ -34,10 +34,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "45"
@@ -81,10 +81,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/CSSNamespaceRule.json
+++ b/api/CSSNamespaceRule.json
@@ -32,10 +32,10 @@
             "version_added": "36"
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -82,10 +82,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -133,10 +133,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/CSSPageRule.json
+++ b/api/CSSPageRule.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -85,7 +85,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -133,10 +133,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/CSSRule.json
+++ b/api/CSSRule.json
@@ -79,10 +79,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -127,10 +127,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -175,10 +175,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -223,10 +223,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/CSSRuleList.json
+++ b/api/CSSRuleList.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -79,10 +79,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -127,10 +127,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/CSSStyleDeclaration.json
+++ b/api/CSSStyleDeclaration.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "37"
@@ -82,7 +82,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -527,7 +527,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "46"

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -607,10 +607,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/ChannelMergerNode.json
+++ b/api/ChannelMergerNode.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/ChannelSplitterNode.json
+++ b/api/ChannelSplitterNode.json
@@ -39,7 +39,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/CharacterData.json
+++ b/api/CharacterData.json
@@ -129,10 +129,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -177,10 +177,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -225,10 +225,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -273,10 +273,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -321,10 +321,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -369,10 +369,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -417,10 +417,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -36,10 +36,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true

--- a/api/CompositionEvent.json
+++ b/api/CompositionEvent.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -134,10 +134,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/ConvolverNode.json
+++ b/api/ConvolverNode.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -137,7 +137,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -188,7 +188,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -134,10 +134,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -185,10 +185,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -236,10 +236,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -35,7 +35,7 @@
             "version_added": "3.2"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -131,7 +131,7 @@
               "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/DOMQuad.json
+++ b/api/DOMQuad.json
@@ -32,10 +32,10 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -134,10 +134,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -185,10 +185,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -236,10 +236,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -287,10 +287,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -338,10 +338,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -389,10 +389,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -440,10 +440,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -491,10 +491,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -146,10 +146,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/DOMStringMap.json
+++ b/api/DOMStringMap.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -184,7 +184,7 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -285,10 +285,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -180,7 +180,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -231,7 +231,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -282,7 +282,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -333,7 +333,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -384,7 +384,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -891,7 +891,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -942,7 +942,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -993,7 +993,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false

--- a/api/DelayNode.json
+++ b/api/DelayNode.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -140,7 +140,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/Document.json
+++ b/api/Document.json
@@ -231,7 +231,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -278,10 +278,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "64",
@@ -334,10 +334,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "64",
@@ -386,10 +386,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -642,10 +642,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -740,10 +740,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "64",
@@ -841,10 +841,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "64",
@@ -1031,7 +1031,7 @@
             ],
             "safari": [
               {
-                "version_added": null
+                "version_added": true
               },
               {
                 "alternative_name": "charset",
@@ -1044,7 +1044,7 @@
             ],
             "safari_ios": [
               {
-                "version_added": null
+                "version_added": true
               },
               {
                 "alternative_name": "charset",
@@ -1111,10 +1111,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "64",
@@ -1162,10 +1162,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "45",
@@ -1211,10 +1211,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43"
@@ -1307,10 +1307,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43"
@@ -1567,10 +1567,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1615,10 +1615,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1666,7 +1666,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2015,10 +2015,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2159,10 +2159,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2207,10 +2207,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2255,10 +2255,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2303,10 +2303,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2774,7 +2774,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2824,7 +2824,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "45",
@@ -2874,10 +2874,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "45",
@@ -2923,10 +2923,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2971,10 +2971,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3217,10 +3217,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3686,10 +3686,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "45",
@@ -4353,7 +4353,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
@@ -4409,10 +4409,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "64",
@@ -4571,10 +4571,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5054,10 +5054,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5102,10 +5102,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5479,10 +5479,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5527,10 +5527,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5671,10 +5671,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5769,10 +5769,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "64",
@@ -6277,10 +6277,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6325,10 +6325,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6591,10 +6591,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6638,7 +6638,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
@@ -6686,7 +6686,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null
@@ -6734,10 +6734,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6846,10 +6846,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -7003,10 +7003,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "41",
@@ -7156,10 +7156,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "45",
@@ -8175,10 +8175,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -8223,10 +8223,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -8333,10 +8333,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -8435,10 +8435,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -8685,10 +8685,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -8857,10 +8857,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "64",
@@ -9265,10 +9265,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -9952,10 +9952,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "64",
@@ -10099,10 +10099,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "45",
@@ -10150,10 +10150,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "45",

--- a/api/DynamicsCompressorNode.json
+++ b/api/DynamicsCompressorNode.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -140,7 +140,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -191,7 +191,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -242,7 +242,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -295,7 +295,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -347,7 +347,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -398,7 +398,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/Element.json
+++ b/api/Element.json
@@ -424,7 +424,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1050,7 +1050,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1101,7 +1101,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -2019,7 +2019,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -2122,7 +2122,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -2173,7 +2173,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -2224,7 +2224,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -2531,7 +2531,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -2584,7 +2584,7 @@
               "notes": "Safari on iOS 8 and OS X 10.10 returns a <code>NodeList</code>."
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -2889,7 +2889,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -2941,7 +2941,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -3330,7 +3330,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -3592,7 +3592,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -3981,7 +3981,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -4229,7 +4229,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -4280,7 +4280,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -4331,7 +4331,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -5485,7 +5485,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -5536,7 +5536,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -5587,7 +5587,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -5638,7 +5638,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -5691,7 +5691,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -5953,7 +5953,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -6055,7 +6055,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -6106,7 +6106,7 @@
               "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/ErrorEvent.json
+++ b/api/ErrorEvent.json
@@ -128,10 +128,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -176,10 +176,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -224,10 +224,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -272,10 +272,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -320,10 +320,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Event.json
+++ b/api/Event.json
@@ -128,10 +128,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -231,10 +231,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -279,10 +279,10 @@
               "version_added": "40"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "53"
@@ -562,10 +562,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "45"
@@ -1322,10 +1322,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "45"

--- a/api/FileList.json
+++ b/api/FileList.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -82,10 +82,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -133,10 +133,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -179,7 +179,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -227,7 +227,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -291,7 +291,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": [
               {
@@ -363,7 +363,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": [
               {
@@ -419,7 +419,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -467,7 +467,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -515,7 +515,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -563,7 +563,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -611,7 +611,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -659,7 +659,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"

--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -82,7 +82,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "48"
@@ -130,7 +130,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -178,7 +178,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "48"
@@ -226,7 +226,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "48"
@@ -274,7 +274,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -322,7 +322,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "48"
@@ -370,7 +370,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "48"
@@ -418,7 +418,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "48"
@@ -466,7 +466,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -514,7 +514,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "48"

--- a/api/FormData.json
+++ b/api/FormData.json
@@ -36,7 +36,7 @@
             "version_added": "5"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -142,7 +142,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/GainNode.json
+++ b/api/GainNode.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -140,7 +140,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/HTMLAllCollection.json
+++ b/api/HTMLAllCollection.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -79,10 +79,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -127,10 +127,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -175,10 +175,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -133,7 +133,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null

--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -543,10 +543,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -84,10 +84,10 @@
               "version_added": "38"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/HTMLCollection.json
+++ b/api/HTMLCollection.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -79,10 +79,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -127,10 +127,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -178,7 +178,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLDetailsElement.json
+++ b/api/HTMLDetailsElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -82,10 +82,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -82,7 +82,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -431,7 +431,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -632,7 +632,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -680,7 +680,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -827,7 +827,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -1023,7 +1023,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1221,7 +1221,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -1575,7 +1575,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -1771,7 +1771,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "47"
@@ -1819,7 +1819,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "47"
@@ -1867,7 +1867,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "47"
@@ -1915,7 +1915,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "47"
@@ -1963,7 +1963,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "47"
@@ -2056,10 +2056,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "71"
@@ -2104,10 +2104,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "71"
@@ -2152,10 +2152,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "71"
@@ -2867,7 +2867,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43"
@@ -2916,7 +2916,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "45"
@@ -2975,7 +2975,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -3023,7 +3023,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -3279,7 +3279,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"

--- a/api/HTMLFontElement.json
+++ b/api/HTMLFontElement.json
@@ -23,7 +23,7 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {
@@ -55,7 +55,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -121,7 +121,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/api/HTMLFormControlsCollection.json
+++ b/api/HTMLFormControlsCollection.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -95,10 +95,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -82,10 +82,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -133,10 +133,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -184,10 +184,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -235,10 +235,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -286,10 +286,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -337,10 +337,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -388,10 +388,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -439,10 +439,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -490,10 +490,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -541,10 +541,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -592,10 +592,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -646,7 +646,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -745,10 +745,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -847,10 +847,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/HTMLFrameElement.json
+++ b/api/HTMLFrameElement.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null
@@ -79,10 +79,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -127,10 +127,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -175,10 +175,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -223,10 +223,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -271,10 +271,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -319,10 +319,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -367,10 +367,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -415,10 +415,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -463,10 +463,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -511,10 +511,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/HTMLFrameSetElement.json
+++ b/api/HTMLFrameSetElement.json
@@ -173,10 +173,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -220,10 +220,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -267,10 +267,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -82,7 +82,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -126,10 +126,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -448,7 +448,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -496,7 +496,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -544,7 +544,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -592,7 +592,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -640,7 +640,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -688,7 +688,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -879,7 +879,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,
@@ -928,7 +928,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1025,7 +1025,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1072,7 +1072,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1120,7 +1120,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -122,10 +122,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -167,10 +167,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -212,10 +212,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -423,10 +423,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "64"
@@ -513,10 +513,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -558,10 +558,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -603,10 +603,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -648,10 +648,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -738,10 +738,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1121,10 +1121,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1169,10 +1169,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1217,10 +1217,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1265,10 +1265,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -81,7 +81,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -128,7 +128,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -175,7 +175,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -221,10 +221,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -271,7 +271,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -365,7 +365,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -412,7 +412,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -459,7 +459,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -503,10 +503,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -550,10 +550,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -597,10 +597,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -832,10 +832,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -930,7 +930,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -977,7 +977,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1075,7 +1075,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1174,7 +1174,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1230,7 +1230,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1281,7 +1281,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1342,10 +1342,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1397,10 +1397,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1447,7 +1447,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1494,7 +1494,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1682,7 +1682,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -82,7 +82,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "50"
@@ -127,10 +127,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -271,10 +271,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "54"
@@ -323,10 +323,10 @@
               "notes": "Before Opera 37, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,

--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -268,10 +268,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -315,10 +315,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -503,10 +503,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -161,10 +161,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": [
               {
@@ -229,10 +229,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -908,7 +908,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43"
@@ -1347,7 +1347,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -1628,7 +1628,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43"
@@ -2611,7 +2611,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2653,7 +2653,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2747,7 +2747,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3148,7 +3148,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3450,7 +3450,7 @@
               "notes": "Currently only supports <code>MediaStream</code> objects."
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "52",
@@ -3592,7 +3592,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -3694,7 +3694,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/api/HTMLMenuElement.json
+++ b/api/HTMLMenuElement.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null
@@ -79,10 +79,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/HTMLMeterElement.json
+++ b/api/HTMLMeterElement.json
@@ -298,7 +298,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/api/HTMLOptionsCollection.json
+++ b/api/HTMLOptionsCollection.json
@@ -133,10 +133,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -184,10 +184,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -235,10 +235,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/HTMLOutputElement.json
+++ b/api/HTMLOutputElement.json
@@ -237,7 +237,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false

--- a/api/HTMLProgressElement.json
+++ b/api/HTMLProgressElement.json
@@ -226,7 +226,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -36,7 +36,7 @@
             "version_added": "1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "1"
@@ -80,10 +80,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -176,10 +176,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -512,10 +512,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -560,10 +560,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -608,10 +608,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -656,10 +656,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -704,10 +704,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -754,10 +754,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -802,10 +802,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -850,10 +850,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -949,10 +949,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -997,10 +997,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1048,7 +1048,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1093,10 +1093,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1141,10 +1141,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1237,10 +1237,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1285,10 +1285,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1333,10 +1333,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1381,10 +1381,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -204,7 +204,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -318,7 +318,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLTableColElement.json
+++ b/api/HTMLTableColElement.json
@@ -127,10 +127,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -175,10 +175,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/HTMLTableSectionElement.json
+++ b/api/HTMLTableSectionElement.json
@@ -127,10 +127,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -175,10 +175,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null
@@ -127,10 +127,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -229,7 +229,7 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -274,10 +274,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/HashChangeEvent.json
+++ b/api/HashChangeEvent.json
@@ -79,10 +79,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -130,10 +130,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/History.json
+++ b/api/History.json
@@ -79,10 +79,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -127,10 +127,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -175,10 +175,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -223,10 +223,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -417,10 +417,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -657,10 +657,10 @@
               "version_added": "35"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -187,7 +187,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -286,10 +286,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -340,7 +340,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -807,7 +807,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -909,7 +909,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1112,10 +1112,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1163,10 +1163,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1214,10 +1214,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1265,10 +1265,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -137,10 +137,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/MediaError.json
+++ b/api/MediaError.json
@@ -32,7 +32,7 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
             "version_added": true
@@ -82,7 +82,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": true

--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -32,10 +32,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -133,10 +133,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -247,10 +247,10 @@
               "version_removed": "39"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -299,10 +299,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -350,10 +350,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -401,10 +401,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -452,10 +452,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -505,10 +505,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -556,10 +556,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -607,10 +607,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -660,10 +660,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -711,10 +711,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/MediaStreamAudioDestinationNode.json
+++ b/api/MediaStreamAudioDestinationNode.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -140,7 +140,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/MediaStreamAudioSourceNode.json
+++ b/api/MediaStreamAudioSourceNode.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -137,10 +137,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -82,10 +82,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -133,10 +133,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -235,10 +235,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -286,10 +286,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": false
@@ -337,7 +337,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -388,7 +388,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": "11"
@@ -493,10 +493,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -595,10 +595,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -646,10 +646,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -697,10 +697,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -748,10 +748,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -850,10 +850,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -901,10 +901,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -952,10 +952,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1054,10 +1054,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1161,10 +1161,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/MediaStreamTrackEvent.json
+++ b/api/MediaStreamTrackEvent.json
@@ -32,10 +32,10 @@
             "version_added": "42"
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -134,10 +134,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -439,10 +439,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/MimeType.json
+++ b/api/MimeType.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -82,10 +82,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -133,10 +133,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -184,10 +184,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -235,10 +235,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/MimeTypeArray.json
+++ b/api/MimeTypeArray.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -84,10 +84,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -136,10 +136,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -189,10 +189,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -247,7 +247,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -304,7 +304,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -611,7 +611,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -815,7 +815,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1024,7 +1024,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1126,7 +1126,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1228,7 +1228,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1330,7 +1330,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1504,7 +1504,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1759,7 +1759,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1863,7 +1863,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -1914,7 +1914,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -82,10 +82,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -133,10 +133,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -184,10 +184,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -235,10 +235,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -286,10 +286,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/NamedNodeMap.json
+++ b/api/NamedNodeMap.json
@@ -101,10 +101,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -149,10 +149,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -197,10 +197,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -245,10 +245,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -293,10 +293,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -341,10 +341,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -389,10 +389,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -437,10 +437,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2232,10 +2232,10 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/Node.json
+++ b/api/Node.json
@@ -140,7 +140,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -900,10 +900,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1008,10 +1008,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1216,10 +1216,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1264,10 +1264,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1371,10 +1371,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1422,10 +1422,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1530,10 +1530,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1581,10 +1581,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1632,10 +1632,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1744,10 +1744,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1799,7 +1799,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1958,10 +1958,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2009,10 +2009,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2209,7 +2209,7 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -82,10 +82,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -235,10 +235,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -375,7 +375,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -477,7 +477,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -648,7 +648,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -750,7 +750,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -801,7 +801,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -852,7 +852,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -903,7 +903,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -954,7 +954,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -1158,7 +1158,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -1260,7 +1260,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -1362,7 +1362,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -1413,7 +1413,7 @@
               "version_added": "40"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false

--- a/api/OfflineAudioCompletionEvent.json
+++ b/api/OfflineAudioCompletionEvent.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -140,7 +140,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/OscillatorNode.json
+++ b/api/OscillatorNode.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -140,7 +140,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -191,7 +191,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -293,7 +293,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -344,7 +344,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/OverconstrainedErrorEvent.json
+++ b/api/OverconstrainedErrorEvent.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -82,10 +82,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/PageTransitionEvent.json
+++ b/api/PageTransitionEvent.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -82,10 +82,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -72,10 +72,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -152,10 +152,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -233,10 +233,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -314,10 +314,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -462,10 +462,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -543,10 +543,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -624,10 +624,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -705,10 +705,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -869,10 +869,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -950,10 +950,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1031,10 +1031,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1113,10 +1113,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -58,10 +58,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -196,7 +196,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -264,7 +264,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -331,7 +331,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -465,7 +465,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -532,7 +532,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -735,7 +735,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -802,7 +802,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -869,7 +869,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/PaymentRequestUpdateEvent.json
+++ b/api/PaymentRequestUpdateEvent.json
@@ -71,10 +71,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -232,10 +232,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -71,10 +71,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -150,10 +150,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -230,10 +230,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -310,10 +310,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -377,10 +377,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -457,10 +457,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -577,10 +577,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": false
@@ -657,10 +657,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -737,10 +737,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -818,10 +818,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -885,10 +885,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/PeriodicWave.json
+++ b/api/PeriodicWave.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/Plugin.json
+++ b/api/Plugin.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -82,10 +82,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -133,10 +133,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -186,10 +186,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -238,10 +238,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -291,10 +291,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/PluginArray.json
+++ b/api/PluginArray.json
@@ -32,10 +32,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -84,10 +84,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -136,10 +136,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -189,10 +189,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -243,10 +243,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/PopStateEvent.json
+++ b/api/PopStateEvent.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null
@@ -79,10 +79,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/ProcessingInstruction.json
+++ b/api/ProcessingInstruction.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -79,10 +79,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -96,7 +96,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false

--- a/api/RTCDataChannelEvent.json
+++ b/api/RTCDataChannelEvent.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -134,10 +134,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -134,10 +134,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -542,10 +542,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -593,10 +593,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -848,10 +848,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -53,10 +53,10 @@
             }
           ],
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": [
             {
@@ -208,7 +208,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": [
               {
@@ -390,7 +390,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -543,7 +543,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -723,7 +723,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": [
               {
@@ -944,7 +944,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": [
               {
@@ -1023,7 +1023,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1321,7 +1321,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1553,7 +1553,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1669,7 +1669,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1740,7 +1740,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -2039,7 +2039,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -2156,7 +2156,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -2377,7 +2377,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -2610,7 +2610,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -2675,7 +2675,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -2791,7 +2791,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -2856,7 +2856,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -3116,7 +3116,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -3313,7 +3313,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -3378,7 +3378,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -3560,7 +3560,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -3625,7 +3625,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -3692,7 +3692,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -3864,7 +3864,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -3994,7 +3994,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -4136,7 +4136,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": [
               {
@@ -4227,7 +4227,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -4298,7 +4298,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/RTCPeerConnectionIceEvent.json
+++ b/api/RTCPeerConnectionIceEvent.json
@@ -46,10 +46,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -103,10 +103,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -206,10 +206,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -32,10 +32,10 @@
             "version_added": "46"
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": "7.0"
@@ -82,10 +82,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -286,10 +286,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -236,10 +236,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -394,7 +394,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/RTCRtpTransceiver.json
+++ b/api/RTCRtpTransceiver.json
@@ -32,10 +32,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": false
@@ -133,10 +133,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": false
@@ -184,10 +184,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": false
@@ -235,10 +235,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": false
@@ -286,10 +286,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": false
@@ -337,10 +337,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": false
@@ -439,10 +439,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/RTCSessionDescription.json
+++ b/api/RTCSessionDescription.json
@@ -33,10 +33,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -84,10 +84,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -136,10 +136,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -241,10 +241,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/RTCTrackEvent.json
+++ b/api/RTCTrackEvent.json
@@ -32,10 +32,10 @@
             "version_added": "43"
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -82,10 +82,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -133,10 +133,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -184,10 +184,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -235,10 +235,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/Range.json
+++ b/api/Range.json
@@ -515,10 +515,10 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -566,7 +566,7 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -858,10 +858,10 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -909,7 +909,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1050,10 +1050,10 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1098,10 +1098,10 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/SVGAngle.json
+++ b/api/SVGAngle.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGAnimatedBoolean.json
+++ b/api/SVGAnimatedBoolean.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGAnimatedEnumeration.json
+++ b/api/SVGAnimatedEnumeration.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGAnimatedInteger.json
+++ b/api/SVGAnimatedInteger.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGAnimatedLength.json
+++ b/api/SVGAnimatedLength.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGAnimatedLengthList.json
+++ b/api/SVGAnimatedLengthList.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGAnimatedNumber.json
+++ b/api/SVGAnimatedNumber.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGAnimatedNumberList.json
+++ b/api/SVGAnimatedNumberList.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGAnimatedPreserveAspectRatio.json
+++ b/api/SVGAnimatedPreserveAspectRatio.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGAnimatedRect.json
+++ b/api/SVGAnimatedRect.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGAnimatedString.json
+++ b/api/SVGAnimatedString.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null
@@ -79,10 +79,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -127,10 +127,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/SVGAnimatedTransformList.json
+++ b/api/SVGAnimatedTransformList.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGCircleElement.json
+++ b/api/SVGCircleElement.json
@@ -79,10 +79,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -126,10 +126,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -173,10 +173,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/SVGClipPathElement.json
+++ b/api/SVGClipPathElement.json
@@ -78,10 +78,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/SVGComponentTransferFunctionElement.json
+++ b/api/SVGComponentTransferFunctionElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGEllipseElement.json
+++ b/api/SVGEllipseElement.json
@@ -78,10 +78,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -125,10 +125,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -172,10 +172,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -219,10 +219,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/SVGFEBlendElement.json
+++ b/api/SVGFEBlendElement.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true

--- a/api/SVGFEColorMatrixElement.json
+++ b/api/SVGFEColorMatrixElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -82,10 +82,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -133,10 +133,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -184,10 +184,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/SVGFEComponentTransferElement.json
+++ b/api/SVGFEComponentTransferElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFECompositeElement.json
+++ b/api/SVGFECompositeElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFEConvolveMatrixElement.json
+++ b/api/SVGFEConvolveMatrixElement.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true

--- a/api/SVGFEDiffuseLightingElement.json
+++ b/api/SVGFEDiffuseLightingElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFEDisplacementMapElement.json
+++ b/api/SVGFEDisplacementMapElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFEDistantLightElement.json
+++ b/api/SVGFEDistantLightElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFEDropShadowElement.json
+++ b/api/SVGFEDropShadowElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFEFloodElement.json
+++ b/api/SVGFEFloodElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFEFuncAElement.json
+++ b/api/SVGFEFuncAElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFEFuncBElement.json
+++ b/api/SVGFEFuncBElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFEFuncGElement.json
+++ b/api/SVGFEFuncGElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFEFuncRElement.json
+++ b/api/SVGFEFuncRElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFEGaussianBlurElement.json
+++ b/api/SVGFEGaussianBlurElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFEImageElement.json
+++ b/api/SVGFEImageElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFEMergeElement.json
+++ b/api/SVGFEMergeElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFEMergeNodeElement.json
+++ b/api/SVGFEMergeNodeElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFEMorphologyElement.json
+++ b/api/SVGFEMorphologyElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFEOffsetElement.json
+++ b/api/SVGFEOffsetElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFEPointLightElement.json
+++ b/api/SVGFEPointLightElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFESpecularLightingElement.json
+++ b/api/SVGFESpecularLightingElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFESpotLightElement.json
+++ b/api/SVGFESpotLightElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFETileElement.json
+++ b/api/SVGFETileElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFETurbulenceElement.json
+++ b/api/SVGFETurbulenceElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGFilterElement.json
+++ b/api/SVGFilterElement.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true

--- a/api/SVGGeometryElement.json
+++ b/api/SVGGeometryElement.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -127,10 +127,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -175,10 +175,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -223,10 +223,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -273,10 +273,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -323,10 +323,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/SVGGradientElement.json
+++ b/api/SVGGradientElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null
@@ -78,10 +78,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -133,10 +133,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -180,10 +180,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -227,10 +227,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -224,10 +224,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -272,10 +272,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -320,10 +320,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -368,10 +368,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -416,10 +416,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -464,10 +464,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/SVGLength.json
+++ b/api/SVGLength.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGLengthList.json
+++ b/api/SVGLengthList.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGLineElement.json
+++ b/api/SVGLineElement.json
@@ -78,10 +78,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -125,10 +125,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -172,10 +172,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -219,10 +219,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/SVGLinearGradientElement.json
+++ b/api/SVGLinearGradientElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGMaskElement.json
+++ b/api/SVGMaskElement.json
@@ -78,10 +78,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -125,10 +125,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -175,7 +175,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -219,10 +219,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -266,10 +266,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -313,10 +313,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/SVGMetadataElement.json
+++ b/api/SVGMetadataElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGNumber.json
+++ b/api/SVGNumber.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGNumberList.json
+++ b/api/SVGNumberList.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true

--- a/api/SVGPatternElement.json
+++ b/api/SVGPatternElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -78,10 +78,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -125,10 +125,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -172,10 +172,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -219,10 +219,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -266,10 +266,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -313,10 +313,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -360,10 +360,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/SVGPreserveAspectRatio.json
+++ b/api/SVGPreserveAspectRatio.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGRadialGradientElement.json
+++ b/api/SVGRadialGradientElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGRectElement.json
+++ b/api/SVGRectElement.json
@@ -81,10 +81,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -128,10 +128,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -175,10 +175,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -222,10 +222,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -269,10 +269,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -316,10 +316,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -125,10 +125,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -172,10 +172,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -315,10 +315,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -362,10 +362,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -409,10 +409,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -456,10 +456,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -503,10 +503,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -550,10 +550,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -597,10 +597,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -644,10 +644,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -691,10 +691,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -738,10 +738,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -837,10 +837,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -884,10 +884,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -978,10 +978,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1025,10 +1025,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1072,10 +1072,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1119,10 +1119,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1476,10 +1476,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1570,10 +1570,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1617,10 +1617,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1763,10 +1763,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1810,10 +1810,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1857,10 +1857,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/SVGScriptElement.json
+++ b/api/SVGScriptElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGStopElement.json
+++ b/api/SVGStopElement.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true

--- a/api/SVGStringList.json
+++ b/api/SVGStringList.json
@@ -34,10 +34,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGSwitchElement.json
+++ b/api/SVGSwitchElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGSymbolElement.json
+++ b/api/SVGSymbolElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false

--- a/api/SVGTextContentElement.json
+++ b/api/SVGTextContentElement.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -78,10 +78,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -125,10 +125,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -172,10 +172,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -219,10 +219,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -266,10 +266,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -313,10 +313,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -360,10 +360,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -407,10 +407,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -454,10 +454,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -501,10 +501,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -548,10 +548,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/SVGTextPathElement.json
+++ b/api/SVGTextPathElement.json
@@ -78,10 +78,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -125,10 +125,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -172,10 +172,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/SVGTextPositioningElement.json
+++ b/api/SVGTextPositioningElement.json
@@ -78,10 +78,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -125,10 +125,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -172,10 +172,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -219,10 +219,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -266,10 +266,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/SVGTransform.json
+++ b/api/SVGTransform.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGTransformList.json
+++ b/api/SVGTransformList.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGUnitTypes.json
+++ b/api/SVGUnitTypes.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null

--- a/api/SVGUseElement.json
+++ b/api/SVGUseElement.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null
@@ -125,10 +125,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -219,10 +219,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -266,10 +266,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -313,10 +313,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/SVGViewElement.json
+++ b/api/SVGViewElement.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true

--- a/api/Screen.json
+++ b/api/Screen.json
@@ -86,7 +86,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -240,7 +240,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -293,7 +293,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -345,7 +345,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -750,7 +750,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -907,7 +907,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -81,10 +81,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -129,10 +129,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -177,10 +177,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -273,10 +273,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -321,10 +321,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -467,10 +467,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -663,7 +663,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -708,10 +708,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -756,10 +756,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -804,10 +804,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -996,10 +996,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1188,10 +1188,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1333,10 +1333,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -598,10 +598,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -649,10 +649,10 @@
               "version_added": "61"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -1271,7 +1271,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/StorageEvent.json
+++ b/api/StorageEvent.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -128,10 +128,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -176,10 +176,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -224,10 +224,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -272,10 +272,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -320,10 +320,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -368,10 +368,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/StyleSheet.json
+++ b/api/StyleSheet.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -79,10 +79,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -127,10 +127,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -175,10 +175,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -223,10 +223,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -271,10 +271,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -319,10 +319,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -367,10 +367,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/StyleSheetList.json
+++ b/api/StyleSheetList.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -79,10 +79,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -127,10 +127,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -35,7 +35,7 @@
             "version_added": "3.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -146,10 +146,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -210,10 +210,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -274,10 +274,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -338,7 +338,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -402,10 +402,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -466,10 +466,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -530,10 +530,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -594,10 +594,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -658,10 +658,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -722,10 +722,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -786,10 +786,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -492,7 +492,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -642,7 +642,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null

--- a/api/TimeRanges.json
+++ b/api/TimeRanges.json
@@ -133,7 +133,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": true

--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -200,7 +200,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -711,10 +711,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/VTTCue.json
+++ b/api/VTTCue.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": null
@@ -128,10 +128,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -176,10 +176,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -224,10 +224,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -320,10 +320,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -464,10 +464,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -512,10 +512,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -560,10 +560,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -608,10 +608,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/VideoTrack.json
+++ b/api/VideoTrack.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -82,10 +82,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -133,10 +133,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -184,10 +184,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -235,10 +235,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -286,10 +286,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -337,7 +337,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null

--- a/api/WaveShaperNode.json
+++ b/api/WaveShaperNode.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -140,7 +140,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -191,7 +191,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -158,10 +158,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -206,10 +206,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -261,10 +261,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -309,10 +309,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -357,10 +357,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -405,10 +405,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -453,10 +453,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -501,10 +501,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -549,10 +549,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -597,10 +597,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -663,10 +663,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -711,10 +711,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -188,7 +188,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -240,7 +240,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -292,7 +292,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -344,7 +344,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/Window.json
+++ b/api/Window.json
@@ -3070,7 +3070,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -3633,10 +3633,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -3866,10 +3866,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -3968,10 +3968,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -4226,10 +4226,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -4379,10 +4379,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -4481,10 +4481,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -4532,10 +4532,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -4787,10 +4787,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -4838,10 +4838,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -5008,7 +5008,7 @@
               "version_added": null
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -5059,7 +5059,7 @@
               "version_added": null
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -5107,10 +5107,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -5260,10 +5260,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -5314,7 +5314,7 @@
               "version_added": null
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -5518,7 +5518,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -5569,7 +5569,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -5620,7 +5620,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -5821,10 +5821,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -6061,10 +6061,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -6114,10 +6114,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -6165,10 +6165,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -6491,10 +6491,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -6543,10 +6543,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -6747,10 +6747,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -7635,7 +7635,7 @@
             ],
             "safari_ios": [
               {
-                "version_added": null
+                "version_added": true
               },
               {
                 "version_added": null,
@@ -8400,10 +8400,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -8451,10 +8451,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -8502,10 +8502,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -8553,10 +8553,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -8608,7 +8608,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -9571,10 +9571,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -41,7 +41,7 @@
             "version_added": "1.2"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -97,7 +97,7 @@
               "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -254,7 +254,7 @@
               "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -364,7 +364,7 @@
               "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -563,7 +563,7 @@
               "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -779,7 +779,7 @@
               "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -880,7 +880,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -932,7 +932,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -983,7 +983,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1290,7 +1290,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1825,7 +1825,7 @@
               "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1882,7 +1882,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1933,7 +1933,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1987,7 +1987,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2039,7 +2039,7 @@
               "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/XMLHttpRequestEventTarget.json
+++ b/api/XMLHttpRequestEventTarget.json
@@ -35,7 +35,7 @@
             "version_added": "1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true
@@ -82,10 +82,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -133,10 +133,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -184,10 +184,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -235,10 +235,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -286,10 +286,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -337,10 +337,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null
@@ -388,10 +388,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/XMLHttpRequestUpload.json
+++ b/api/XMLHttpRequestUpload.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null

--- a/api/XMLSerializer.json
+++ b/api/XMLSerializer.json
@@ -35,7 +35,7 @@
             "version_added": "3"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": true


### PR DESCRIPTION
Tests were generated by https://github.com/foolip/mdn-bcd-collector
and results collected in Safari 12 on macOs and iOS.  Snapshot of the
tests and results:
https://gist.github.com/foolip/ec968569abfb5e25662f2ca23f6809ec
https://github.com/foolip/mdn-bcd-results/pull/82
https://github.com/foolip/mdn-bcd-results/pull/98

Example of tests which were actually used:
```js
bcd.test('api.AnalyserNode', function() {
  return 'AnalyserNode' in self;
});
bcd.test('api.AnalyserNode.fftSize', function() {
  return 'fftSize' in AnalyserNode.prototype;
});
```

Where the results were true and the existing data in BCD was null, the
value was changed to true. Snapshot of script used:
https://gist.github.com/foolip/07713854c8d8a2aed748ff92e228dee8

Plain false positives are very unlikely, but some of the exposed APIs
might still need notes or could be partial implementations.