### PR TITLE
Update import.meta data for Safari

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1971,7 +1971,10 @@
               "version_added": "51"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
+            },
+            "safari_ios": {
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
Since import.meta is now supported in Safari, it's time to update this data here.

I could not find much info in Safari Release Notes. This page https://aremodulesready.com/ has some info and can help testing it, so I did my own tests in Browserstack.

In Safari Desktop it seems to be supported since 11.1 (as well as dynamic modules which are already up-to-date in the compat data):

![image](https://user-images.githubusercontent.com/137844/54819680-f5906180-4c9c-11e9-9f9e-7f49800390f5.png)

![image](https://user-images.githubusercontent.com/137844/54819721-10fb6c80-4c9d-11e9-85d8-f467598d0a2b.png)

In Safari iOS this looks different. Although dynamic modules also landed there in 11, the import.meta was added only in 12.

![image](https://user-images.githubusercontent.com/137844/54819753-2d97a480-4c9d-11e9-826e-ba6e49f14708.png)

![image](https://user-images.githubusercontent.com/137844/54819759-31c3c200-4c9d-11e9-889c-f048cee7d4cf.png)

![image](https://user-images.githubusercontent.com/137844/54819765-35efdf80-4c9d-11e9-9c88-6a6e2af13d3b.png)

