### PR TITLE
Drop Chrome origin trials data

### DIFF
--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/adData",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/connectGATT",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -148,10 +148,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/deviceClass",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -244,10 +244,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/gattServer",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -388,10 +388,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/paired",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -436,10 +436,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/productID",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -484,10 +484,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/productVersion",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -532,10 +532,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/unwatchAdvertisements",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -580,10 +580,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/uuids",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -628,10 +628,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/vendorID",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -676,10 +676,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/vendorIDSource",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -724,10 +724,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/watchAdvertisements",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -772,10 +772,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/watchingAdvertisements",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null

--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": "74"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "74"
           },
           "edge": {
             "version_added": null
@@ -196,10 +196,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/gatt",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "74"
             },
             "edge": {
               "version_added": null
@@ -292,10 +292,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/id",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "74"
             },
             "edge": {
               "version_added": null
@@ -340,10 +340,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/name",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "74"
             },
             "edge": {
               "version_added": null

--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -4,19 +4,11 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice",
         "support": {
-          "chrome": [
-            {
-              "version_added": "52",
-              "notes": "Chrome origin trials only."
-            },
-            {
-              "version_added": "45",
-              "notes": "Behind a flag. Chrome OS only."
-            }
-          ],
+          "chrome": {
+            "version_added": null
+          },
           "chrome_android": {
-            "version_added": "52",
-            "notes": "Chrome origin trials only."
+            "version_added": null
           },
           "edge": {
             "version_added": null
@@ -60,12 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/adData",
           "support": {
             "chrome": {
-              "version_added": "45",
-              "version_removed": "52",
-              "notes": "Behind a flag. Chrome OS only."
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -110,12 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/connectGATT",
           "support": {
             "chrome": {
-              "version_added": "45",
-              "version_removed": "52",
-              "notes": "Behind a flag. Chrome OS only."
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -160,12 +148,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/deviceClass",
           "support": {
             "chrome": {
-              "version_added": "45",
-              "version_removed": "52",
-              "notes": "Behind a flag. Chrome OS only."
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -209,19 +195,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/gatt",
           "support": {
-            "chrome": [
-              {
-                "version_added": "52",
-                "notes": "Chrome origin trials only."
-              },
-              {
-                "version_added": "45",
-                "notes": "Behind a flag. Chrome OS only."
-              }
-            ],
+            "chrome": {
+              "version_added": null
+            },
             "chrome_android": {
-              "version_added": "52",
-              "notes": "Chrome origin trials only."
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -266,12 +244,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/gattServer",
           "support": {
             "chrome": {
-              "version_added": "45",
-              "version_removed": "52",
-              "notes": "Behind a flag. Chrome OS only."
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -315,19 +291,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/id",
           "support": {
-            "chrome": [
-              {
-                "version_added": "52",
-                "notes": "Chrome origin trials only."
-              },
-              {
-                "version_added": "45",
-                "notes": "Behind a flag. Chrome OS only."
-              }
-            ],
+            "chrome": {
+              "version_added": null
+            },
             "chrome_android": {
-              "version_added": "52",
-              "notes": "Chrome origin trials only."
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -371,19 +339,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/name",
           "support": {
-            "chrome": [
-              {
-                "version_added": "52",
-                "notes": "Chrome origin trials only."
-              },
-              {
-                "version_added": "45",
-                "notes": "Behind a flag. Chrome OS only."
-              }
-            ],
+            "chrome": {
+              "version_added": null
+            },
             "chrome_android": {
-              "version_added": "52",
-              "notes": "Chrome origin trials only."
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -428,12 +388,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/paired",
           "support": {
             "chrome": {
-              "version_added": "45",
-              "version_removed": "52",
-              "notes": "Behind a flag. Chrome OS only."
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -478,12 +436,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/productID",
           "support": {
             "chrome": {
-              "version_added": "45",
-              "version_removed": "52",
-              "notes": "Behind a flag. Chrome OS only."
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -528,12 +484,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/productVersion",
           "support": {
             "chrome": {
-              "version_added": "45",
-              "version_removed": "52",
-              "notes": "Behind a flag. Chrome OS only."
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -577,19 +531,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/unwatchAdvertisements",
           "support": {
-            "chrome": [
-              {
-                "version_added": "52",
-                "notes": "Chrome origin trials only."
-              },
-              {
-                "version_added": "45",
-                "notes": "Behind a flag. Chrome OS only."
-              }
-            ],
+            "chrome": {
+              "version_added": null
+            },
             "chrome_android": {
-              "version_added": "52",
-              "notes": "Chrome origin trials only."
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -633,19 +579,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/uuids",
           "support": {
-            "chrome": [
-              {
-                "version_added": "52",
-                "notes": "Chrome origin trials only."
-              },
-              {
-                "version_added": "45",
-                "notes": "Behind a flag. Chrome OS only."
-              }
-            ],
+            "chrome": {
+              "version_added": null
+            },
             "chrome_android": {
-              "version_added": "52",
-              "notes": "Chrome origin trials only."
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -690,12 +628,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/vendorID",
           "support": {
             "chrome": {
-              "version_added": "45",
-              "version_removed": "52",
-              "notes": "Behind a flag. Chrome OS only."
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -740,12 +676,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/vendorIDSource",
           "support": {
             "chrome": {
-              "version_added": "45",
-              "version_removed": "52",
-              "notes": "Behind a flag. Chrome OS only."
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -789,19 +723,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/watchAdvertisements",
           "support": {
-            "chrome": [
-              {
-                "version_added": "52",
-                "notes": "Chrome origin trials only."
-              },
-              {
-                "version_added": "45",
-                "notes": "Behind a flag. Chrome OS only."
-              }
-            ],
+            "chrome": {
+              "version_added": null
+            },
             "chrome_android": {
-              "version_added": "52",
-              "notes": "Chrome origin trials only."
+              "version_added": null
             },
             "edge": {
               "version_added": null
@@ -845,19 +771,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/watchingAdvertisements",
           "support": {
-            "chrome": [
-              {
-                "version_added": "52",
-                "notes": "Chrome origin trials only."
-              },
-              {
-                "version_added": "45",
-                "notes": "Behind a flag. Chrome OS only."
-              }
-            ],
+            "chrome": {
+              "version_added": null
+            },
             "chrome_android": {
-              "version_added": "52",
-              "notes": "Chrome origin trials only."
+              "version_added": null
             },
             "edge": {
               "version_added": null


### PR DESCRIPTION
I had a discussion with @chrisdavidmills where it came up that Chrome origin trials have a weird status (flag-like, but not exactly) and we might regard it as unsupported (perhaps from a discussion with @jpmedley?). This drops the only remaining origin trials data I could find, concerning the Web Bluetooth API.

I've opted to `null` this data because the history of this API in Chrome is complex, to say the least: https://www.chromestatus.com/features/5264933985976320. I can revisit that decision, if there's opposition to rolling back a quality measure (or if Joe wants to provide a review for that data specifically).
