### PR TITLE
Set Firefox for HTML data URL to true

### DIFF
--- a/http/data-url.json
+++ b/http/data-url.json
@@ -131,10 +131,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
While testing #3697, I found that Firefox and Firefox Android support HTML-based data URLs.  This PR sets them as such.