### PR TITLE
Add Chrome/Firefox support for ANGLE/EXT/OES/WebGL APIs

### DIFF
--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ANGLE_instanced_arrays",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null
@@ -26,10 +26,10 @@
             "version_added": "11"
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {
@@ -55,10 +55,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ANGLE_instanced_arrays/drawArraysInstancedANGLE",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -76,10 +76,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -88,10 +88,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -106,10 +106,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ANGLE_instanced_arrays/drawElementsInstancedANGLE",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -127,10 +127,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -139,10 +139,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -157,10 +157,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ANGLE_instanced_arrays/vertexAttribDivisorANGLE",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -178,10 +178,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -190,10 +190,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/api/EXT_blend_minmax.json
+++ b/api/EXT_blend_minmax.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_blend_minmax",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": "17"
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/EXT_frag_depth.json
+++ b/api/EXT_frag_depth.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_frag_depth",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/EXT_sRGB.json
+++ b/api/EXT_sRGB.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_sRGB",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": false
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/EXT_shader_texture_lod.json
+++ b/api/EXT_shader_texture_lod.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_shader_texture_lod",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": "17"
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/EXT_texture_filter_anisotropic.json
+++ b/api/EXT_texture_filter_anisotropic.json
@@ -4,12 +4,24 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_texture_filter_anisotropic",
         "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
+          "chrome": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
           "edge": {
             "version_added": true
           },
@@ -25,24 +37,48 @@
           "ie": {
             "version_added": null
           },
-          "opera": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
+          "opera": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
           "safari": {
             "version_added": null
           },
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          }
+          "samsunginternet_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
+          "webview_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ]
         },
         "status": {
           "experimental": false,

--- a/api/EXT_texture_filter_anisotropic.json
+++ b/api/EXT_texture_filter_anisotropic.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_texture_filter_anisotropic",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/OES_element_index_uint.json
+++ b/api/OES_element_index_uint.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_element_index_uint",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/OES_standard_derivatives.json
+++ b/api/OES_standard_derivatives.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_standard_derivatives",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/OES_texture_float.json
+++ b/api/OES_texture_float.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_texture_float",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/OES_texture_float_linear.json
+++ b/api/OES_texture_float_linear.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_texture_float_linear",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/OES_texture_half_float.json
+++ b/api/OES_texture_half_float.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_texture_half_float",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/OES_texture_half_float_linear.json
+++ b/api/OES_texture_half_float_linear.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_texture_half_float_linear",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/OES_vertex_array_object.json
+++ b/api/OES_vertex_array_object.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": "17"
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {
@@ -55,10 +55,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object/createVertexArrayOES",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "17"
@@ -76,10 +76,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -88,10 +88,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -106,10 +106,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object/deleteVertexArrayOES",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "17"
@@ -127,10 +127,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -139,10 +139,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -157,10 +157,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object/isVertexArrayOES",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "17"
@@ -178,10 +178,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -190,10 +190,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -208,10 +208,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object/bindVertexArrayOES",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "17"
@@ -229,10 +229,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -241,10 +241,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/api/WEBGL_color_buffer_float.json
+++ b/api/WEBGL_color_buffer_float.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_color_buffer_float",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": "17"
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {
@@ -55,10 +55,10 @@
           "description": "<code>RGB32F_EXT</code> constant",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -76,10 +76,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -88,10 +88,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/api/WEBGL_compressed_texture_atc.json
+++ b/api/WEBGL_compressed_texture_atc.json
@@ -20,7 +20,8 @@
           },
           "firefox": [
             {
-              "version_added": "18"
+              "version_added": "18",
+              "version_removed": "64"
             },
             {
               "prefix": "MOZ_",

--- a/api/WEBGL_compressed_texture_atc.json
+++ b/api/WEBGL_compressed_texture_atc.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_atc",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": false
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": false
           },
           "edge": {
             "version_added": false
@@ -33,10 +33,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": false
           },
           "opera_android": {
-            "version_added": null
+            "version_added": false
           },
           "safari": {
             "version_added": null
@@ -45,10 +45,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
-            "version_added": null
+            "version_added": false
           }
         },
         "status": {

--- a/api/WEBGL_compressed_texture_atc.json
+++ b/api/WEBGL_compressed_texture_atc.json
@@ -5,10 +5,12 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_atc",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": true,
+            "version_removed": "68"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": true,
+            "version_removed": "68"
           },
           "edge": {
             "version_added": false
@@ -33,10 +35,12 @@
             "version_added": null
           },
           "opera": {
-            "version_added": false
+            "version_added": true,
+            "version_removed": "55"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": true,
+            "version_removed": "55"
           },
           "safari": {
             "version_added": null
@@ -48,7 +52,8 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": false
+            "version_added": true,
+            "version_removed": "68"
           }
         },
         "status": {

--- a/api/WEBGL_compressed_texture_etc.json
+++ b/api/WEBGL_compressed_texture_etc.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_etc",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": false
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/WEBGL_compressed_texture_etc1.json
+++ b/api/WEBGL_compressed_texture_etc1.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_etc1",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": false
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_pvrtc",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": false
@@ -33,10 +33,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -45,10 +45,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_s3tc",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -33,10 +33,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -45,10 +45,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -4,12 +4,24 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_s3tc",
         "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
+          "chrome": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
           "edge": {
             "version_added": true
           },
@@ -32,24 +44,48 @@
           "ie": {
             "version_added": null
           },
-          "opera": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
+          "opera": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
           "safari": {
             "version_added": null
           },
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          }
+          "samsunginternet_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
+          "webview_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ]
         },
         "status": {
           "experimental": false,

--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_s3tc_srgb",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/WEBGL_depth_texture.json
+++ b/api/WEBGL_depth_texture.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_depth_texture",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -33,10 +33,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -45,10 +45,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/WEBGL_depth_texture.json
+++ b/api/WEBGL_depth_texture.json
@@ -4,12 +4,24 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_depth_texture",
         "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
+          "chrome": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
           "edge": {
             "version_added": true
           },
@@ -32,24 +44,48 @@
           "ie": {
             "version_added": null
           },
-          "opera": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
+          "opera": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
           "safari": {
             "version_added": null
           },
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          }
+          "samsunginternet_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
+          "webview_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ]
         },
         "status": {
           "experimental": false,

--- a/api/WEBGL_draw_buffers.json
+++ b/api/WEBGL_draw_buffers.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_draw_buffers",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": "17"
@@ -40,10 +40,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -52,10 +52,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {
@@ -69,10 +69,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_draw_buffers/drawBuffersWEBGL",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "17"
@@ -104,10 +104,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -116,10 +116,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/api/WEBGL_lose_context.json
+++ b/api/WEBGL_lose_context.json
@@ -4,12 +4,24 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_lose_context",
         "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
+          "chrome": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
           "edge": {
             "version_added": "17"
           },
@@ -32,24 +44,48 @@
           "ie": {
             "version_added": null
           },
-          "opera": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
+          "opera": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
           "safari": {
             "version_added": null
           },
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          }
+          "samsunginternet_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ],
+          "webview_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": true,
+              "prefix": "WEBKIT_"
+            }
+          ]
         },
         "status": {
           "experimental": false,

--- a/api/WEBGL_lose_context.json
+++ b/api/WEBGL_lose_context.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_lose_context",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": "17"
@@ -33,10 +33,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -45,10 +45,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {
@@ -62,10 +62,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_lose_context/loseContext",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "17"
@@ -90,10 +90,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -102,10 +102,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -120,10 +120,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_lose_context/restoreContext",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "17"
@@ -148,10 +148,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -160,10 +160,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
**Reviews and suggestions are highly encouraged and welcomed, especially as this is an almost entirely automated process, which hardly takes runtime flags into account.  See something that looks inaccurate?  Let me know!**

Sub-PR of #3658 regarding ANGLE/EXT/OES/WebGL APIs.  Something to note is that these are all marked with `[NoInterfaceObject]`, meaning that the APIs are not exposed (yet have support added), yet `api.WEBGL_compressed_texture_astc` had support already listed.