### PR TITLE
adding compat data for inset shorthands

### DIFF
--- a/css/properties/inset-block.json
+++ b/css/properties/inset-block.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/inset-inline.json
+++ b/css/properties/inset-inline.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/inset.json
+++ b/css/properties/inset.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1520229
