### PR TITLE
updating overflow-anchor support for Fx mobile

### DIFF
--- a/css/properties/overflow-anchor.json
+++ b/css/properties/overflow-anchor.json
@@ -21,7 +21,7 @@
               "version_added": "66"
             },
             "firefox_android": {
-              "version_added": "66"
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1515946

Previously we had overflow-scroll listed as enabled in Fx66 on mobile and desktop, but the above bug indicates that we have not got it enabled in Fennec as yet.