### PR TITLE
Update CoC according to new Mozilla template

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -5,7 +5,7 @@ For more details, please read the
 [Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/).
 
 ## How to Report
-For more information on how to report violations of the Community Participation Guidelines, please read our '[How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/)' page.
+For more information on how to report violations of the Community Participation Guidelines, please read our [How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/) page.
 
 ## Project Specific Etiquette
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,12 @@
-Code of conduct
-===============
+# Community Participation Guidelines
 
-This repository is governed by Mozilla's code of conduct and etiquette guidelines. For more details please see the [Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/) and [Developer Etiquette Guidelines](https://bugzilla.mozilla.org/page.cgi?id=etiquette.html).
+This repository is governed by Mozilla's code of conduct and etiquette guidelines.
+For more details, please read the
+[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/).
+
+## How to Report
+For more information on how to report violations of the Community Participation Guidelines, please read our '[How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/)' page.
+
+## Project Specific Etiquette
+
+For more specific information about how and by whom this project is governed, please see the BCD [governance](https://github.com/mdn/browser-compat-data/blob/master/governance.md) doc.


### PR DESCRIPTION
Mozilla has created a Mozilla standard Code of Conduct for GitHub repos.
More info later today in https://wiki.mozilla.org/WeeklyUpdates/2019-03-25#Speakers

The Mozilla template lives here: https://github.com/mozilla/repo-templates/blob/master/templates/CODE_OF_CONDUCT.md
Docs: https://wiki.mozilla.org/GitHub/Repository_Requirements

For the optional Project Specific Etiquette, I have linked to the governance doc that is worked on in PR https://github.com/mdn/browser-compat-data/pull/3668, so these two PRs should be merged together.

Fixes https://github.com/mdn/browser-compat-data/issues/3744