### PR TITLE
Safari Mobile 12.2 supports <input inputmode=

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -836,7 +836,10 @@
           }
         }
       },
-      "inputmode": {
+      "
+      
+      
+      ": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/inputmode",
           "support": {
@@ -871,7 +874,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "66"


### PR DESCRIPTION
Although I haven't added (because I haven't tested):  download attribute, Web Share API, Datalist, Color input type (as mentioned in https://twitter.com/daytonlowell/status/1089165318646349825 )

I did test inputmode on iPhone and iPad, but I didn't test if it has any bugs.