### PR TITLE
resizeWidth and resizeHeight unsupported on Firefox

### DIFF
--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -473,10 +473,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
`ImageBitmap` does not supports options on Firefox.

I updated the compatibility data to refer that the `resize*` options were also unsupported as their support was marked as unknown.

This issue https://bugzilla.mozilla.org/show_bug.cgi?id=1533680 states that support does not exist currently.

PS: It looks like the compat data for `options_parameter` was updated a month ago, but it does not seems to be reflected on https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap. Is that expected?