### PR TITLE
removed `caputreTab` support from FF for Android

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -810,7 +810,7 @@
                 "version_added": "59"
               },
               "firefox_android": {
-                "version_added": "59"
+                "version_added": false
               },
               "opera": {
                 "version_added": false


### PR DESCRIPTION
I've tested it myself while porting my add-on to Android, the API is not on there.

Related issue:
https://bugzilla.mozilla.org/show_bug.cgi?id=1427463