### PR TITLE
[Chrome] Update MIDIAccess.

### DIFF
--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -157,10 +157,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess/sysexEnabled",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": "45"
             },
             "edge": {
               "version_added": null
@@ -193,7 +193,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": "45"
             }
           },
           "status": {

--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -49,6 +49,210 @@
           "standard_track": true,
           "deprecated": false
         }
+      },
+      "inputs": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess/inputs",
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "43"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "43"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "outputs": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess/outputs",
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "43"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "43"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sysexEnabled": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess/sysexEnabled",
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "43"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "43"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "statechange_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess/outputs",
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "43"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "43"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
In this PR:
- [onstatechange added in 45](https://storage.googleapis.com/chromium-find-releases-static/4b5.html#4b5368da896dfaa1d5b342042420e48cab588f5c)
- [sysexEnabled added in 45](https://storage.googleapis.com/chromium-find-releases-static/545.html#5455496fc3b82a0dc6645f78474f9ab5950a70bb)

Everything else is [Chrome 43](https://www.chromestatus.com/features/4923613069180928). (I know I tell people not to trust Chrome Status, but I literally sit next to the MIDI spec author. He assures me this is correct.)
