### PR TITLE
Chrome support for some of the logical properties border-* longhands.

### DIFF
--- a/css/properties/border-block-color.json
+++ b/css/properties/border-block-color.json
@@ -49,7 +49,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-block-end.json
+++ b/css/properties/border-block-end.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false
@@ -62,7 +62,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-block-start-style.json
+++ b/css/properties/border-block-start-style.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start-style",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false

--- a/css/properties/border-block-start.json
+++ b/css/properties/border-block-start.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false
@@ -62,7 +62,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-inline-color.json
+++ b/css/properties/border-inline-color.json
@@ -49,7 +49,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-inline-end.json
+++ b/css/properties/border-inline-end.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false
@@ -57,7 +57,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-inline-start.json
+++ b/css/properties/border-inline-start.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-start",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": false
@@ -57,7 +57,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {


### PR DESCRIPTION
Added the missing Chrome support for some of the logical properties border-* longhands.

https://www.chromestatus.com/feature/6041507983261696
