### PR TITLE
Add missing descriptions to selectors

### DIFF
--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -3,6 +3,7 @@
     "selectors": {
       "any-link": {
         "__compat": {
+          "description": "<code>::any-link</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:any-link",
           "support": {
             "chrome": {

--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -3,7 +3,7 @@
     "selectors": {
       "any-link": {
         "__compat": {
-          "description": "<code>::any-link</code>",
+          "description": "<code>:any-link</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:any-link",
           "support": {
             "chrome": {

--- a/css/selectors/cue.json
+++ b/css/selectors/cue.json
@@ -3,6 +3,7 @@
     "selectors": {
       "cue": {
         "__compat": {
+          "description": "<code>::cue</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::cue",
           "support": {
             "chrome": {


### PR DESCRIPTION
:any-link and ::cue were missing descriptions that show the leading colons. This PR should make it so that all the CSS selectors  have descriptions.
