### PR TITLE
fix(api): `RTCPeerConnection.sctp` is unsupported

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -3885,57 +3885,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/sctp",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/943976'>bug 943976</a>."
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/943976'>bug 943976</a>."
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/943976'>bug 943976</a>."
             }
           },
           "status": {

--- a/api/RTCSctpTransport.json
+++ b/api/RTCSctpTransport.json
@@ -5,43 +5,48 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSctpTransport",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": false,
+            "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": false,
+            "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "edge_mobile": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
-            "version_added": false
+            "version_added": false,
+            "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": false,
+            "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
           },
           "opera_android": {
-            "version_added": null
+            "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
-            "version_added": null
+            "version_added": false,
+            "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
           }
         },
         "status": {
@@ -50,48 +55,53 @@
           "deprecated": false
         }
       },
-      "maxMessageSize": {
+      "maxChannels": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSctpTransport/maxMessageSize",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSctpTransport/maxChannels",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/943976'>bug 943976</a>."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/943976'>bug 943976</a>."
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/943976'>bug 943976</a>."
             }
           },
           "status": {
@@ -101,48 +111,53 @@
           }
         }
       },
-      "transport": {
+      "maxMessageSize": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSctpTransport/transport",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSctpTransport/maxMessageSize",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/943975'>bug 943975</a>."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/943975'>bug 943975</a>."
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/943975'>bug 943975</a>."
             }
           },
           "status": {
@@ -157,47 +172,108 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSctpTransport/onstatechange",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transport": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSctpTransport/transport",
+          "support": {
+            "chrome": {
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
+            }
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -208,47 +284,52 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSctpTransport/state",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/818643'>bug 818643</a>."
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
No browser currently supports `RTCSctpTransport` (except for Chrome Canary 75)

review?(@Elchi3)