### PR TITLE
Set false values in CSS for Firefox

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1731,10 +1731,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": null

--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -70,10 +70,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": null
@@ -174,10 +174,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": null

--- a/css/properties/box-flex-group.json
+++ b/css/properties/box-flex-group.json
@@ -22,10 +22,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -71,10 +71,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -122,10 +122,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -173,10 +173,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -224,10 +224,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -481,10 +481,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": null

--- a/css/types/clamp.json
+++ b/css/types/clamp.json
@@ -19,10 +19,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1751,11 +1751,11 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null,
+                "version_added": false,
                 "notes": "The <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-image-rect'><code>-moz-image-rect()</code></a> function supports fragments as of Firefox 4."
               },
               "firefox_android": {
-                "version_added": null,
+                "version_added": false,
                 "notes": "The <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-image-rect'><code>-moz-image-rect()</code></a> function supports fragments as of Firefox 4."
               },
               "ie": {
@@ -1875,10 +1875,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/types/max.json
+++ b/css/types/max.json
@@ -19,10 +19,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null

--- a/css/types/min.json
+++ b/css/types/min.json
@@ -19,10 +19,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This PR sets many CSS values that were originally `null` to `false` based upon manual testing in Firefox 65.0.2 on macOS, all default flags.  Derived from #3625.