### PR TITLE
Change Firefox Windows/Android support from null to true based on tests

### DIFF
--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -192,7 +192,7 @@
               "version_added": "6"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "10"

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -1533,7 +1533,7 @@
               "version_added": "40"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -1643,7 +1643,7 @@
               "version_added": "40"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -166,10 +166,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -214,10 +214,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -262,10 +262,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -310,10 +310,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/CSSMediaRule.json
+++ b/api/CSSMediaRule.json
@@ -66,10 +66,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/CSSPageRule.json
+++ b/api/CSSPageRule.json
@@ -118,10 +118,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/CharacterData.json
+++ b/api/CharacterData.json
@@ -114,10 +114,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -162,10 +162,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -210,10 +210,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -258,10 +258,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -306,10 +306,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -354,10 +354,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -402,10 +402,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/Credential.json
+++ b/api/Credential.json
@@ -20,7 +20,7 @@
             "version_added": "60"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -70,7 +70,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -121,7 +121,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -64,10 +64,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -112,10 +112,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -171,10 +171,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -223,10 +223,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/DOMQuad.json
+++ b/api/DOMQuad.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -221,10 +221,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -272,10 +272,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -323,10 +323,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -374,10 +374,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -425,10 +425,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -476,10 +476,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/Element.json
+++ b/api/Element.json
@@ -1035,7 +1035,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1086,7 +1086,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -2158,7 +2158,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -2209,7 +2209,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -2516,7 +2516,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -2568,7 +2568,7 @@
               "notes": "Prior to Firefox 19, this method was returning a <code>NodeList</code>; it was then changed to reflect the change in the spec."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "9"
@@ -2874,7 +2874,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -2926,7 +2926,7 @@
               "notes": "[1] Before Firefox 35, it was implemented on the <code>Node</code> interface."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "9"
@@ -4214,7 +4214,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -4265,7 +4265,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -4316,7 +4316,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -4623,7 +4623,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -5470,7 +5470,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -5521,7 +5521,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -5572,7 +5572,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -5623,7 +5623,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -5675,7 +5675,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true,

--- a/api/ErrorEvent.json
+++ b/api/ErrorEvent.json
@@ -113,10 +113,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -161,10 +161,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -209,10 +209,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -257,10 +257,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -305,10 +305,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/Event.json
+++ b/api/Event.json
@@ -113,10 +113,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -216,10 +216,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -547,10 +547,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1307,10 +1307,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/FileSystemDirectoryReader.json
+++ b/api/FileSystemDirectoryReader.json
@@ -69,10 +69,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -164,7 +164,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -212,7 +212,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -276,7 +276,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -348,7 +348,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -404,7 +404,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -452,7 +452,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -500,7 +500,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -548,7 +548,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -596,7 +596,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -644,7 +644,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -211,7 +211,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -307,7 +307,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -355,7 +355,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -403,7 +403,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -499,7 +499,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/FontFaceSetLoadEvent.json
+++ b/api/FontFaceSetLoadEvent.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -119,10 +119,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -250,10 +250,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/HTMLAllCollection.json
+++ b/api/HTMLAllCollection.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -64,10 +64,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -112,10 +112,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -160,10 +160,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -121,7 +121,7 @@
               "version_added": "20"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -223,7 +223,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true

--- a/api/HTMLDetailsElement.json
+++ b/api/HTMLDetailsElement.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -67,10 +67,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -631,7 +631,7 @@
               "version_added": "49"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/HTMLFrameSetElement.json
+++ b/api/HTMLFrameSetElement.json
@@ -205,10 +205,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -252,10 +252,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -241,7 +241,7 @@
               "version_added": "56"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -433,7 +433,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -481,7 +481,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -529,7 +529,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -577,7 +577,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -625,7 +625,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -673,7 +673,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -913,7 +913,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1010,7 +1010,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1105,7 +1105,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -110,10 +110,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -155,10 +155,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -200,10 +200,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -501,10 +501,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -546,10 +546,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -591,10 +591,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -636,10 +636,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -726,10 +726,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -774,7 +774,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "9"
@@ -819,7 +819,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "9"
@@ -1106,10 +1106,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1154,10 +1154,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1202,10 +1202,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1250,10 +1250,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -66,7 +66,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -113,7 +113,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -160,7 +160,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "10"
@@ -207,7 +207,7 @@
               "version_added": "3"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "10",
@@ -256,7 +256,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -350,7 +350,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -397,7 +397,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "10"
@@ -444,7 +444,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -491,7 +491,7 @@
               "version_added": "16"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -538,7 +538,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -585,7 +585,7 @@
               "version_added": "56"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -632,7 +632,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -820,7 +820,7 @@
               "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -915,7 +915,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -962,7 +962,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -1060,7 +1060,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -1215,7 +1215,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "10"
@@ -1330,7 +1330,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1385,7 +1385,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1432,7 +1432,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "10"
@@ -1479,7 +1479,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "10"
@@ -1667,7 +1667,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "10"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -146,10 +146,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1696,7 +1696,7 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -2203,7 +2203,7 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -2309,7 +2309,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -3220,7 +3220,7 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -3583,7 +3583,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/HTMLOptionsCollection.json
+++ b/api/HTMLOptionsCollection.json
@@ -118,10 +118,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -169,10 +169,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -220,10 +220,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -161,10 +161,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -593,10 +593,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -641,10 +641,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -689,10 +689,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -787,10 +787,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -934,10 +934,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -982,10 +982,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1126,10 +1126,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1318,10 +1318,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -112,10 +112,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -214,7 +214,7 @@
               "version_added": "28"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/IDBKeyRange.json
+++ b/api/IDBKeyRange.json
@@ -466,7 +466,7 @@
               "version_added": "47"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -645,7 +645,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -172,7 +172,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -271,10 +271,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -325,7 +325,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -634,7 +634,7 @@
               "version_added": "3"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "6"
@@ -792,7 +792,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -894,7 +894,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -1097,10 +1097,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1148,10 +1148,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1199,10 +1199,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1250,10 +1250,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -296,10 +296,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -84,7 +84,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/MediaKeyMessageEvent.json
+++ b/api/MediaKeyMessageEvent.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -119,10 +119,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -170,10 +170,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/MediaKeySession.json
+++ b/api/MediaKeySession.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -67,10 +67,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -118,10 +118,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -169,10 +169,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -220,10 +220,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -271,10 +271,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -322,10 +322,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -373,10 +373,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -424,10 +424,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -475,10 +475,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -526,10 +526,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -577,10 +577,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/MediaKeyStatusMap.json
+++ b/api/MediaKeyStatusMap.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -67,10 +67,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -220,10 +220,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -271,10 +271,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/MediaKeySystemAccess.json
+++ b/api/MediaKeySystemAccess.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -67,10 +67,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -118,10 +118,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -169,10 +169,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/MediaKeys.json
+++ b/api/MediaKeys.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -67,10 +67,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -118,10 +118,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -20,7 +20,7 @@
             "version_added": "6"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": "10"
@@ -67,7 +67,7 @@
               "version_added": "6"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "10"
@@ -115,7 +115,7 @@
               "version_added": "6"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "10"
@@ -163,7 +163,7 @@
               "version_added": "6"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "10"
@@ -259,7 +259,7 @@
               "version_added": "6"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "10"

--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -592,10 +592,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -696,10 +696,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -121,7 +121,7 @@
               "version_added": "48"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -481,7 +481,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -583,7 +583,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -634,7 +634,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/MediaStreamTrackEvent.json
+++ b/api/MediaStreamTrackEvent.json
@@ -119,10 +119,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": "9"
@@ -121,7 +121,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "9"
@@ -172,7 +172,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "9"
@@ -223,7 +223,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "9"
@@ -376,7 +376,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "9"

--- a/api/MimeType.json
+++ b/api/MimeType.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -67,10 +67,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -118,10 +118,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -169,10 +169,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -220,10 +220,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -232,7 +232,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -283,7 +283,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": [
               {
@@ -341,7 +341,7 @@
               "notes": "Resrictions apply depending on OS."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "9"
@@ -596,7 +596,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -644,10 +644,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -800,7 +800,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -1213,7 +1213,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "9"
@@ -1315,7 +1315,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "9"
@@ -1489,7 +1489,7 @@
               "version_added": "48"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -1744,7 +1744,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true

--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -67,10 +67,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -118,10 +118,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -169,10 +169,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -220,10 +220,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -271,10 +271,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -514,10 +514,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -2217,10 +2217,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/Node.json
+++ b/api/Node.json
@@ -1356,10 +1356,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1407,10 +1407,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1515,10 +1515,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1566,10 +1566,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1943,10 +1943,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -67,10 +67,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -220,10 +220,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/Plugin.json
+++ b/api/Plugin.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -67,10 +67,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -118,10 +118,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -171,10 +171,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -223,10 +223,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -276,10 +276,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -67,10 +67,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/RTCCertificate.json
+++ b/api/RTCCertificate.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -67,10 +67,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -912,7 +912,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -20,7 +20,7 @@
             "version_added": "22"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -122,7 +122,7 @@
               "version_added": "22"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -530,7 +530,7 @@
               "version_added": "22"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -581,7 +581,7 @@
               "version_added": "22"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -528,7 +528,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1059,7 +1059,7 @@
               "version_added": "57"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -1725,7 +1725,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -2010,7 +2010,7 @@
               "version_added": "52"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -67,10 +67,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -376,10 +376,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -428,10 +428,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/RTCSessionDescription.json
+++ b/api/RTCSessionDescription.json
@@ -21,7 +21,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": false
@@ -72,7 +72,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -124,7 +124,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -229,7 +229,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/Request.json
+++ b/api/Request.json
@@ -1450,10 +1450,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/SVGAngle.json
+++ b/api/SVGAngle.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGAnimatedAngle.json
+++ b/api/SVGAnimatedAngle.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGAnimatedBoolean.json
+++ b/api/SVGAnimatedBoolean.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGAnimatedEnumeration.json
+++ b/api/SVGAnimatedEnumeration.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGAnimatedInteger.json
+++ b/api/SVGAnimatedInteger.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGAnimatedLength.json
+++ b/api/SVGAnimatedLength.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGAnimatedLengthList.json
+++ b/api/SVGAnimatedLengthList.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGAnimatedNumber.json
+++ b/api/SVGAnimatedNumber.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGAnimatedNumberList.json
+++ b/api/SVGAnimatedNumberList.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGAnimatedPreserveAspectRatio.json
+++ b/api/SVGAnimatedPreserveAspectRatio.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGAnimatedRect.json
+++ b/api/SVGAnimatedRect.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGCircleElement.json
+++ b/api/SVGCircleElement.json
@@ -64,10 +64,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -111,10 +111,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -158,10 +158,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/SVGClipPathElement.json
+++ b/api/SVGClipPathElement.json
@@ -63,10 +63,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/SVGComponentTransferFunctionElement.json
+++ b/api/SVGComponentTransferFunctionElement.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGEllipseElement.json
+++ b/api/SVGEllipseElement.json
@@ -63,10 +63,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -110,10 +110,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -157,10 +157,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -204,10 +204,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/SVGFEBlendElement.json
+++ b/api/SVGFEBlendElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFEColorMatrixElement.json
+++ b/api/SVGFEColorMatrixElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true
@@ -70,7 +70,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -121,7 +121,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true
@@ -172,7 +172,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true

--- a/api/SVGFEComponentTransferElement.json
+++ b/api/SVGFEComponentTransferElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFECompositeElement.json
+++ b/api/SVGFECompositeElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFEConvolveMatrixElement.json
+++ b/api/SVGFEConvolveMatrixElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFEDiffuseLightingElement.json
+++ b/api/SVGFEDiffuseLightingElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFEDisplacementMapElement.json
+++ b/api/SVGFEDisplacementMapElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFEDistantLightElement.json
+++ b/api/SVGFEDistantLightElement.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGFEDropShadowElement.json
+++ b/api/SVGFEDropShadowElement.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGFEFloodElement.json
+++ b/api/SVGFEFloodElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFEFuncAElement.json
+++ b/api/SVGFEFuncAElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFEFuncBElement.json
+++ b/api/SVGFEFuncBElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFEFuncGElement.json
+++ b/api/SVGFEFuncGElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFEFuncRElement.json
+++ b/api/SVGFEFuncRElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFEGaussianBlurElement.json
+++ b/api/SVGFEGaussianBlurElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFEImageElement.json
+++ b/api/SVGFEImageElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFEMergeElement.json
+++ b/api/SVGFEMergeElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFEMergeNodeElement.json
+++ b/api/SVGFEMergeNodeElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFEMorphologyElement.json
+++ b/api/SVGFEMorphologyElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFEOffsetElement.json
+++ b/api/SVGFEOffsetElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFEPointLightElement.json
+++ b/api/SVGFEPointLightElement.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGFESpecularLightingElement.json
+++ b/api/SVGFESpecularLightingElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFESpotLightElement.json
+++ b/api/SVGFESpotLightElement.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGFETileElement.json
+++ b/api/SVGFETileElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFETurbulenceElement.json
+++ b/api/SVGFETurbulenceElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": true

--- a/api/SVGFilterElement.json
+++ b/api/SVGFilterElement.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGGradientElement.json
+++ b/api/SVGGradientElement.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -63,10 +63,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -165,10 +165,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -212,10 +212,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -209,10 +209,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -257,10 +257,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -305,10 +305,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -353,10 +353,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -401,10 +401,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -449,10 +449,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/SVGLength.json
+++ b/api/SVGLength.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGLengthList.json
+++ b/api/SVGLengthList.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGLineElement.json
+++ b/api/SVGLineElement.json
@@ -63,10 +63,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -110,10 +110,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -157,10 +157,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -204,10 +204,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/SVGLinearGradientElement.json
+++ b/api/SVGLinearGradientElement.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGMaskElement.json
+++ b/api/SVGMaskElement.json
@@ -63,10 +63,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -110,10 +110,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -157,10 +157,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -204,10 +204,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -251,10 +251,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -298,10 +298,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/SVGMetadataElement.json
+++ b/api/SVGMetadataElement.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGNumber.json
+++ b/api/SVGNumber.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGNumberList.json
+++ b/api/SVGNumberList.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGPatternElement.json
+++ b/api/SVGPatternElement.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -63,10 +63,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -110,10 +110,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -157,10 +157,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -204,10 +204,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -251,10 +251,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -298,10 +298,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -345,10 +345,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/SVGPreserveAspectRatio.json
+++ b/api/SVGPreserveAspectRatio.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGRadialGradientElement.json
+++ b/api/SVGRadialGradientElement.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGRectElement.json
+++ b/api/SVGRectElement.json
@@ -66,10 +66,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -113,10 +113,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -160,10 +160,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -207,10 +207,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -254,10 +254,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -301,10 +301,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -300,10 +300,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -347,10 +347,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -394,10 +394,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -441,10 +441,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -488,10 +488,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -535,10 +535,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -582,10 +582,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -629,10 +629,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -676,10 +676,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -723,10 +723,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -822,10 +822,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -869,10 +869,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -966,7 +966,7 @@
               "version_added": "11"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1104,10 +1104,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1461,10 +1461,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1555,10 +1555,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1602,10 +1602,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1748,10 +1748,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1795,10 +1795,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -1842,10 +1842,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/SVGScriptElement.json
+++ b/api/SVGScriptElement.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGStopElement.json
+++ b/api/SVGStopElement.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGSwitchElement.json
+++ b/api/SVGSwitchElement.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGSymbolElement.json
+++ b/api/SVGSymbolElement.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGTextContentElement.json
+++ b/api/SVGTextContentElement.json
@@ -63,10 +63,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -110,10 +110,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -157,10 +157,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -204,10 +204,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -251,10 +251,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -298,10 +298,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -345,10 +345,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -392,10 +392,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -439,10 +439,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -486,10 +486,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -533,10 +533,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/SVGTextPathElement.json
+++ b/api/SVGTextPathElement.json
@@ -63,10 +63,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -110,10 +110,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -157,10 +157,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/SVGTextPositioningElement.json
+++ b/api/SVGTextPositioningElement.json
@@ -63,10 +63,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -110,10 +110,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -157,10 +157,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -204,10 +204,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -251,10 +251,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/SVGTransform.json
+++ b/api/SVGTransform.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGUnitTypes.json
+++ b/api/SVGUnitTypes.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/SVGUseElement.json
+++ b/api/SVGUseElement.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null
@@ -110,10 +110,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -204,10 +204,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -251,10 +251,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -298,10 +298,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/SVGViewElement.json
+++ b/api/SVGViewElement.json
@@ -17,10 +17,10 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -583,10 +583,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -328,10 +328,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -379,10 +379,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/Touch.json
+++ b/api/Touch.json
@@ -476,7 +476,7 @@
               "version_added": null
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -527,7 +527,7 @@
               "version_added": null
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -578,7 +578,7 @@
               "version_added": null
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -696,10 +696,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/Window.json
+++ b/api/Window.json
@@ -2835,7 +2835,7 @@
               "version_added": "49"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "11"
@@ -4211,10 +4211,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -4990,10 +4990,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -5041,10 +5041,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -8593,7 +8593,7 @@
               "notes": "Starting in Firefox 6, this property is read only, as defined by the standard."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": true

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1918,7 +1918,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/XMLHttpRequestEventTarget.json
+++ b/api/XMLHttpRequestEventTarget.json
@@ -67,10 +67,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -118,10 +118,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -169,10 +169,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -220,10 +220,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -271,10 +271,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -322,10 +322,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -373,10 +373,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/api/XMLHttpRequestUpload.json
+++ b/api/XMLHttpRequestUpload.json
@@ -17,10 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": true
           },
           "ie": {
             "version_added": null


### PR DESCRIPTION
Tests were generated by https://github.com/foolip/mdn-bcd-collector
and results collected in Firefox 66 on Windows 10 and Android:
https://github.com/foolip/mdn-bcd-results/pull/108
https://github.com/foolip/mdn-bcd-results/pull/109

Example of tests which were actually used:
```
bcd.test('api.Credential', function() {
  return 'Credential' in self;
});
bcd.test('api.Credential.id', function() {
  return 'id' in Credential.prototype;
});
```

Where the results were true and the existing data in BCD was null, the
value was changed to true. Snapshot of script used:
https://gist.github.com/foolip/57fb835508ce96281854cc2ba44277ad

Plain false positives are very unlikely, but some of the exposed APIs
might still need notes or could be partial implementations.

Similar to https://github.com/mdn/browser-compat-data/pull/3700.