### PR TITLE
Correct the Chrome versions for createImageBitmap support

### DIFF
--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -360,10 +360,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap",
           "support": {
             "chrome": {
-              "version_added": "30"
+              "version_added": "50"
             },
             "chrome_android": {
-              "version_added": "30"
+              "version_added": "50"
             },
             "edge": {
               "version_added": false
@@ -399,7 +399,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "50"
             }
           },
           "status": {


### PR DESCRIPTION
Whilst testing some code I noticed that `createImageBitmap` wasn't available in Chrome 49, despite MDN saying support was added by Chrome version 30. I then searched and [found this blog post](https://developers.google.com/web/updates/2016/03/createimagebitmap-in-chrome-50) which confirmed support was added in version 50.