### PR TITLE
Change Edge API support from null to true based on tests

### DIFF
--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -23,7 +23,7 @@
             }
           ],
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/Attr.json
+++ b/api/Attr.json
@@ -61,7 +61,7 @@
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
               "version_added": "48",
@@ -106,7 +106,7 @@
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
               "version_added": "48",

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -747,7 +747,7 @@
               "version_added": "41"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/AudioTrack.json
+++ b/api/AudioTrack.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "firefox": {
             "version_added": true

--- a/api/CSSRuleList.json
+++ b/api/CSSRuleList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/CSSStyleDeclaration.json
+++ b/api/CSSStyleDeclaration.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/CanvasPattern.json
+++ b/api/CanvasPattern.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -317,7 +317,7 @@
               "notes": "Before Chrome 50, this property was part of the deprecated child <code>DOMSettableTokenList</code> interface."
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
               "version_added": true

--- a/api/DeviceAcceleration.json
+++ b/api/DeviceAcceleration.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/External.json
+++ b/api/External.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/FileList.json
+++ b/api/FileList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/HTMLAllCollection.json
+++ b/api/HTMLAllCollection.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/HTMLFontElement.json
+++ b/api/HTMLFontElement.json
@@ -8,7 +8,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "firefox": {
             "version_added": "22"

--- a/api/HTMLFrameElement.json
+++ b/api/HTMLFrameElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/HTMLMenuElement.json
+++ b/api/HTMLMenuElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/HTMLOptionsCollection.json
+++ b/api/HTMLOptionsCollection.json
@@ -112,7 +112,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -214,7 +214,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1091,7 +1091,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1142,7 +1142,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1193,7 +1193,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -1244,7 +1244,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/MediaStreamTrackEvent.json
+++ b/api/MediaStreamTrackEvent.json
@@ -11,7 +11,7 @@
             "version_added": "55"
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/MimeType.json
+++ b/api/MimeType.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null
@@ -112,7 +112,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/MimeTypeArray.json
+++ b/api/MimeTypeArray.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null
@@ -316,7 +316,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -367,7 +367,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -418,7 +418,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -469,7 +469,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/PageTransitionEvent.json
+++ b/api/PageTransitionEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/PaymentRequestUpdateEvent.json
+++ b/api/PaymentRequestUpdateEvent.json
@@ -24,7 +24,7 @@
             }
           ],
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/Plugin.json
+++ b/api/Plugin.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/PluginArray.json
+++ b/api/PluginArray.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/PopStateEvent.json
+++ b/api/PopStateEvent.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/ProcessingInstruction.json
+++ b/api/ProcessingInstruction.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -11,7 +11,7 @@
             "version_added": "59"
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null
@@ -432,7 +432,7 @@
               "version_added": "67"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": true

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -113,7 +113,7 @@
               "version_added": "67"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": true

--- a/api/RadioNodeList.json
+++ b/api/RadioNodeList.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/SVGComponentTransferFunctionElement.json
+++ b/api/SVGComponentTransferFunctionElement.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/SVGFEDistantLightElement.json
+++ b/api/SVGFEDistantLightElement.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/SVGFEPointLightElement.json
+++ b/api/SVGFEPointLightElement.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/SVGFESpotLightElement.json
+++ b/api/SVGFESpotLightElement.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/SVGLineElement.json
+++ b/api/SVGLineElement.json
@@ -57,7 +57,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -104,7 +104,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -151,7 +151,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -198,7 +198,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/SVGMetadataElement.json
+++ b/api/SVGMetadataElement.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/SVGPolygonElement.json
+++ b/api/SVGPolygonElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/SVGPolylineElement.json
+++ b/api/SVGPolylineElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/SVGRectElement.json
+++ b/api/SVGRectElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/SVGUnitTypes.json
+++ b/api/SVGUnitTypes.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -11,7 +11,7 @@
             "version_added": "60"
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/StorageEvent.json
+++ b/api/StorageEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/StyleSheet.json
+++ b/api/StyleSheet.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/StyleSheetList.json
+++ b/api/StyleSheetList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/VideoTrack.json
+++ b/api/VideoTrack.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/WebGLObject.json
+++ b/api/WebGLObject.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/XMLHttpRequestEventTarget.json
+++ b/api/XMLHttpRequestEventTarget.json
@@ -61,7 +61,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -112,7 +112,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -163,7 +163,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -214,7 +214,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -265,7 +265,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -316,7 +316,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
@@ -367,7 +367,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/XMLHttpRequestUpload.json
+++ b/api/XMLHttpRequestUpload.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null


### PR DESCRIPTION
Tests were generated by https://github.com/foolip/mdn-bcd-collector
and results collected in Edge 18 on Windows 10:
https://github.com/foolip/mdn-bcd-results/pull/116

This is similar to https://github.com/mdn/browser-compat-data/pull/3700,
which has examples of what the tests look like.

Where the results were true and the existing data in BCD was null, the
value was changed to true. Snapshot of script used:
https://gist.github.com/foolip/57fb835508ce96281854cc2ba44277ad

Plain false positives are very unlikely, but some of the exposed APIs
might still need notes or could be partial implementations.