### PR TITLE
Change Chrome API support from null to true based on tests

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -1521,7 +1521,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -1631,7 +1631,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -8,7 +8,7 @@
             "version_added": "5"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -221,7 +221,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -154,10 +154,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframesRule/cssRules",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -202,10 +202,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframesRule/deleteRule",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -250,10 +250,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframesRule/findRule",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -298,10 +298,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframesRule/name",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/CSSMediaRule.json
+++ b/api/CSSMediaRule.json
@@ -54,10 +54,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMediaRule/media",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/CSSPageRule.json
+++ b/api/CSSPageRule.json
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -106,10 +106,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPageRule/style",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -568,7 +568,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "15"

--- a/api/CharacterData.json
+++ b/api/CharacterData.json
@@ -102,10 +102,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData/appendData",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -150,10 +150,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData/data",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -198,10 +198,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData/deleteData",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -246,10 +246,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData/insertData",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -294,10 +294,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData/length",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -342,10 +342,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData/replaceData",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -390,10 +390,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData/substringData",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -8,7 +8,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -104,7 +104,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/DOMQuad.json
+++ b/api/DOMQuad.json
@@ -107,10 +107,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMQuad/fromRect",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -158,10 +158,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMQuad/fromQuad",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -209,10 +209,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMQuad/getBounds",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -260,10 +260,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMQuad/p1",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -311,10 +311,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMQuad/p2",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -362,10 +362,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMQuad/p3",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -413,10 +413,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMQuad/p4",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -464,10 +464,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMQuad/toJSON",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null

--- a/api/External.json
+++ b/api/External.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/External",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null
@@ -49,10 +49,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/External/AddSearchProvider",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -94,10 +94,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/External/IsSearchProviderInstalled",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null

--- a/api/FormData.json
+++ b/api/FormData.json
@@ -112,7 +112,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -238,10 +238,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GamepadButton/touched",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "15"

--- a/api/HTMLDataListElement.json
+++ b/api/HTMLDataListElement.json
@@ -8,7 +8,7 @@
             "version_added": "62"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -55,7 +55,7 @@
               "version_added": "62"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/HTMLDetailsElement.json
+++ b/api/HTMLDetailsElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLDetailsElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null
@@ -55,10 +55,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLDetailsElement/open",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null

--- a/api/HTMLFontElement.json
+++ b/api/HTMLFontElement.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFontElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null
@@ -37,7 +37,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFontElement/color",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -70,7 +70,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFontElement/face",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -103,7 +103,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFontElement/size",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/HTMLFrameSetElement.json
+++ b/api/HTMLFrameSetElement.json
@@ -146,10 +146,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -193,10 +193,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -240,10 +240,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -627,7 +627,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -523,10 +523,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -573,7 +573,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "18"
@@ -617,10 +617,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1307,10 +1307,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1362,10 +1362,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1690,7 +1690,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mediaKeys",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "13"
@@ -2197,7 +2197,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/onencrypted",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "13"
@@ -3214,7 +3214,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/setMediaKeys",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "13"
@@ -3574,7 +3574,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/textTracks",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/HTMLMeterElement.json
+++ b/api/HTMLMeterElement.json
@@ -277,7 +277,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMeterElement/labels",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "18"

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -488,7 +488,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -536,7 +536,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "18"
@@ -581,10 +581,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/length",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -629,10 +629,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/multiple",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -677,10 +677,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/name",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -775,10 +775,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/options",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -922,10 +922,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/required",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -970,10 +970,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/selectedIndex",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1021,7 +1021,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1069,7 +1069,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1114,10 +1114,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/size",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1213,7 +1213,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1261,7 +1261,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1306,10 +1306,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/value",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1357,7 +1357,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/HTMLTableColElement.json
+++ b/api/HTMLTableColElement.json
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableColElement/ch",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -148,10 +148,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableColElement/chOff",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/HTMLTableSectionElement.json
+++ b/api/HTMLTableSectionElement.json
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableSectionElement/ch",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -148,10 +148,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableSectionElement/chOff",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -202,7 +202,7 @@
               "version_added": "47"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "17"
@@ -250,7 +250,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "18"

--- a/api/InputDeviceInfo.json
+++ b/api/InputDeviceInfo.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/InputDeviceInfo",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null
@@ -55,10 +55,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/InputDeviceInfo/getCapabilities",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -160,7 +160,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -211,7 +211,7 @@
               "version_added": "26"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -259,10 +259,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardEvent/code",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -313,7 +313,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -622,7 +622,7 @@
               "version_added": "26"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -729,7 +729,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -780,7 +780,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -831,7 +831,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -882,7 +882,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1085,10 +1085,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardEvent/DOM_KEY_LOCATION_LEFT",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -1136,10 +1136,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardEvent/DOM_KEY_LOCATION_NUMPAD",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -1187,10 +1187,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardEvent/DOM_KEY_LOCATION_RIGHT",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -1238,10 +1238,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardEvent/DOM_KEY_LOCATION_STANDARD",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null

--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -284,10 +284,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDeviceInfo/toJSON",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "18"

--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -110,10 +110,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaElementAudioSourceNode/mediaElement",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null

--- a/api/MediaStreamTrackEvent.json
+++ b/api/MediaStreamTrackEvent.json
@@ -107,10 +107,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackEvent/track",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -8,7 +8,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -109,7 +109,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -160,7 +160,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -211,7 +211,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "17"
@@ -262,7 +262,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -364,7 +364,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -415,7 +415,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -220,7 +220,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -271,7 +271,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -584,7 +584,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -788,7 +788,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1477,7 +1477,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1732,7 +1732,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1836,7 +1836,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1887,7 +1887,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null
@@ -55,10 +55,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/type",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -106,10 +106,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/target",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -157,10 +157,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/addedNodes",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -208,10 +208,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/removedNodes",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -259,10 +259,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/previousSibling",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/NamedNodeMap.json
+++ b/api/NamedNodeMap.json
@@ -74,10 +74,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NamedNodeMap/getNamedItem",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -122,10 +122,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NamedNodeMap/getNamedItemNS",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -170,10 +170,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NamedNodeMap/item",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -218,10 +218,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NamedNodeMap/length",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -266,10 +266,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NamedNodeMap/removeNamedItem",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -314,10 +314,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NamedNodeMap/removeNamedItemNS",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -362,10 +362,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NamedNodeMap/setNamedItem",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -410,10 +410,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NamedNodeMap/setNamedItemNS",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/PresentationConnection.json
+++ b/api/PresentationConnection.json
@@ -69,10 +69,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationConnection/binaryType",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -394,10 +394,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationConnection/onmessage",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -654,10 +654,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationConnection/terminate",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null

--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushSubscriptionOptions",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null
@@ -55,10 +55,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushSubscriptionOptions/applicationServerKey",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "17"
@@ -106,10 +106,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushSubscriptionOptions/userVisibleOnly",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "17"

--- a/api/RTCCertificate.json
+++ b/api/RTCCertificate.json
@@ -106,10 +106,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCCertificate/getFingerprints",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -821,10 +821,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/toJSON",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "15"

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -312,10 +312,10 @@
           "description": "<code>getCapabilities()</code>",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -468,10 +468,10 @@
           "description": "<code>setParameters()</code>",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null

--- a/api/RadioNodeList.json
+++ b/api/RadioNodeList.json
@@ -8,7 +8,7 @@
             "version_added": "34"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null
@@ -58,7 +58,7 @@
               "version_added": "34"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "18"

--- a/api/SVGAngle.json
+++ b/api/SVGAngle.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAngle",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGAnimatedAngle.json
+++ b/api/SVGAnimatedAngle.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedAngle",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGAnimatedBoolean.json
+++ b/api/SVGAnimatedBoolean.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedBoolean",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGAnimatedEnumeration.json
+++ b/api/SVGAnimatedEnumeration.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedEnumeration",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGAnimatedInteger.json
+++ b/api/SVGAnimatedInteger.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedInteger",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGAnimatedLength.json
+++ b/api/SVGAnimatedLength.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedLength",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGAnimatedLengthList.json
+++ b/api/SVGAnimatedLengthList.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedLengthList",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGAnimatedNumber.json
+++ b/api/SVGAnimatedNumber.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedNumber",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGAnimatedNumberList.json
+++ b/api/SVGAnimatedNumberList.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedNumberList",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGAnimatedPreserveAspectRatio.json
+++ b/api/SVGAnimatedPreserveAspectRatio.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedPreserveAspectRatio",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGAnimatedRect.json
+++ b/api/SVGAnimatedRect.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedRect",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGAnimatedTransformList.json
+++ b/api/SVGAnimatedTransformList.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedTransformList",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGCircleElement.json
+++ b/api/SVGCircleElement.json
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGCircleElement/cx",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -99,10 +99,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -146,10 +146,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/SVGClipPathElement.json
+++ b/api/SVGClipPathElement.json
@@ -51,10 +51,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/SVGComponentTransferFunctionElement.json
+++ b/api/SVGComponentTransferFunctionElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGComponentTransferFunctionElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null

--- a/api/SVGDefsElement.json
+++ b/api/SVGDefsElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGDescElement.json
+++ b/api/SVGDescElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFEComponentTransferElement.json
+++ b/api/SVGFEComponentTransferElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFECompositeElement.json
+++ b/api/SVGFECompositeElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFEDiffuseLightingElement.json
+++ b/api/SVGFEDiffuseLightingElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFEDisplacementMapElement.json
+++ b/api/SVGFEDisplacementMapElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFEDistantLightElement.json
+++ b/api/SVGFEDistantLightElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEDistantLightElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null

--- a/api/SVGFEDropShadowElement.json
+++ b/api/SVGFEDropShadowElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEDropShadowElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null

--- a/api/SVGFEFloodElement.json
+++ b/api/SVGFEFloodElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFEFuncAElement.json
+++ b/api/SVGFEFuncAElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFEFuncBElement.json
+++ b/api/SVGFEFuncBElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFEFuncGElement.json
+++ b/api/SVGFEFuncGElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFEFuncRElement.json
+++ b/api/SVGFEFuncRElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFEGaussianBlurElement.json
+++ b/api/SVGFEGaussianBlurElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFEImageElement.json
+++ b/api/SVGFEImageElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFEMergeElement.json
+++ b/api/SVGFEMergeElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFEMergeNodeElement.json
+++ b/api/SVGFEMergeNodeElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFEMorphologyElement.json
+++ b/api/SVGFEMorphologyElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFEOffsetElement.json
+++ b/api/SVGFEOffsetElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFEPointLightElement.json
+++ b/api/SVGFEPointLightElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEPointLightElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null

--- a/api/SVGFESpecularLightingElement.json
+++ b/api/SVGFESpecularLightingElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFESpotLightElement.json
+++ b/api/SVGFESpotLightElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFESpotLightElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null

--- a/api/SVGFETileElement.json
+++ b/api/SVGFETileElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGFETurbulenceElement.json
+++ b/api/SVGFETurbulenceElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGForeignObjectElement.json
+++ b/api/SVGForeignObjectElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGGradientElement.json
+++ b/api/SVGGradientElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGradientElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -51,10 +51,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -153,10 +153,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -200,10 +200,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "15"

--- a/api/SVGLength.json
+++ b/api/SVGLength.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLength",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGLengthList.json
+++ b/api/SVGLengthList.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLengthList",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGLinearGradientElement.json
+++ b/api/SVGLinearGradientElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLinearGradientElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGMetadataElement.json
+++ b/api/SVGMetadataElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMetadataElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null

--- a/api/SVGNumber.json
+++ b/api/SVGNumber.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGNumber",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGPatternElement.json
+++ b/api/SVGPatternElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPatternElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -51,10 +51,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -98,10 +98,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -145,10 +145,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -192,10 +192,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -239,10 +239,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -286,10 +286,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -333,10 +333,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/SVGPreserveAspectRatio.json
+++ b/api/SVGPreserveAspectRatio.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPreserveAspectRatio",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGRadialGradientElement.json
+++ b/api/SVGRadialGradientElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRadialGradientElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGRectElement.json
+++ b/api/SVGRectElement.json
@@ -54,10 +54,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -101,10 +101,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -148,10 +148,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -195,10 +195,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -242,10 +242,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -289,10 +289,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -98,10 +98,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -145,10 +145,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -288,10 +288,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -335,10 +335,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -382,10 +382,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -429,10 +429,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -476,10 +476,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -523,10 +523,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -570,10 +570,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -617,10 +617,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -664,10 +664,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -711,10 +711,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -810,10 +810,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -857,10 +857,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -998,10 +998,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1045,10 +1045,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1092,10 +1092,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1449,10 +1449,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1543,10 +1543,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1590,10 +1590,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1736,10 +1736,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1783,10 +1783,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1830,10 +1830,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/SVGScriptElement.json
+++ b/api/SVGScriptElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGScriptElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGStringList.json
+++ b/api/SVGStringList.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStringList",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -53,10 +53,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null

--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStyleElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGSwitchElement.json
+++ b/api/SVGSwitchElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSwitchElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGSymbolElement.json
+++ b/api/SVGSymbolElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSymbolElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGTextContentElement.json
+++ b/api/SVGTextContentElement.json
@@ -51,10 +51,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -98,10 +98,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -145,10 +145,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -192,10 +192,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -239,10 +239,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -286,10 +286,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -333,10 +333,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -380,10 +380,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -427,10 +427,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -474,10 +474,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -521,10 +521,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/SVGTextPathElement.json
+++ b/api/SVGTextPathElement.json
@@ -51,10 +51,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -98,10 +98,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -145,10 +145,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/SVGTextPositioningElement.json
+++ b/api/SVGTextPositioningElement.json
@@ -51,10 +51,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -98,10 +98,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -145,10 +145,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -192,10 +192,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -239,10 +239,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/SVGTitleElement.json
+++ b/api/SVGTitleElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGTransform.json
+++ b/api/SVGTransform.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransform",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/SVGTransformList.json
+++ b/api/SVGTransformList.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransformList",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -51,10 +51,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null

--- a/api/SVGUnitTypes.json
+++ b/api/SVGUnitTypes.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGUnitTypes",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null

--- a/api/SVGUseElement.json
+++ b/api/SVGUseElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGUseElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -98,10 +98,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -192,10 +192,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -239,10 +239,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -286,10 +286,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/ScriptProcessorNode.json
+++ b/api/ScriptProcessorNode.json
@@ -9,7 +9,7 @@
             "prefix": "webkit"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -68,7 +68,7 @@
               "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -128,7 +128,7 @@
               "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -316,10 +316,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextDecoder/fatal",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -367,10 +367,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextDecoder/ignoreBOM",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null

--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -684,10 +684,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/UIEvent/which",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": true

--- a/api/Window.json
+++ b/api/Window.json
@@ -1291,10 +1291,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/external",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -3043,7 +3043,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -3504,7 +3504,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -4253,7 +4253,7 @@
               "version_added": "9"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -4927,10 +4927,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onbeforeinstallprompt",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -4978,10 +4978,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ondevicemotion",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -5029,10 +5029,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ondeviceorientation",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -8580,7 +8580,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "12"

--- a/api/XMLHttpRequestEventTarget.json
+++ b/api/XMLHttpRequestEventTarget.json
@@ -55,10 +55,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequestEventTarget/onabort",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -106,10 +106,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequestEventTarget/onerror",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -157,10 +157,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequestEventTarget/onload",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -208,10 +208,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequestEventTarget/onloadend",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -259,10 +259,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequestEventTarget/onloadstart",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -310,10 +310,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequestEventTarget/onprogress",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -361,10 +361,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequestEventTarget/ontimeout",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null

--- a/api/XMLHttpRequestUpload.json
+++ b/api/XMLHttpRequestUpload.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequestUpload",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null


### PR DESCRIPTION
Tests were generated by https://github.com/foolip/mdn-bcd-collector
and results collected in Chrome 73 on Android 9 and Windows 10:
https://github.com/foolip/mdn-bcd-results/pull/111
https://github.com/foolip/mdn-bcd-results/pull/112

This is similar to https://github.com/mdn/browser-compat-data/pull/3700,
which has examples of what the tests look like.

Where the results were true and the existing data in BCD was null, the
value was changed to true. Snapshot of script used:
https://gist.github.com/foolip/57fb835508ce96281854cc2ba44277ad

Plain false positives are very unlikely, but some of the exposed APIs
might still need notes or could be partial implementations.