### PR TITLE
Change Samsung Internet API support from null to true based on tests

### DIFF
--- a/api/AbsoluteOrientationSensor.json
+++ b/api/AbsoluteOrientationSensor.json
@@ -32,7 +32,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "69"

--- a/api/Accelerometer.json
+++ b/api/Accelerometer.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "69"
@@ -140,7 +140,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "69"
@@ -191,7 +191,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "69"
@@ -242,7 +242,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "69"

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -781,7 +781,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/AudioWorklet.json
+++ b/api/AudioWorklet.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"

--- a/api/AudioWorkletNode.json
+++ b/api/AudioWorkletNode.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -140,7 +140,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -242,7 +242,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -51,7 +51,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -101,7 +101,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -166,7 +166,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -231,7 +231,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -296,7 +296,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -361,7 +361,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -426,7 +426,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -491,7 +491,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -542,7 +542,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "56"
@@ -607,7 +607,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -672,7 +672,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -737,7 +737,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -802,7 +802,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -853,7 +853,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -918,7 +918,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -983,7 +983,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1067,7 +1067,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": [
               {
@@ -1193,7 +1193,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1244,7 +1244,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1309,7 +1309,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1374,7 +1374,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1439,7 +1439,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1555,7 +1555,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1620,7 +1620,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1671,7 +1671,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1736,7 +1736,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1787,7 +1787,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/BeforeInstallPromptEvent.json
+++ b/api/BeforeInstallPromptEvent.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "45"
@@ -191,7 +191,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "45"

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -260,7 +260,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/BluetoothRemoteGATTService.json
+++ b/api/BluetoothRemoteGATTService.json
@@ -74,7 +74,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -142,7 +142,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -229,7 +229,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -280,7 +280,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -469,7 +469,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -556,7 +556,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/CSS.json
+++ b/api/CSS.json
@@ -60,7 +60,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "37"
@@ -110,7 +110,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -161,7 +161,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -212,7 +212,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -263,7 +263,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -314,7 +314,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -365,7 +365,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -416,7 +416,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -467,7 +467,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "46"
@@ -518,7 +518,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -569,7 +569,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -620,7 +620,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -671,7 +671,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -722,7 +722,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -824,7 +824,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -926,7 +926,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -977,7 +977,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -1028,7 +1028,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -1079,7 +1079,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "65"
@@ -1130,7 +1130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -1181,7 +1181,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -1232,7 +1232,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -1283,7 +1283,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -1334,7 +1334,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -1385,7 +1385,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -1487,7 +1487,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -1538,7 +1538,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -1699,7 +1699,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -1801,7 +1801,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -1903,7 +1903,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -1954,7 +1954,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSImageValue.json
+++ b/api/CSSImageValue.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"

--- a/api/CSSKeywordValue.json
+++ b/api/CSSKeywordValue.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSMathInvert.json
+++ b/api/CSSMathInvert.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSMathMax.json
+++ b/api/CSSMathMax.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSMathMin.json
+++ b/api/CSSMathMin.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSMathNegate.json
+++ b/api/CSSMathNegate.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"

--- a/api/CSSMathProduct.json
+++ b/api/CSSMathProduct.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSMathSum.json
+++ b/api/CSSMathSum.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSMathValue.json
+++ b/api/CSSMathValue.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -88,7 +88,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSMatrixComponent.json
+++ b/api/CSSMatrixComponent.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSNumericArray.json
+++ b/api/CSSNumericArray.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -343,7 +343,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSNumericValue.json
+++ b/api/CSSNumericValue.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -88,7 +88,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -139,7 +139,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -190,7 +190,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -241,7 +241,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -292,7 +292,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -343,7 +343,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -398,7 +398,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66",
@@ -450,7 +450,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -501,7 +501,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -552,7 +552,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -603,7 +603,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSPageRule.json
+++ b/api/CSSPageRule.json
@@ -88,7 +88,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -139,7 +139,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/CSSPerspective.json
+++ b/api/CSSPerspective.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSRotate.json
+++ b/api/CSSRotate.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -191,7 +191,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -242,7 +242,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -293,7 +293,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSScale.json
+++ b/api/CSSScale.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -191,7 +191,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -242,7 +242,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSSkew.json
+++ b/api/CSSSkew.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -191,7 +191,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSSkewX.json
+++ b/api/CSSSkewX.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSSkewY.json
+++ b/api/CSSSkewY.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSStyleValue.json
+++ b/api/CSSStyleValue.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -88,7 +88,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -139,7 +139,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSTransformComponent.json
+++ b/api/CSSTransformComponent.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -88,7 +88,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -139,7 +139,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSTransformValue.json
+++ b/api/CSSTransformValue.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -293,7 +293,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -395,7 +395,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -446,7 +446,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSTranslate.json
+++ b/api/CSSTranslate.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -191,7 +191,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -242,7 +242,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSUnitValue.json
+++ b/api/CSSUnitValue.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -191,7 +191,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSUnparsedValue.json
+++ b/api/CSSUnparsedValue.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -344,7 +344,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSVariableReferenceValue.json
+++ b/api/CSSVariableReferenceValue.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -191,7 +191,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -613,7 +613,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "4.4"

--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -157,7 +157,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -277,7 +277,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/ClipboardEvent.json
+++ b/api/ClipboardEvent.json
@@ -140,7 +140,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/CompositionEvent.json
+++ b/api/CompositionEvent.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -140,7 +140,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Credential.json
+++ b/api/Credential.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "51"
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "51"
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "51"

--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -140,7 +140,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -191,7 +191,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -242,7 +242,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/DOMQuad.json
+++ b/api/DOMQuad.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "61"
@@ -140,7 +140,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -191,7 +191,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -242,7 +242,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -293,7 +293,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -344,7 +344,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -395,7 +395,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -446,7 +446,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -497,7 +497,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -152,7 +152,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "57"

--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -186,7 +186,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -237,7 +237,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -288,7 +288,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -339,7 +339,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -390,7 +390,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -897,7 +897,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -948,7 +948,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -999,7 +999,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -38,7 +38,7 @@
             "version_added": "4.2"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -140,7 +140,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -191,7 +191,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -242,7 +242,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -293,7 +293,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -42,7 +42,7 @@
             "version_added": "4.2"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true,
@@ -145,7 +145,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -196,7 +196,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -247,7 +247,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -298,7 +298,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Element.json
+++ b/api/Element.json
@@ -560,7 +560,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -741,7 +741,7 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "53"
@@ -843,7 +843,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1112,7 +1112,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1521,7 +1521,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43"
@@ -1572,7 +1572,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43"
@@ -1674,7 +1674,7 @@
               "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "41"
@@ -1881,7 +1881,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -2698,7 +2698,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2801,7 +2801,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "61"
@@ -2852,7 +2852,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2903,7 +2903,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2955,7 +2955,7 @@
               "notes": "Safari for iOS will modify the effective viewport based on the user zoom. This results in incorrect values whenever the user has zoomed."
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3210,7 +3210,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3263,7 +3263,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3433,7 +3433,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3568,7 +3568,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3620,7 +3620,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3695,7 +3695,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "55"
@@ -4009,7 +4009,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,
@@ -4323,7 +4323,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,
@@ -4764,7 +4764,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4961,7 +4961,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "55"
@@ -5013,7 +5013,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5064,7 +5064,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5115,7 +5115,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5422,7 +5422,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": [
               {
@@ -5738,7 +5738,7 @@
               "notes": "No support for <code>smooth</code> behavior or <code>center</code> options."
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6269,7 +6269,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6320,7 +6320,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6371,7 +6371,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6422,7 +6422,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6475,7 +6475,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6608,7 +6608,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "55"
@@ -6687,7 +6687,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43"
@@ -6738,7 +6738,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "53"
@@ -6840,7 +6840,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43"

--- a/api/FileList.json
+++ b/api/FileList.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -88,7 +88,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -139,7 +139,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/FocusEvent.json
+++ b/api/FocusEvent.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -140,7 +140,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/FormData.json
+++ b/api/FormData.json
@@ -39,7 +39,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true,
@@ -145,7 +145,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "3",
@@ -249,7 +249,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -300,7 +300,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -351,7 +351,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -402,7 +402,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -453,7 +453,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Gyroscope.json
+++ b/api/Gyroscope.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "69"
@@ -140,7 +140,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "69"
@@ -191,7 +191,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "69"
@@ -242,7 +242,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "69"

--- a/api/HTMLDetailsElement.json
+++ b/api/HTMLDetailsElement.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -88,7 +88,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1173,7 +1173,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -88,7 +88,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -139,7 +139,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -190,7 +190,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -241,7 +241,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -292,7 +292,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -343,7 +343,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -394,7 +394,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -445,7 +445,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -496,7 +496,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -547,7 +547,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -598,7 +598,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -751,7 +751,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -853,7 +853,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1177,7 +1177,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "uc_android": {
               "version_added": null
@@ -1284,7 +1284,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "uc_android": {
               "version_added": null

--- a/api/HTMLOptionsCollection.json
+++ b/api/HTMLOptionsCollection.json
@@ -139,7 +139,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -190,7 +190,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -241,7 +241,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -259,7 +259,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "65"

--- a/api/HashChangeEvent.json
+++ b/api/HashChangeEvent.json
@@ -85,7 +85,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -136,7 +136,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/IdleDeadline.json
+++ b/api/IdleDeadline.json
@@ -62,7 +62,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "47"
@@ -136,7 +136,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "47"
@@ -211,7 +211,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "47"

--- a/api/ImageCapture.json
+++ b/api/ImageCapture.json
@@ -191,7 +191,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "61"

--- a/api/InputDeviceCapabilities.json
+++ b/api/InputDeviceCapabilities.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "47"
@@ -140,7 +140,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "47"

--- a/api/InputDeviceInfo.json
+++ b/api/InputDeviceInfo.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -38,7 +38,7 @@
             "version_added": "10.1"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "60"
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "60"
@@ -191,7 +191,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "60"
@@ -242,7 +242,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "60"
@@ -293,7 +293,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "60"
@@ -344,7 +344,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "60"

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -190,7 +190,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -241,7 +241,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -292,7 +292,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -343,7 +343,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -394,7 +394,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "56"
@@ -446,7 +446,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "51"
@@ -652,7 +652,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -759,7 +759,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -810,7 +810,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -861,7 +861,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -912,7 +912,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1118,7 +1118,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1169,7 +1169,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1220,7 +1220,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1271,7 +1271,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/LinearAccelerationSensor.json
+++ b/api/LinearAccelerationSensor.json
@@ -32,7 +32,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "69"

--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43"
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43"
@@ -190,7 +190,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "45"

--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -317,7 +317,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -38,7 +38,7 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "47"
@@ -211,7 +211,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "47"
@@ -262,7 +262,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "53"
@@ -509,7 +509,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "53"

--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -143,7 +143,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/MediaEncryptedEvent.json
+++ b/api/MediaEncryptedEvent.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "43"
@@ -140,7 +140,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43"
@@ -191,7 +191,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43"

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -140,7 +140,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -191,7 +191,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -242,7 +242,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -293,7 +293,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -624,7 +624,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -683,7 +683,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -742,7 +742,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -852,7 +852,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -911,7 +911,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -970,7 +970,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -1029,7 +1029,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -1088,7 +1088,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -1147,7 +1147,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"
@@ -1206,7 +1206,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "49"

--- a/api/MediaStreamAudioSourceNode.json
+++ b/api/MediaStreamAudioSourceNode.json
@@ -143,7 +143,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/MediaStreamTrackEvent.json
+++ b/api/MediaStreamTrackEvent.json
@@ -140,7 +140,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/MessageChannel.json
+++ b/api/MessageChannel.json
@@ -38,7 +38,7 @@
             "version_added": "5.1"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "4.4"
@@ -139,7 +139,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "4.4"
@@ -190,7 +190,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "4.4"

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -38,7 +38,7 @@
             "version_added": "3"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -139,7 +139,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -190,7 +190,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -241,7 +241,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -292,7 +292,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -394,7 +394,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -445,7 +445,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -38,7 +38,7 @@
             "version_added": "5.1"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -139,7 +139,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -294,7 +294,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -345,7 +345,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "60"
@@ -396,7 +396,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -447,7 +447,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/MimeType.json
+++ b/api/MimeType.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -88,7 +88,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -139,7 +139,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -190,7 +190,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -241,7 +241,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -250,7 +250,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -307,7 +307,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -359,7 +359,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -410,7 +410,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -512,7 +512,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -614,7 +614,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -665,7 +665,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "47"
@@ -818,7 +818,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -897,7 +897,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -976,7 +976,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -1027,7 +1027,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1129,7 +1129,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1231,7 +1231,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "45"
@@ -1333,7 +1333,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "45"
@@ -1507,7 +1507,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1558,7 +1558,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1660,7 +1660,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1762,7 +1762,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1866,7 +1866,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1917,7 +1917,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -88,7 +88,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -139,7 +139,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -190,7 +190,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -241,7 +241,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -292,7 +292,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -430,7 +430,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -482,7 +482,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "50"
@@ -535,7 +535,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "59"
@@ -760,7 +760,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -866,7 +866,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "45"
@@ -941,7 +941,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": [
               {
@@ -1255,7 +1255,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "37"
@@ -1306,7 +1306,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -1357,7 +1357,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "51"
@@ -1408,7 +1408,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -1563,7 +1563,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -1614,7 +1614,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -1670,7 +1670,7 @@
               "notes": "Always returns <code>20030107</code>."
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1902,7 +1902,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43",
@@ -1961,7 +1961,7 @@
               "version_added": "11.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "40",
@@ -2025,7 +2025,7 @@
               "version_added": "11.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "40"
@@ -2178,7 +2178,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2254,7 +2254,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "4.4.3",

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -57,7 +57,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -279,7 +279,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -330,7 +330,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -381,7 +381,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -432,7 +432,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -483,7 +483,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -552,7 +552,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -603,7 +603,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -654,7 +654,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -705,7 +705,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -756,7 +756,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -807,7 +807,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -858,7 +858,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -909,7 +909,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -960,7 +960,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -1011,7 +1011,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -1062,7 +1062,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -1113,7 +1113,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -1164,7 +1164,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -1215,7 +1215,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -1266,7 +1266,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -1317,7 +1317,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -1368,7 +1368,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -1419,7 +1419,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/OrientationSensor.json
+++ b/api/OrientationSensor.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "69"
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "69"
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "69"

--- a/api/PageTransitionEvent.json
+++ b/api/PageTransitionEvent.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -88,7 +88,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -334,7 +334,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -891,7 +891,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -49,7 +49,7 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": [
             {
@@ -156,7 +156,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -207,7 +207,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -258,7 +258,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -309,7 +309,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -360,7 +360,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/PerformanceLongTaskTiming.json
+++ b/api/PerformanceLongTaskTiming.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "58"
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "58"

--- a/api/PerformanceMark.json
+++ b/api/PerformanceMark.json
@@ -38,7 +38,7 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true

--- a/api/PerformanceMeasure.json
+++ b/api/PerformanceMeasure.json
@@ -38,7 +38,7 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true

--- a/api/PerformanceNavigation.json
+++ b/api/PerformanceNavigation.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -90,7 +90,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -141,7 +141,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -194,7 +194,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/PerformanceObserverEntryList.json
+++ b/api/PerformanceObserverEntryList.json
@@ -38,7 +38,7 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -88,7 +88,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -139,7 +139,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -190,7 +190,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/PerformancePaintTiming.json
+++ b/api/PerformancePaintTiming.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "60"

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -853,7 +853,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "65"

--- a/api/PerformanceServerTiming.json
+++ b/api/PerformanceServerTiming.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "65"
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "65"
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "65"
@@ -190,7 +190,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "65"
@@ -241,7 +241,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "65"

--- a/api/PermissionStatus.json
+++ b/api/PermissionStatus.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -153,7 +153,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "43"
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43"

--- a/api/Plugin.json
+++ b/api/Plugin.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -88,7 +88,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -139,7 +139,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -192,7 +192,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,
@@ -244,7 +244,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -297,7 +297,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,

--- a/api/PluginArray.json
+++ b/api/PluginArray.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -90,7 +90,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,
@@ -142,7 +142,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -195,7 +195,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,
@@ -249,7 +249,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true,

--- a/api/Presentation.json
+++ b/api/Presentation.json
@@ -52,7 +52,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -116,7 +116,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -181,7 +181,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationAvailability.json
+++ b/api/PresentationAvailability.json
@@ -52,7 +52,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -116,7 +116,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -181,7 +181,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationConnection.json
+++ b/api/PresentationConnection.json
@@ -52,7 +52,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -116,7 +116,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -181,7 +181,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -246,7 +246,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -311,7 +311,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -376,7 +376,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -441,7 +441,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -506,7 +506,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -571,7 +571,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -636,7 +636,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -701,7 +701,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -766,7 +766,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationConnectionAvailableEvent.json
+++ b/api/PresentationConnectionAvailableEvent.json
@@ -52,7 +52,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -182,7 +182,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationConnectionCloseEvent.json
+++ b/api/PresentationConnectionCloseEvent.json
@@ -52,7 +52,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -182,7 +182,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -247,7 +247,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationConnectionList.json
+++ b/api/PresentationConnectionList.json
@@ -52,7 +52,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -116,7 +116,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -181,7 +181,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationReceiver.json
+++ b/api/PresentationReceiver.json
@@ -52,7 +52,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -116,7 +116,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -52,7 +52,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -233,7 +233,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -298,7 +298,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -363,7 +363,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -428,7 +428,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/ProgressEvent.json
+++ b/api/ProgressEvent.json
@@ -140,7 +140,7 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "50"

--- a/api/PromiseRejectionEvent.json
+++ b/api/PromiseRejectionEvent.json
@@ -54,7 +54,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -184,7 +184,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -249,7 +249,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCCertificate.json
+++ b/api/RTCCertificate.json
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/RTCDTMFSender.json
+++ b/api/RTCDTMFSender.json
@@ -293,7 +293,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -854,7 +854,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -546,7 +546,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1743,7 +1743,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": [
               {

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -449,7 +449,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "65"

--- a/api/RadioNodeList.json
+++ b/api/RadioNodeList.json
@@ -38,7 +38,7 @@
             "version_added": "9"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -88,7 +88,7 @@
               "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/RelativeOrientationSensor.json
+++ b/api/RelativeOrientationSensor.json
@@ -32,7 +32,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "69"

--- a/api/Request.json
+++ b/api/Request.json
@@ -904,7 +904,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "65"
@@ -1537,7 +1537,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/ResizeObserverEntry.json
+++ b/api/ResizeObserverEntry.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "64"
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "64"
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "64"

--- a/api/SVGFEColorMatrixElement.json
+++ b/api/SVGFEColorMatrixElement.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -88,7 +88,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -139,7 +139,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -190,7 +190,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Screen.json
+++ b/api/Screen.json
@@ -700,7 +700,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -88,7 +88,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "38"
@@ -139,7 +139,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "38"
@@ -190,7 +190,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "38"
@@ -241,7 +241,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "38"
@@ -292,7 +292,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "38"

--- a/api/ScriptProcessorNode.json
+++ b/api/ScriptProcessorNode.json
@@ -53,7 +53,7 @@
             "prefix": "webkit"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -118,7 +118,7 @@
               "prefix": "webkit"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -184,7 +184,7 @@
               "prefix": "webkit"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Sensor.json
+++ b/api/Sensor.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "69"
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "69"
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "69"
@@ -190,7 +190,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "69"
@@ -241,7 +241,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "69"
@@ -292,7 +292,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "69"
@@ -343,7 +343,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "69"
@@ -394,7 +394,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "69"
@@ -445,7 +445,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "69"

--- a/api/SensorErrorEvent.json
+++ b/api/SensorErrorEvent.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "69"
@@ -140,7 +140,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "69"

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -38,7 +38,7 @@
             "version_added": "10.1"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "60"

--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -60,7 +60,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "48"
@@ -110,7 +110,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "52"
@@ -175,7 +175,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": [
               {
@@ -247,7 +247,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": [
               {

--- a/api/StylePropertyMap.json
+++ b/api/StylePropertyMap.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -88,7 +88,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -139,7 +139,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -190,7 +190,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -241,7 +241,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/StylePropertyMapReadOnly.json
+++ b/api/StylePropertyMapReadOnly.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "66"
@@ -241,7 +241,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -292,7 +292,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -343,7 +343,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -445,7 +445,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/TaskAttributionTiming.json
+++ b/api/TaskAttributionTiming.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "58"
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "58"
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "58"
@@ -190,7 +190,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "58"
@@ -241,7 +241,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "58"

--- a/api/Text.json
+++ b/api/Text.json
@@ -214,7 +214,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "53"

--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -52,7 +52,7 @@
             "version_added": "10.1"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "38"
@@ -233,7 +233,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "38"
@@ -298,7 +298,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "38"
@@ -349,7 +349,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -400,7 +400,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -50,7 +50,7 @@
             "version_added": "10.1"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": "38"
@@ -257,7 +257,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "38"
@@ -320,7 +320,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "38"

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -88,7 +88,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -241,7 +241,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -292,7 +292,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -343,7 +343,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -394,7 +394,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -190,7 +190,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -241,7 +241,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Touch.json
+++ b/api/Touch.json
@@ -46,7 +46,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -156,7 +156,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -215,7 +215,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -266,7 +266,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -325,7 +325,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -384,7 +384,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -443,7 +443,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -494,7 +494,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43"
@@ -545,7 +545,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43"
@@ -596,7 +596,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "43"
@@ -655,7 +655,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -714,7 +714,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -773,7 +773,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/TouchEvent.json
+++ b/api/TouchEvent.json
@@ -52,7 +52,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -220,7 +220,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -277,7 +277,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -334,7 +334,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -391,7 +391,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -448,7 +448,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -505,7 +505,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/TrackEvent.json
+++ b/api/TrackEvent.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -242,7 +242,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -615,7 +615,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "47"
@@ -666,7 +666,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -717,7 +717,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -191,7 +191,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -243,7 +243,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -295,7 +295,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -347,7 +347,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Window.json
+++ b/api/Window.json
@@ -1093,7 +1093,7 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1168,7 +1168,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "47"
@@ -1272,7 +1272,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1369,7 +1369,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2963,7 +2963,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "54"
@@ -3116,7 +3116,7 @@
               "version_added": "9.3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3285,7 +3285,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3336,7 +3336,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3593,7 +3593,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3799,7 +3799,7 @@
               "notes": "No support for selection start."
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3951,7 +3951,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4068,7 +4068,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4133,7 +4133,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4184,7 +4184,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4335,7 +4335,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4491,7 +4491,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4593,7 +4593,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4644,7 +4644,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4746,7 +4746,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4848,7 +4848,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4899,7 +4899,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5154,7 +5154,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5205,7 +5205,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5270,7 +5270,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -5321,7 +5321,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5372,7 +5372,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5423,7 +5423,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5474,7 +5474,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5627,7 +5627,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5678,7 +5678,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -5781,7 +5781,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5832,7 +5832,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6038,7 +6038,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6089,7 +6089,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6140,7 +6140,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6293,7 +6293,7 @@
               "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6344,7 +6344,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6481,7 +6481,7 @@
               "notes": "For security reasons, to work properly on Safari, construct using <code>document.getElementById('your-frame').contentWindow</code>."
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6584,7 +6584,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6637,7 +6637,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6739,7 +6739,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6850,7 +6850,7 @@
               }
             ],
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -7021,7 +7021,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "47"
@@ -7073,7 +7073,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -7125,7 +7125,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -7329,7 +7329,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -7484,7 +7484,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -7537,7 +7537,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -7588,7 +7588,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -7690,7 +7690,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -7745,7 +7745,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -8220,7 +8220,7 @@
             ],
             "samsunginternet_android": [
               {
-                "version_added": null
+                "version_added": true
               },
               {
                 "version_added": null,
@@ -8400,7 +8400,7 @@
             ],
             "samsunginternet_android": [
               {
-                "version_added": null
+                "version_added": true
               },
               {
                 "version_added": null,
@@ -8513,7 +8513,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -8564,7 +8564,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -8931,7 +8931,7 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -8982,7 +8982,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -9033,7 +9033,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -9084,7 +9084,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -9135,7 +9135,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -9187,7 +9187,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -10204,7 +10204,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/XMLHttpRequestEventTarget.json
+++ b/api/XMLHttpRequestEventTarget.json
@@ -88,7 +88,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -139,7 +139,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -190,7 +190,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -241,7 +241,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -292,7 +292,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -343,7 +343,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -394,7 +394,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/XMLHttpRequestUpload.json
+++ b/api/XMLHttpRequestUpload.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true


### PR DESCRIPTION
Tests were generated by https://github.com/foolip/mdn-bcd-collector
and results collected in Samsung Internet 9 on Android 8:
https://github.com/foolip/mdn-bcd-results/pull/115

This is similar to https://github.com/mdn/browser-compat-data/pull/3700,
which has examples of what the tests look like.

Where the results were true and the existing data in BCD was null, the
value was changed to true. Snapshot of script used:
https://gist.github.com/foolip/ee98164b3fcc7c52671f3145a9686311

Plain false positives are very unlikely, but some of the exposed APIs
might still need notes or could be partial implementations.