### PR TITLE
feat(api): Complete `RTCDtlsTransport`

### DIFF
--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -320,6 +320,62 @@
             "deprecated": false
           }
         }
+      },
+      "statechange_event": {
+        "__compat": {
+          "description": "<code>statechange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDtlsTransport/statechange_event",
+          "support": {
+            "chrome": {
+              "version_added": "72"
+            },
+            "chrome_android": {
+              "version_added": "72"
+            },
+            "edge": {
+              "version_added": "12",
+              "alternative_name": "dtlsstatechange"
+            },
+            "edge_mobile": {
+              "version_added": null,
+              "alternative_name": "dtlsstatechange"
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "59"
+            },
+            "opera_android": {
+              "version_added": "50"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "72"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -5,43 +5,45 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDtlsTransport",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": "72"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "72"
           },
           "edge": {
-            "version_added": true
+            "version_added": "12"
           },
           "edge_mobile": {
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": false,
+            "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false,
+            "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "59"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "50"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": null
           },
           "webview_android": {
-            "version_added": null
+            "version_added": "72"
           }
         },
         "status": {
@@ -50,15 +52,15 @@
           "deprecated": false
         }
       },
-      "onerror": {
+      "getRemoteCertificates": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDtlsTransport/onerror",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDtlsTransport/getRemoteCertificates",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "72"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "72"
             },
             "edge": {
               "version_added": "12"
@@ -67,31 +69,141 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "59"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "50"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
+              "version_added": "72"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "iceTransport": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDtlsTransport/iceTransport",
+          "support": {
+            "chrome": {
+              "version_added": "72"
+            },
+            "chrome_android": {
+              "version_added": "72"
+            },
+            "edge": {
+              "version_added": "15",
+              "alternative_name": "transport"
+            },
+            "edge_mobile": {
+              "version_added": null,
+              "alternative_name": "transport"
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "59"
+            },
+            "opera_android": {
+              "version_added": "50"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": "72"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onerror": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDtlsTransport/onerror",
+          "support": {
+            "chrome": {
+              "version_added": "72"
+            },
+            "chrome_android": {
+              "version_added": "72"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "59"
+            },
+            "opera_android": {
+              "version_added": "50"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "72"
             }
           },
           "status": {
@@ -106,43 +218,47 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDtlsTransport/onstatechange",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "72"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "72"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12",
+              "alternative_name": "ondtlsstatechange"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": null,
+              "alternative_name": "ondtlsstatechange"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "59"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "50"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "72"
             }
           },
           "status": {
@@ -157,10 +273,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDtlsTransport/state",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "72"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "72"
             },
             "edge": {
               "version_added": "12"
@@ -169,133 +285,33 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "59"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "50"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "transport": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDtlsTransport/transport",
-          "support": {
-            "chrome": {
-              "version_added": null
-            },
-            "chrome_android": {
-              "version_added": null
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "getRemoteCertificates": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDtlsTransport/getRemoteCertificates",
-          "support": {
-            "chrome": {
-              "version_added": null
-            },
-            "chrome_android": {
-              "version_added": null
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": null
+              "version_added": "72"
             }
           },
           "status": {


### PR DESCRIPTION
This was added in **Chromium 72**: https://storage.googleapis.com/chromium-find-releases-static/108.html#1081d0ac7c5532ddbd4a66c776e6ec8c6d36b01a

**Firefox** is implementing this in [bug 1307996](https://bugzilla.mozilla.org/show_bug.cgi?id=1307996).

**Safari** and **IE** don’t support this.

---

review?(@a2sheppy, @Elchi3)