### PR TITLE
Set support to true for HTML data URLs

### DIFF
--- a/http/data-url.json
+++ b/http/data-url.json
@@ -119,10 +119,10 @@
           "description": "HTML files",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": false
@@ -131,31 +131,31 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
Supersedes #3697 by adding support for Chromium, Firefox, and Safari to HTML-formatted data URLs.  Manually tested in Chrome, Firefox, and Safari on macOS, Chrome and Firefox on Android, and Safari on iOS.