### PR TITLE
inputmodes now supported on iOS 12.2 Safari

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -871,7 +871,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "66"


### PR DESCRIPTION
### Summary
Safari on iOS 12.2 now supports the global attribute [inputmode](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).

### Documentation
This was not called out in Safari's [Release Notes](https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes) yet, but it is discussed in the [WebKit Bugzilla](https://bugs.webkit.org/show_bug.cgi?id=183621#c21) and mentioned in the latest summary of [PWA features on iOS 12.2 from Maximiliano Firtman](https://medium.com/@firt/whats-new-on-ios-12-2-for-progressive-web-apps-75c348f8e945)
It can be confirmed by viewing an [inputmode demo](https://codepen.io/danwilson/pen/KYPWgW) on an iOS 12.2 device.


