### PR TITLE
Update DateTimeFormat/formatToParts support for Edge

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -724,7 +724,7 @@
                   "notes": "Before version 71, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 71 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>."
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "18"
                 },
                 "edge_mobile": {
                   "version_added": false


### PR DESCRIPTION
The function `Intl.DateTimeFormat.prototype.formatToParts` exists in Edge 18, but is undefined in Edge 17.
(Tested on two Windows 10 machines, one with each version)

Also confirmed with Confluence.

issue #3720 