### PR TITLE
Add AbortSignal: abort event

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -50,6 +50,58 @@
           "deprecated": false
         }
       },
+      "abort_event": {
+        "__compat": {
+          "description": "<code>abort</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal/abort_event",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "57"
+            },
+            "firefox_android": {
+              "version_added": "57"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "53"
+            },
+            "safari": {
+              "version_added": "11.1"
+            },
+            "safari_ios": {
+              "version_added": "11.1"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "aborted": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal/aborted",


### PR DESCRIPTION
This adds compat data for this page where we still use a legacy table:
https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/abort_event

https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/onabort#Browser_compatibility has much better compat data than the legacy table, so I've used that here.