### PR TITLE
Remove compile_flag from the schema

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5852,18 +5852,10 @@
             },
             "firefox": [
               {
-                "version_added": "61",
-                "version_removed": "63",
-                "flags": [
-                  {
-                    "type": "compile_flag",
-                    "name": "MOZ_BREAK_XUL_OVERLAYS",
-                    "value_to_set": "False"
-                  }
-                ],
+                "version_added": true,
+                "version_removed": "61",
                 "notes": [
                   "Available only to <a href='https://developer.mozilla.org/docs/Mozilla/Tech/XUL'>XUL documents</a>.",
-                  "If a XUL document attempts to load an overlay without the compile flag, an error will be thrown (see <a href='https://bugzil.la/1448162'>bug 1448162</a>).",
                   "See <a href='https://bugzil.la/1449791'>bug 1449791</a>"
                 ]
               },

--- a/javascript/operators/pipeline.json
+++ b/javascript/operators/pipeline.json
@@ -20,22 +20,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "58",
-              "flags": [
-                {
-                  "name": "--enable-pipeline-operator",
-                  "type": "compile_flag"
-                }
-              ]
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "58",
-              "flags": [
-                {
-                  "name": "--enable-pipeline-operator",
-                  "type": "compile_flag"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -305,7 +305,6 @@ array will have one item, but there are cases where two or more flags can be req
 An object in the `flags` array consists of three properties:
 * `type` (mandatory): an enum that indicates the flag type:
   * `preference` a flag the user can set (like in `about:config` in Firefox).
-  * `compile_flag` a flag to be set before compiling the browser.
   * `runtime_flag` a flag to be set before starting the browser.
 * `name` (mandatory): a string giving the value which the specified flag must be set to for this feature to work.
 * `value_to_set` (optional): representing the actual value to set the flag to.

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -24,7 +24,7 @@
               "type": {
                 "type": "string",
                 "description": "An enum that indicates the flag type.",
-                "enum": ["preference", "compile_flag", "runtime_flag"]
+                "enum": ["preference", "runtime_flag"]
               },
               "name": {
                 "type": "string",

--- a/scripts/render.js
+++ b/scripts/render.js
@@ -185,10 +185,6 @@ function writeFlagsNote(supportData, browserId) {
     output += `${flagText} preference${valueToSet}. ${prefSettings}`;
   }
 
-  if (supportData.flag.type === 'compile_flag') {
-    output += `${flagText} compile flag${valueToSet}.`;
-  }
-
   return output;
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -160,10 +160,9 @@ export interface SimpleSupportStatement {
     /**
      * An enum that indicates the flag type:
      * - `preference` a flag the user can set (like in `about:config` in Firefox).
-     * - `compile_flag` a flag to be set before compiling the browser.
      * - `runtime_flag` a flag to be set before starting the browser.
      */
-    type: 'preference' | 'compile_flag' | 'runtime_flag';
+    type: 'preference' | 'runtime_flag';
 
     /**
      * A `string` representing the flag or preference to modify.


### PR DESCRIPTION
We hardly use compile flag data and compile flags strain the sense of a "version" of a browser. I say we get rid of 'em.

## Background
While reviewing, #3742, I found that a feature was supported in an earlier version of Firefox but behind a compile flag (https://github.com/mdn/browser-compat-data/pull/3742#pullrequestreview-221047381). Initially, I intended to suggest adding the compile flag, but I couldn't remember the format for it. I looked and we only have two compile flags in the entire repository. One is for a non-Web platform feature, XUL overlays. The other is for an experimental JavaScript feature, the pipeline operator.

## Proposal
Remove `compile_flag` from BCD. My reasoning has two parts. First, we have only one Web platform feature that uses `compile_flag` and it seems silly to maintain this part of BCD for a single feature. Second, it strains the sense of a "version" of a browser if, to get access to a feature, you can't actually use the version of the browser you'd download from the vendor—you have to build your own.

## Changes
This PR removes:

* The remaining `compile_flag` data
* Code that uses `compile_flag` in supporting scripts
* Schema and docs that refer to the compile flag