### PR TITLE
Add TextTrack: cuechange event

### DIFF
--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -508,6 +508,55 @@
           }
         }
       },
+      "cuechange_event": {
+        "__compat": {
+          "description": "<code>cuechange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/cuechange_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "addCue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/addCue",


### PR DESCRIPTION
Add cuechange event for this page: https://developer.mozilla.org/en-US/docs/Web/API/TextTrack/cuechange_event

Data taken from oncuechange https://developer.mozilla.org/en-US/docs/Web/API/TextTrack#Browser_compatibility