### PR TITLE
Add MediaDevices: devicechange event

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -132,23 +132,9 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "51",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.ondevicechange.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "<code>MediaDevices.ondevicechange</code> is supported only on macOS."
-              }
-            ],
+            "firefox": {
+              "version_added": "52"
+            },
             "firefox_android": {
               "version_added": null
             },
@@ -159,7 +145,7 @@
               "version_added": "34"
             },
             "opera_android": {
-              "version_added": "34"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -115,6 +115,72 @@
           }
         }
       },
+      "devicechange_event": {
+        "__compat": {
+          "description": "<code>devicechange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/devicechange_event",
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "51",
+                "version_removed": "52",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.ondevicechange.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "<code>MediaDevices.ondevicechange</code> is supported only on macOS."
+              }
+            ],
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "34"
+            },
+            "opera_android": {
+              "version_added": "34"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "enumerateDevices": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/enumerateDevices",


### PR DESCRIPTION
Another migration for a legacy table
https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/devicechange_event

Data is the same as https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/ondevicechange#Browser_compatibility