### PR TITLE
Add Window: hashchange event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3610,7 +3610,7 @@
               "version_added": "5"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -3631,7 +3631,7 @@
               "version_added": "10.6"
             },
             "opera_android": {
-              "version_added": "11.0"
+              "version_added": "11"
             },
             "safari": {
               "version_added": "5"

--- a/api/Window.json
+++ b/api/Window.json
@@ -3601,6 +3601,55 @@
           }
         }
       },
+      "hashchange_event": {
+        "__compat": {
+          "description": "<code>hashchange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/hashchange_event",
+          "support": {
+            "chrome": {
+              "version_added": "5"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.6"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "8"
+            },
+            "opera": {
+              "version_added": "10.6"
+            },
+            "opera_android": {
+              "version_added": "11.0"
+            },
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "version_added": "5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "history": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/history",


### PR DESCRIPTION
Another legacy table migration for this page: https://developer.mozilla.org/en-US/docs/Web/API/Window/hashchange_event#Browser_compatibility

The table mentions "Support for the oldURL/newURL", but that doesn't belong here. We've already captured it in https://developer.mozilla.org/en-US/docs/Web/API/HashChangeEvent#Browser_compatibility