### PR TITLE
Add Window: languagechange event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3936,6 +3936,55 @@
           }
         }
       },
+      "languagechange_event": {
+        "__compat": {
+          "description": "<code>languagechange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/languagechange_event",
+          "support": {
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": "37"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "32"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "24"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/length",


### PR DESCRIPTION
Another legacy table: https://developer.mozilla.org/en-US/docs/Web/API/Window/languagechange_event

c.f. https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onlanguagechange#Browser_compatibility