### PR TITLE
[Chrome] Update MediaStream.

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "14"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -53,12 +53,13 @@
       "MediaStream": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/MediaStream",
+          "description": "<code>MediaStream()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "55"
+              "version_added": "19"
             },
             "chrome_android": {
-              "version_added": "55"
+              "version_added": "25"
             },
             "edge": {
               "version_added": true
@@ -91,7 +92,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "55"
+              "version_added": true
             }
           },
           "status": {
@@ -106,10 +107,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/active",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "12"
@@ -142,7 +143,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "45"
             }
           },
           "status": {
@@ -267,117 +268,15 @@
           }
         }
       },
-      "onaddtrack": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/onaddtrack",
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": "50"
-            },
-            "firefox_android": {
-              "version_added": "50"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": true
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onremovetrack": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/onremovetrack",
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": true
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "addTrack": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/addTrack",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "edge": {
               "version_added": "12"
@@ -386,10 +285,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "50"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "50"
             },
             "ie": {
               "version_added": false
@@ -425,10 +324,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/clone",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "12"
@@ -461,7 +360,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "45"
             }
           },
           "status": {
@@ -476,10 +375,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/getAudioTracks",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "edge": {
               "version_added": "12"
@@ -529,10 +428,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/getTrackById",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "edge": {
               "version_added": "12"
@@ -580,10 +479,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/getTracks",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "12"
@@ -616,7 +515,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "45"
             }
           },
           "status": {
@@ -631,10 +530,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/getVideoTracks",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "edge": {
               "version_added": "12"
@@ -684,10 +583,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/removeTrack",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "edge": {
               "version_added": "12"
@@ -790,10 +689,12 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true,
+              "version_removed": "47"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": true,
+              "version_removed": "47"
             },
             "edge": {
               "version_added": "13"
@@ -824,6 +725,215 @@
             },
             "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": true,
+              "version_removed": "47"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "addtrack_event": {
+        "__compat": {
+          "description": "<code>addtrack</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/addtrack_event",
+          "support": {
+            "chrome": {
+              "version_added": "26"
+            },
+            "chrome_android": {
+              "version_added": "26"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "50"
+            },
+            "firefox_android": {
+              "version_added": "50"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "removetrack_event": {
+        "__compat": {
+          "description": "<code>removetrack</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/removetrack_event",
+          "support": {
+            "chrome": {
+              "version_added": "26"
+            },
+            "chrome_android": {
+              "version_added": "26"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "active_event": {
+        "__compat": {
+          "description": "<code>active</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/active_event",
+          "support": {
+            "chrome": {
+              "version_added": "45"
+            },
+            "chrome_android": {
+              "version_added": "45"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "45"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "remove_event": {
+        "__compat": {
+          "description": "<code>remove</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/remove_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
Information Sources:
- Interface [added in 14](https://chromium.googlesource.com/chromium/src/+/fa2a5f4175e792744c0099ec96627805f7e04596)
- [Constructor added in 19](https://chromium.googlesource.com/chromium/src/+/de5d8ba44a4837017257e509fdfbac938527dfd0)
- [active, onactive, oninactive added in 45](https://storage.googleapis.com/chromium-find-releases-static/ed9.html#ed9b6182a0e701c905eaa98d1bde6dff5de73796)
- [getAudioTracks(), getVideoTracks(), addTrack(), removeTrack(), getTrackById(), onaddTrack, onremoveTrack added in 26](https://chromium.googlesource.com/chromium/src/+/7af37e05a5f40687912beb14c2740611db0dd658)
- [clone added in 45](https://storage.googleapis.com/chromium-find-releases-static/776.html#776e9a66223e95141b0b8bc6c6f9a847cd5fd8c4)
- [getTracks() added in 45](https://storage.googleapis.com/chromium-find-releases-static/e99.html#e99d73de1761aec44e23381e565ee48430d9a699)
- [stop() removed in 47](https://storage.googleapis.com/chromium-find-releases-static/ec7.html#ec7a7c5064c87ddf3dcba31a3bdf5981ad32e912)
