### PR TITLE
Add Window: orientationchange event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5330,6 +5330,58 @@
           }
         }
       },
+      "orientationchange_event": {
+        "__compat": {
+          "description": "<code>orientationchange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/orientationchange_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "44"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
       "outerHeight": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/outerHeight",


### PR DESCRIPTION
Data for https://developer.mozilla.org/en-US/docs/Web/API/Window/orientationchange_event#Browser_compatibility

This is mobile browsers only as per https://compat.spec.whatwg.org/#windoworientation-interface

Firefox for Android implemented it in https://bugzilla.mozilla.org/show_bug.cgi?id=920734, so that's where I got version 44 from.