### PR TITLE
Chrome 74 supports prefers-reduced-motion media query

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1295,10 +1295,10 @@
             "description": "<code>prefers-reduced-motion</code> media feature",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "74"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "74"
               },
               "edge": {
                 "version_added": false
@@ -1328,7 +1328,7 @@
                 "version_added": "10.3"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "74"
               }
             },
             "status": {


### PR DESCRIPTION
Chrome 74 on all platforms supports CSS media query prefers-reduced-motion.
Specifically, these products support @media prefers-reduced-motion:
Chrome for desktop release 74
Chrome for Android release 74
Android WebView relese 74

Source: https://www.chromestatus.com/feature/5597964353404928

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!) - OK
- [x] Link to related issues or pull requests, if any -- did not find any
