### PR TITLE
Misc. event refactoring

### DIFF
--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -716,6 +716,58 @@
           }
         }
       },
+      "mute_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrack/mute_event",
+          "description": "<code>mute</code> event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "59"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "onended": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrack/onended",
@@ -1171,6 +1223,58 @@
             },
             "webview_android": {
               "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unmute_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrack/unmute_event",
+          "description": "<code>unmute</code> event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "59"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -617,6 +617,74 @@
           }
         }
       },
+      "paymentmethodchange_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/paymentmethodchange_event",
+          "description": "<code>paymentmethodchange</code> event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "63",
+              "notes": "Available only in nightly builds.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "63",
+              "notes": "Available only in nightly builds.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "requestId": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/requestId",
@@ -684,9 +752,145 @@
           }
         }
       },
+      "shippingaddresschange_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/shippingaddresschange_event",
+          "description": "<code>shippingaddresschange</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Available only in nightly builds.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "55",
+              "notes": "Available only in nightly builds.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "11.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "shippingOption": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/shippingOption",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "55",
+              "notes": "Available only in nightly builds.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "55",
+              "notes": "Available only in nightly builds.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "11.1"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "shippingoptionchange_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/shippingoptionchange_event",
+          "description": "<code>shippingoptionchange</code> event",
           "support": {
             "chrome": {
               "version_added": "61"

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -347,6 +347,141 @@
           }
         }
       },
+      "merchantvalidation_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/merchantvalidation_event",
+          "description": "<code>merchantvalidation</code> event",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "64",
+              "notes": "Available only in nightly builds.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "64",
+              "notes": "Available only in nightly builds.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onmerchantvalidation": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/onmerchantvalidation",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "64",
+              "notes": "Available only in nightly builds.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "64",
+              "notes": "Available only in nightly builds.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "onpaymentmethodchange": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/onpaymentmethodchange",

--- a/api/PromiseRejectionEvent.json
+++ b/api/PromiseRejectionEvent.json
@@ -25,7 +25,7 @@
                 "value_to_set": "true"
               }
             ],
-            "notes": "Firefox doesn't yet send the <a href='https://developer.mozilla.org/docs/Web/Events/unhandledrejection'>unhandledrejection</a> or understand <a href='https://developer.mozilla.org/docs/Web/Events/rejectionhandled'>rejectionhandled<a> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+            "notes": "Firefox doesn't yet send the <code><a href='https://developer.mozilla.org/docs/Web/API/Window/unhandledrejection_event'>unhandledrejection</a></code> or understand <code><a href='https://developer.mozilla.org/docs/Web/API/Window/rejectionhandled_event'>rejectionhandled<a></code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
           },
           "firefox_android": {
             "version_added": false,
@@ -36,7 +36,7 @@
                 "value_to_set": "true"
               }
             ],
-            "notes": "Firefox doesn't yet send the <a href='https://developer.mozilla.org/docs/Web/Events/unhandledrejection'>unhandledrejection</a> or understand <a href='https://developer.mozilla.org/docs/Web/Events/rejectionhandled'>rejectionhandled<a> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+            "notes": "Firefox doesn't yet send the <code><a href='https://developer.mozilla.org/docs/Web/API/Window/unhandledrejection_event'>unhandledrejection</a></code> or understand <code><a href='https://developer.mozilla.org/docs/Web/API/Window/rejectionhandled_event'>rejectionhandled<a></code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
           },
           "ie": {
             "version_added": false
@@ -69,6 +69,7 @@
       "PromiseRejectionEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PromiseRejectionEvent/PromiseRejectionEvent",
+          "description": "<code>PromiseRejectionEvent()</code> constructor",
           "support": {
             "chrome": {
               "version_added": "49"
@@ -90,8 +91,7 @@
                   "name": "dom.promise_rejection_events.enabled",
                   "value_to_set": "true"
                 }
-              ],
-              "notes": "Firefox doesn't yet send the <a href='https://developer.mozilla.org/docs/Web/Events/unhandledrejection'>unhandledrejection</a> or understand <a href='https://developer.mozilla.org/docs/Web/Events/rejectionhandled'>rejectionhandled<a> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              ]
             },
             "firefox_android": {
               "version_added": false,
@@ -101,8 +101,7 @@
                   "name": "dom.promise_rejection_events.enabled",
                   "value_to_set": "true"
                 }
-              ],
-              "notes": "Firefox doesn't yet send the <a href='https://developer.mozilla.org/docs/Web/Events/unhandledrejection'>unhandledrejection</a> or understand <a href='https://developer.mozilla.org/docs/Web/Events/rejectionhandled'>rejectionhandled<a> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              ]
             },
             "ie": {
               "version_added": false
@@ -157,8 +156,7 @@
                   "name": "dom.promise_rejection_events.enabled",
                   "value_to_set": "true"
                 }
-              ],
-              "notes": "Firefox doesn't yet send the <a href='https://developer.mozilla.org/docs/Web/Events/unhandledrejection'>unhandledrejection</a> or understand <a href='https://developer.mozilla.org/docs/Web/Events/rejectionhandled'>rejectionhandled<a> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              ]
             },
             "firefox_android": {
               "version_added": false,
@@ -168,8 +166,7 @@
                   "name": "dom.promise_rejection_events.enabled",
                   "value_to_set": "true"
                 }
-              ],
-              "notes": "Firefox doesn't yet send the <a href='https://developer.mozilla.org/docs/Web/Events/unhandledrejection'>unhandledrejection</a> or understand <a href='https://developer.mozilla.org/docs/Web/Events/rejectionhandled'>rejectionhandled<a> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              ]
             },
             "ie": {
               "version_added": false
@@ -224,8 +221,7 @@
                   "name": "dom.promise_rejection_events.enabled",
                   "value_to_set": "true"
                 }
-              ],
-              "notes": "Firefox doesn't yet send the <a href='https://developer.mozilla.org/docs/Web/Events/unhandledrejection'>unhandledrejection</a> or understand <a href='https://developer.mozilla.org/docs/Web/Events/rejectionhandled'>rejectionhandled<a> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              ]
             },
             "firefox_android": {
               "version_added": false,
@@ -235,8 +231,7 @@
                   "name": "dom.promise_rejection_events.enabled",
                   "value_to_set": "true"
                 }
-              ],
-              "notes": "Firefox doesn't yet send the <a href='https://developer.mozilla.org/docs/Web/Events/unhandledrejection'>unhandledrejection</a> or understand <a href='https://developer.mozilla.org/docs/Web/Events/rejectionhandled'>rejectionhandled<a> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              ]
             },
             "ie": {
               "version_added": false

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -869,6 +869,112 @@
           }
         }
       },
+      "push_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/push_event",
+          "description": "<code>push</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "40"
+            },
+            "chrome_android": {
+              "version_added": "40"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "44",
+              "notes": "Service workers (and Push) have been disabled in the Firefox 45 and 52 Extended Support Releases (ESR)."
+            },
+            "firefox_android": {
+              "version_added": "44"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "24"
+            },
+            "safari": {
+              "version_added": "11.1"
+            },
+            "safari_ios": {
+              "version_added": "11.1"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pushsubscriptionchange_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/pushsubscriptionchange_event",
+          "description": "<code>pushsubscriptionchange</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "40"
+            },
+            "chrome_android": {
+              "version_added": "40"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "44",
+              "notes": "Service workers (and Push) have been disabled in the Firefox 45 and 52 Extended Support Releases (ESR)."
+            },
+            "firefox_android": {
+              "version_added": "44"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "24"
+            },
+            "safari": {
+              "version_added": "11.1"
+            },
+            "safari_ios": {
+              "version_added": "11.1"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "registration": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/registration",

--- a/api/Window.json
+++ b/api/Window.json
@@ -1968,6 +1968,106 @@
           }
         }
       },
+      "onrejectionhandled": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onrejectionhandled",
+          "support": {
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to about:config and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onunhandledrejection": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onunhandledrejection",
+          "support": {
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config</code> and set the <code>dom.promise_rejection_events.enabled</code> preference to <code>true</code>. However, Firefox doesn't yet actually send <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config</code> and set the <code>dom.promise_rejection_events.enabled</code> preference to <code>true</code>. However, Firefox doesn't yet actually send <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "onuserproximity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onuserproximity",
@@ -8989,7 +9089,7 @@
       },
       "unhandledrejection": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onunhandledrejection_event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/unhandledrejection_event",
           "description": "<code>unhandledrejection</code> event",
           "support": {
             "chrome": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -5483,6 +5483,110 @@
           }
         }
       },
+      "pagehide_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/pagehide_event",
+          "description": "<code>pagehide</code> event",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "1.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pageshow_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/pageshow_event",
+          "description": "<code>pageshow</code> event",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "1.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "pageXOffset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/pageXOffset",
@@ -6124,6 +6228,57 @@
             },
             "webview_android": {
               "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rejectionhandled": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/rejectionhandled_event",
+          "description": "<code>rejectionhandled</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to about:config and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
             }
           },
           "status": {
@@ -8820,6 +8975,57 @@
             },
             "samsunginternet_android": {
               "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unhandledrejection": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onunhandledrejection_event",
+          "description": "<code>unhandledrejection</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config</code> and set the <code>dom.promise_rejection_events.enabled</code> preference to <code>true</code>. However, Firefox doesn't yet actually send <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config</code> and set the <code>dom.promise_rejection_events.enabled</code> preference to <code>true</code>. However, Firefox doesn't yet actually send <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
* `pagehide`
* `pageshow`
* `rejectionhandled`
* `unhandledrejection`

Sources for `pageshow` and `pagehide`: https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/1.5/Using_Firefox_1.5_caching.
All other version information copied from the corresponding event handler properties.

* `push`
* `pushsubscriptionchange`

Source: All version information taken from the corresponding event handler properties.

* `paymentmethodchange`
* `merchantvalidation`
* `shippingaddresschange`
* `shippingoptionchange`

Source: All version information taken from the corresponding event handler properties.

* `mute`
* `unmute`

Source: All version information taken from the corresponding event handler properties.

* PromiseRejectionEvent (cleaned up notes that refer to changed events)

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
