### PR TITLE
FormData.set works with safari IOS

### DIFF
--- a/api/FormData.json
+++ b/api/FormData.json
@@ -450,7 +450,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null


### PR DESCRIPTION
FormData.set works with safari IOS (tested with Safari for IOS 12.1.4).