### PR TITLE
`delegatesFocus` is not supported on safari browsers

### DIFF
--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -110,10 +110,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null


### PR DESCRIPTION
## Summary

Changed `delegatesFocus` on `attachShadow` options support to false for Safari browsers (incl iOS).

## Tested On:

iOS Safari: 12.1.4
Mac OSX Safari: 12.0.2 (Mojave) 

Manually tested using the following code pen: https://codepen.io/TomCaserta/pen/YMqPLV


Hope this is enough, let me know if I've missed any important things in this PR.