### PR TITLE
[Chrome][Safari] Update perf APIs.

### DIFF
--- a/api/PerformanceLongTaskTiming.json
+++ b/api/PerformanceLongTaskTiming.json
@@ -100,57 +100,6 @@
             "deprecated": false
           }
         }
-      },
-      "toJSON": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceLongTaskTiming/toJSON",
-          "support": {
-            "chrome": {
-              "version_added": "65"
-            },
-            "chrome_android": {
-              "version_added": "65"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": "65"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
       }
     }
   }

--- a/api/PerformanceLongTaskTiming.json
+++ b/api/PerformanceLongTaskTiming.json
@@ -100,6 +100,57 @@
             "deprecated": false
           }
         }
+      },
+      "toJSON": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceLongTaskTiming/toJSON",
+          "support": {
+            "chrome": {
+              "version_added": "65"
+            },
+            "chrome_android": {
+              "version_added": "65"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "65"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/PerformanceMark.json
+++ b/api/PerformanceMark.json
@@ -8,7 +8,7 @@
             "version_added": "43"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "43"
           },
           "edge": {
             "version_added": true
@@ -41,7 +41,7 @@
             "version_added": null
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "43"
           }
         },
         "status": {

--- a/api/PerformanceMeasure.json
+++ b/api/PerformanceMeasure.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceMeasure",
         "support": {
           "chrome": {
-            "version_added": "43"
+            "version_added": "25"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "25"
           },
           "edge": {
             "version_added": true

--- a/api/PerformanceNavigation.json
+++ b/api/PerformanceNavigation.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceNavigation",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -55,10 +55,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceNavigation/type",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -84,7 +84,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -93,7 +93,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -108,10 +108,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceNavigation/redirectCount",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -135,7 +135,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -144,7 +144,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -159,10 +159,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceNavigation/toJSON",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "edge": {
               "version_added": "12"
@@ -197,7 +197,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -35,7 +35,7 @@
             "version_added": "11"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "52"
           }
         },
         "status": {
@@ -125,7 +125,7 @@
               "version_added": "11"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "52"
             }
           },
           "status": {
@@ -170,7 +170,7 @@
               "version_added": "11"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "52"
             }
           },
           "status": {
@@ -215,11 +215,56 @@
               "version_added": "11"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "52"
             }
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "supportedEntryTypes": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceObserver/supportedEntryTypes",
+          "support": {
+            "chrome": {
+              "version_added": "73"
+            },
+            "chrome_android": {
+              "version_added": "73"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "73"
+            }
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -248,10 +248,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null

--- a/api/PerformanceTiming.json
+++ b/api/PerformanceTiming.json
@@ -8,7 +8,7 @@
             "version_added": "6"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -55,7 +55,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -79,7 +79,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -103,7 +103,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -127,7 +127,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -151,7 +151,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -175,7 +175,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -199,7 +199,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -247,7 +247,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -271,7 +271,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -295,7 +295,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -319,7 +319,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -343,7 +343,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -367,7 +367,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -391,7 +391,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -415,7 +415,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -439,7 +439,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -463,7 +463,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -487,7 +487,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -511,7 +511,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": true
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": true
@@ -535,7 +535,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -559,7 +559,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -583,7 +583,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -607,7 +607,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -631,7 +631,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -655,7 +655,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": true
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": true
@@ -679,7 +679,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -703,7 +703,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -727,7 +727,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -751,7 +751,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -775,7 +775,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -799,7 +799,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -823,7 +823,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -847,7 +847,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -871,7 +871,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -895,7 +895,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -919,7 +919,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "18"
@@ -943,7 +943,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -991,7 +991,7 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": true
@@ -1015,7 +1015,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1039,7 +1039,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false
@@ -1063,7 +1063,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1087,7 +1087,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": false
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
`PerformanceMeasure` [in Chrome 25](https://chromium.googlesource.com/chromium/src/+/6981e8f4adf9a8e1925ac9bb4a32513031470ee2)
`PerformanceLongTaskTiming.toJSON` [in Chrome 65](https://storage.googleapis.com/chromium-find-releases-static/127.html#1278739add31c47c73d424dc561500973d4cbe4d)
`PerformanceNavigation.toJSON` [in Chrome 56](https://storage.googleapis.com/chromium-find-releases-static/fb6.html#fb6c988e174e59fed729751deabe71fbb470b1a3)
`PerformanceObserver.supportedEntryTypes` [in Chrome 73](https://storage.googleapis.com/chromium-find-releases-static/11c.html#11c9531efb1a0d4cf8f28b1c34038c713fe26207)
Safari and remaining Chrome items are from confluence.