### PR TITLE
Edge lacks Intl.NumberFormat.formatToParts support

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -724,7 +724,7 @@
                   "notes": "Before version 71, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 71 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>."
                 },
                 "edge": {
-                  "version_added": "18"
+                  "version_added": false
                 },
                 "edge_mobile": {
                   "version_added": false


### PR DESCRIPTION
Edge apparently doesn’t implement actual support for `Intl.NumberFormat.formatToParts`. See the discussion at https://stackoverflow.com/q/55527585/