### PR TITLE
Safari on iOS 9+ also supports ES6 template literals

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -766,7 +766,7 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
Safari on iOS 9+ also supports ES6 template literals.

https://bugs.webkit.org/show_bug.cgi?id=142691
https://caniuse.com/#feat=template-literals
https://benmccormick.org/2015/06/10/is-safari-being-left-behind (template literals supported in Safari 9 dev preview)
https://web.archive.org/web/20150929191251/https://developer.apple.com/library/prerelease/mac/releasenotes/General/WhatsNewInSafari/Articles/Safari_9.html#//apple_ref/doc/uid/TP40014305-CH9-SW27