### PR TITLE
Update `performance.now()` compatibility table to match rest of article

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -673,14 +673,16 @@
               "version_added": "15",
               "notes": [
                 "In Firefox 57.0.4 the accuracy was reduced to 20 microseconds.",
-                "In Firefox 59 the accuracy was reduced to 2 milliseconds."
+                "In Firefox 59 the accuracy was reduced to 2 milliseconds.",
+                "In Firefox 60 the accuracy was increased to 1 millisecond."
               ]
             },
             "firefox_android": {
               "version_added": "15",
               "notes": [
                 "In Firefox 57.0.4 the accuracy was reduced to 20 microseconds.",
-                "In Firefox 59 the accuracy was reduced to 2 milliseconds."
+                "In Firefox 59 the accuracy was reduced to 2 milliseconds.",
+                "In Firefox 60 the accuracy was increased to 1 millisecond."
               ]
             },
             "ie": {


### PR DESCRIPTION
As mentioned in https://developer.mozilla.org/en-US/docs/Web/API/Performance/now:

> Firefox started rounding to 1 millisecond in Firefox 60.

This commit updates the `performance.now()` compatibility table to match the rest of the article.