### PR TITLE
Add data for tracklist events

### DIFF
--- a/api/AudioTrackList.json
+++ b/api/AudioTrackList.json
@@ -92,6 +92,194 @@
           "deprecated": false
         }
       },
+      "addtrack_event": {
+        "__compat": {
+          "description": "<code>addtrack</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrackList/addtrack_event",
+          "support": {
+            "chrome": {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "opera_android": {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "safari": {
+              "version_added": "6.1"
+            },
+            "safari_ios": {
+              "version_added": "7.1"
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "45"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "change_event": {
+        "__compat": {
+          "description": "<code>change</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrackList/change_event",
+          "support": {
+            "chrome": {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "opera_android": {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "safari": {
+              "version_added": "6.1"
+            },
+            "safari_ios": {
+              "version_added": "7.1"
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "45"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getTrackById": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrackList/getTrackById",
@@ -467,6 +655,100 @@
       "onremovetrack": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrackList/onremovetrack",
+          "support": {
+            "chrome": {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "opera_android": {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "safari": {
+              "version_added": "6.1"
+            },
+            "safari_ios": {
+              "version_added": "7.1"
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "45"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "removetrack_event": {
+        "__compat": {
+          "description": "<code>removetrack</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrackList/removetrack_event",
           "support": {
             "chrome": {
               "version_added": "45",

--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -152,6 +152,58 @@
           }
         }
       },
+      "addtrack_event": {
+        "__compat": {
+          "description": "<code>addtrack</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/addtrack_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "50"
+            },
+            "firefox_android": {
+              "version_added": "50"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "ended": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/ended",
@@ -706,6 +758,58 @@
             },
             "opera": {
               "version_added": true
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "removetrack_event": {
+        "__compat": {
+          "description": "<code>removetrack</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/removetrack_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
             },
             "opera_android": {
               "version_added": false

--- a/api/VideoTrackList.json
+++ b/api/VideoTrackList.json
@@ -92,6 +92,194 @@
           "deprecated": false
         }
       },
+      "addtrack_event": {
+        "__compat": {
+          "description": "<code>addtrack</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrackList/addtrack_event",
+          "support": {
+            "chrome": {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "opera_android": {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "safari": {
+              "version_added": "6.1"
+            },
+            "safari_ios": {
+              "version_added": "7.1"
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "45"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "change_event": {
+        "__compat": {
+          "description": "<code>change</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrackList/change_event",
+          "support": {
+            "chrome": {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "opera_android": {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "safari": {
+              "version_added": "6.1"
+            },
+            "safari_ios": {
+              "version_added": "7.1"
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "45"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getTrackById": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrackList/getTrackById",
@@ -467,6 +655,100 @@
       "onremovetrack": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrackList/onremovetrack",
+          "support": {
+            "chrome": {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "opera_android": {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "safari": {
+              "version_added": "6.1"
+            },
+            "safari_ios": {
+              "version_added": "7.1"
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "45"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "removetrack_event": {
+        "__compat": {
+          "description": "<code>removetrack</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrackList/removetrack_event",
           "support": {
             "chrome": {
               "version_added": "45",


### PR DESCRIPTION
This is part of https://github.com/mdn/sprints/issues/1119.

It adds compat data for the following events:

* [AudioTrackList: addtrack](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrackList/addtrack_event)
* [AudioTrackList: removetrack](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrackList/removetrack_event)
* [AudioTrackList: change](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrackList/change_event)
* [VideoTrackList: addtrack](https://developer.mozilla.org/en-US/docs/Web/API/VideoTrackList/addtrack_event)
* [VideoTrackList: removetrack](https://developer.mozilla.org/en-US/docs/Web/API/VideoTrackList/removetrack_event)
* [VideoTrackList: change](https://developer.mozilla.org/en-US/docs/Web/API/VideoTrackList/change_event)
* [MediaStream: addtrack](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/addtrack_event)
* [MediaStream: removetrack](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/removetrack_event)

The data is taken from the corresponding `on-` event handler properties (though for all the video/audio tracklist ones the data is the same):

* [AudioTrackList.onaddtrack](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrackList/onaddtrack)
* [AudioTrackList.onremovetrack](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrackList/onremovetrack)
* [AudioTrackList.onchange](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrackList/onchange)
* [VideoTrackList.onaddtrack](https://developer.mozilla.org/en-US/docs/Web/API/VideoTrackList/onaddtrack)
* [VideoTrackList.onremovetrack](https://developer.mozilla.org/en-US/docs/Web/API/VideoTrackList/onremovetrack)
* [VideoTrackList.onchange](https://developer.mozilla.org/en-US/docs/Web/API/VideoTrackList/onchange)
* [MediaStream.onaddtrack](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/onaddtrack)
* [MediaStream.onremovetrack](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/onremovetrack)


