### PR TITLE
Add data for HTMLDialogElement close event

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -118,6 +118,58 @@
           }
         }
       },
+      "close_event": {
+        "__compat": {
+          "description": "<code>close</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/close_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "open": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/open",


### PR DESCRIPTION
This is part of https://github.com/mdn/sprints/issues/1119.

It adds compat data for the [HTMLDialogElement: close](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/close_event) event.

I've copied the data from the [cancel event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/cancel_event#Browser_compatibility), which seems sensible as far as it goes (in particular, this event is supported in Chrome and is not supported in Firefox).