### PR TITLE
Add data for error events

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1821,6 +1821,58 @@
           }
         }
       },
+      "error_event": {
+        "__compat": {
+          "description": "<code>error</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/error_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "focus_event": {
         "__compat": {
           "description": "<code>focus</code> event",

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -155,6 +155,66 @@
           }
         }
       },
+      "error_event": {
+        "__compat": {
+          "description": "<code>error</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/error_event",
+          "support": {
+            "chrome": {
+              "version_added": "47",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform features",
+                  "value_to_set": "Enabled"
+                }
+              ],
+              "notes": "Full support since Chrome 49."
+            },
+            "chrome_android": {
+              "version_added": "49"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "25"
+            },
+            "firefox_android": {
+              "version_added": "25"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "36"
+            },
+            "opera_android": {
+              "version_added": "36"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "49"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "mimeType": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/mimeType",

--- a/api/Window.json
+++ b/api/Window.json
@@ -1286,6 +1286,58 @@
           }
         }
       },
+      "error_event": {
+        "__compat": {
+          "description": "<code>error</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/error_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "external": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/external",


### PR DESCRIPTION
This is part of https://github.com/mdn/sprints/issues/1119.

It adds data for the error events:

* [Element: error](https://developer.mozilla.org/en-US/docs/Web/API/Element/error_event)
* [Window: error](https://developer.mozilla.org/en-US/docs/Web/API/Window/error_event)
* [MediaRecorder: error](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/error_event)

For `Element` and `Window` I've taken the data from [`GlobalEventHandlers.onerror`](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror#Browser_compatibility), and for `MediaRecorder` I've used [`MediaRecorder.onerror`](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/onerror#Browser_compatibility).