### PR TITLE
Add data for message and messageerror events

### DIFF
--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -90,6 +90,98 @@
           }
         }
       },
+      "message_event": {
+        "__compat": {
+          "description": "<code>message</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BroadcastChannel/message_event",
+          "support": {
+            "chrome": {
+              "version_added": "54"
+            },
+            "chrome_android": {
+              "version_added": "54"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "38"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "41"
+            },
+            "opera_android": {
+              "version_added": "41"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "54"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "messageerror_event": {
+        "__compat": {
+          "description": "<code>messageerror</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BroadcastChannel/messageerror_event",
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "57"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "47"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "60"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BroadcastChannel/name",

--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -50,6 +50,110 @@
           "deprecated": false
         }
       },
+      "message_event": {
+        "__compat": {
+          "description": "<code>message</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/message_event",
+          "support": {
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "10.6"
+            },
+            "opera_android": {
+              "version_added": "11.5"
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "5.1"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "messageerror_event": {
+        "__compat": {
+          "description": "<code>messageerror</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/messageerror_event",
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "57"
+            },
+            "firefox_android": {
+              "version_added": "57"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "47"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "60"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/name",

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -152,6 +152,110 @@
           }
         }
       },
+      "message_event": {
+        "__compat": {
+          "description": "<code>message</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MessagePort/message_event",
+          "support": {
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "10.6"
+            },
+            "opera_android": {
+              "version_added": "11.5"
+            },
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "version_added": "5.1"
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "messageerror_event": {
+        "__compat": {
+          "description": "<code>messageerror</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MessagePort/messageerror_event",
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "57"
+            },
+            "firefox_android": {
+              "version_added": "57"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "47"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "60"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "onmessage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MessagePort/onmessage",

--- a/api/Window.json
+++ b/api/Window.json
@@ -1490,6 +1490,104 @@
           }
         }
       },
+      "message_event": {
+        "__compat": {
+          "description": "<code>message</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/message_event",
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "47"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "60"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "messageerror_event": {
+        "__compat": {
+          "description": "<code>messageerror</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/messageerror_event",
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "57"
+            },
+            "firefox_android": {
+              "version_added": "57"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "47"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "60"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "ondevicelight": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ondevicelight",

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -155,6 +155,110 @@
           }
         }
       },
+      "message_event": {
+        "__compat": {
+          "description": "<code>message</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Worker/message_event",
+          "support": {
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "10.6"
+            },
+            "opera_android": {
+              "version_added": "11.5"
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "5.1"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "4"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "messageerror_event": {
+        "__compat": {
+          "description": "<code>messageerror</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Worker/messageerror_event",
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "57"
+            },
+            "firefox_android": {
+              "version_added": "57"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "47"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "60"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "onmessage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Worker/onmessage",


### PR DESCRIPTION
This is part of https://github.com/mdn/sprints/issues/1119.

It adds data for:

* message events:
  * [BroadcastChannel: message](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel/message_event)
  * [Window: message](https://developer.mozilla.org/en-US/docs/Web/API/Window/message_event)
  * [Worker: message](https://developer.mozilla.org/en-US/docs/Web/API/Worker/message_event)
  * [MessagePort: message](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/message_event)
  * [DedicatedWorkerGlobalScope: message](https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope/message_event)

* messageerror events:
  * [BroadcastChannel: messageerror](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel/messageerror_event)
  * [Window: messageerror](https://developer.mozilla.org/en-US/docs/Web/API/Window/messageerror_event)
  * [Worker: messageerror](https://developer.mozilla.org/en-US/docs/Web/API/Worker/messageerror_event)
  * [MessagePort: messageerror](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/messageerror_event)
  * [DedicatedWorkerGlobalScope: messageerror](https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope/messageerror_event)

Data is taken from the corresponding `on-` event handler properties:

* `onmessage`:
  * [BroadcastChannel: onmessage](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel/onmessage)
  * [Window: onmessage](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onmessage)
  * [Worker: onmessage](https://developer.mozilla.org/en-US/docs/Web/API/Worker/onmessage)
  * [MessagePort: onmessage](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/onmessage)
  * [DedicatedWorkerGlobalScope: onmessage](https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope/onmessage)

* `onmessageerror`:
  * [BroadcastChannel: onmessageerror](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel/onmessageerror)
  * [Window: onmessageerror](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onmessageerror)
  * [Worker: onmessageerror](https://developer.mozilla.org/en-US/docs/Web/API/Worker/onmessageerror)
  * [MessagePort: onmessageerror](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/onmessageerror)
  * [DedicatedWorkerGlobalScope: onmessageerror](https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope/onmessageerror)

The only change I made is to remove "Available in workers" from the Window: messagerror event, since that didn't seem to make sense.
