### PR TITLE
Update Safari support for the Web Share API

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1999,10 +1999,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": null


### PR DESCRIPTION
Safari has been updated recently to support the Web Share API. This PR adds Safari support to the `Navigator.share` browser compatibility section. 

Note that both OS X Safari and iOS Safari versions are 12.1 - but iOS Safari 12.1 was added to iOS 12.2, so I believe that in this case, it's better to display the iOS version it was added to and not the software version.

**Resources:**
[New WebKit Features in Safari 12.1](https://webkit.org/blog/8718/new-webkit-features-in-safari-12-1/) - The official WebKit blog
[Safari 12.1 & Safari iOS release notes](https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes) - The official Apple developer website

Resolves #3724.