### PR TITLE
Update Firefox compat data for ::marker

### DIFF
--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -19,10 +19,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Bug 205202 added support for ::marker in Firefox.
https://bugzilla.mozilla.org/show_bug.cgi?id=205202
