### PR TITLE
Update Safari support for IntersectionObserver

### DIFF
--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -42,7 +42,7 @@
             "version_added": "12.1"
           },
           "safari_ios": {
-            "version_added": "12.1"
+            "version_added": "12.2"
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -100,7 +100,7 @@
               "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": "12.1"
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -158,7 +158,7 @@
               "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": "12.1"
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -216,7 +216,7 @@
               "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": "12.1"
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -274,7 +274,7 @@
               "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": "12.1"
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -388,7 +388,7 @@
               "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": "12.1"
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -503,7 +503,7 @@
               "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": "12.1"
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -39,7 +39,7 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "12.1"
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -94,7 +94,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -149,7 +149,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -204,7 +204,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -259,7 +259,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -370,7 +370,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -482,7 +482,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -41,6 +41,9 @@
           "safari": {
             "version_added": "12.1"
           },
+          "safari_ios": {
+            "version_added": "12.1"
+          },
           "samsunginternet_android": {
             "version_added": "5.0"
           },
@@ -94,6 +97,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": "12.1"
+            },
+            "safari_ios": {
               "version_added": "12.1"
             },
             "samsunginternet_android": {
@@ -151,6 +157,9 @@
             "safari": {
               "version_added": "12.1"
             },
+            "safari_ios": {
+              "version_added": "12.1"
+            },
             "samsunginternet_android": {
               "version_added": "5.0"
             },
@@ -206,6 +215,9 @@
             "safari": {
               "version_added": "12.1"
             },
+            "safari_ios": {
+              "version_added": "12.1"
+            },
             "samsunginternet_android": {
               "version_added": "5.0"
             },
@@ -259,6 +271,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": "12.1"
+            },
+            "safari_ios": {
               "version_added": "12.1"
             },
             "samsunginternet_android": {
@@ -372,6 +387,9 @@
             "safari": {
               "version_added": "12.1"
             },
+            "safari_ios": {
+              "version_added": "12.1"
+            },
             "samsunginternet_android": {
               "version_added": "5.0"
             },
@@ -482,6 +500,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": "12.1"
+            },
+            "safari_ios": {
               "version_added": "12.1"
             },
             "samsunginternet_android": {

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -213,10 +213,12 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "12.1"
+              "version_added": "12.1",
+              "notes": "<code>rootMargin</code> does not work with <code>&lt;iframe&gt;</code>s."
             },
             "safari_ios": {
-              "version_added": "12.2"
+              "version_added": "12.2",
+              "notes": "<code>rootMargin</code> does not work with <code>&lt;iframe&gt;</code>s."
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- Added Safari support (v 12.1) to IntersectionObserver API
-  https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes#3130314
