### PR TITLE
Add data for min(), max(), and clamp() CSS types.

### DIFF
--- a/css/types/clamp.json
+++ b/css/types/clamp.json
@@ -7,16 +7,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clamp",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -25,25 +25,25 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/css/types/max.json
+++ b/css/types/max.json
@@ -7,16 +7,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -25,25 +25,25 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/css/types/min.json
+++ b/css/types/min.json
@@ -7,16 +7,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -25,27 +25,25 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null,
-              "notes": "Supported in <a href='https://developer.apple.com/safari/technology-preview/release-notes/'>Safari Technology Preview</a>"
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null,
-              "notes": "Supported in <a href='https://developer.apple.com/safari/technology-preview/release-notes/'>Safari Technology Preview</a>"
+              "version_added": "11.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
Resolves #3762.

Data is based on Can I Use, which lists `min()` and `max()` as only being supported in Safari, and `clamp()` as being unsupported by all three: https://caniuse.com/#feat=css-math-functions
