### PR TITLE
Various text-decoration properties are unprefixed in Safari 12.1.

### DIFF
--- a/css/properties/text-decoration-color.json
+++ b/css/properties/text-decoration-color.json
@@ -46,14 +46,24 @@
             "opera_android": {
               "version_added": "43"
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "8"
-            },
+            "safari": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "12.2"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "8"
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "7.0"
             },

--- a/css/properties/text-decoration-line.json
+++ b/css/properties/text-decoration-line.json
@@ -46,14 +46,24 @@
             "opera_android": {
               "version_added": true
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "8"
-            },
+            "safari": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "12.2"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "8"
+              }
+            ],
             "samsunginternet_android": {
               "version_added": true
             },

--- a/css/properties/text-decoration-skip.json
+++ b/css/properties/text-decoration-skip.json
@@ -40,16 +40,28 @@
               "version_removed": "46",
               "notes": "Only supports the deprecated <code>ink</code> value."
             },
-            "safari": {
-              "version_added": "8",
-              "prefix": "-webkit-",
-              "notes": "Only supports the <code>none</code> and <code>skip</code> values; all other values behave like those two values."
-            },
-            "safari_ios": {
-              "version_added": "8",
-              "prefix": "-webkit-",
-              "notes": "Only supports the <code>none</code> and <code>skip</code> values; all other values behave like those two values."
-            },
+            "safari": [
+              {
+                "version_added": "12.1",
+                "notes": "Only supports the <code>none</code> and <code>skip</code> values; all other values behave like those two values."
+              },
+              {
+                "version_added": "8",
+                "prefix": "-webkit-",
+                "notes": "Only supports the <code>none</code> and <code>skip</code> values; all other values behave like those two values."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "12.2",
+                "notes": "Only supports the <code>none</code> and <code>skip</code> values; all other values behave like those two values."
+              },
+              {
+                "version_added": "8",
+                "prefix": "-webkit-",
+                "notes": "Only supports the <code>none</code> and <code>skip</code> values; all other values behave like those two values."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "7.0"
             },

--- a/css/properties/text-decoration-style.json
+++ b/css/properties/text-decoration-style.json
@@ -46,14 +46,24 @@
             "opera_android": {
               "version_added": "43"
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
+            "safari": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "12.2"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "7.0"
             },


### PR DESCRIPTION
See this changeset: https://trac.webkit.org/changeset/238002/webkit/

It was included in [Safari TP 71](https://webkit.org/blog/8517/release-notes-for-safari-technology-preview-71/), which was [one of the TPs included in Safari 12.1](https://webkit.org/blog/8718/new-webkit-features-in-safari-12-1/).

Thus, Safari 12.1 supports `text-decoration-color`, `text-decoration-style`, `text-decoration-line`, and `text-decoration-skip` without prefixes.