### PR TITLE
conic-gradient() is supported by default in Safari 12.1.

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -161,12 +161,10 @@
                   "version_added": "48"
                 },
                 "safari": {
-                  "version_added": null,
-                  "notes": "In Safari Technology Preview Release 66"
+                  "version_added": "12.1"
                 },
                 "safari_ios": {
-                  "version_added": null,
-                  "notes": "In Safari Technology Preview Release 66"
+                  "version_added": "12.2"
                 },
                 "samsunginternet_android": {
                   "version_added": false


### PR DESCRIPTION
TP 69 enabled conic gradients by default, and the changes from TP 69 were released as Safari 12.1.

Sources:

- https://webkit.org/blog/8479/release-notes-for-safari-technology-preview-69/
- https://trac.webkit.org/changeset/237402/webkit/