### PR TITLE
Safari 12.1 adds support for globalThis

### DIFF
--- a/javascript/builtins/globals.json
+++ b/javascript/builtins/globals.json
@@ -477,10 +477,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
Fixes #3741.

Sources:
- https://trac.webkit.org/changeset/239464/webkit
- https://kangax.github.io/compat-table/esnext/#test-globalThis