### PR TITLE
Object.fromEntries() is supported in Safari 12.1

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -767,10 +767,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
Per the ECMAScript 2016+ compat table: http://kangax.github.io/compat-table/es2016plus/#test-Object.fromEntries

Also ran the following in the Safari console and it worked:

```js
const entries = new Map([
  ['foo', 'bar'],
  ['baz', 42]
]);

const obj = Object.fromEntries(entries);

console.log(obj);
```

Here's the WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=188481