### PR TITLE
Safari 12.1 supports well-formed JSON.stringify

### DIFF
--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -199,10 +199,10 @@
                   "version_added": "50"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "12.1"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "12.2"
                 },
                 "samsunginternet_android": {
                   "version_added": false


### PR DESCRIPTION
Sources:
- http://kangax.github.io/compat-table/es2016plus/#test-Well-formed_JSON.stringify
- https://bugs.webkit.org/show_bug.cgi?id=191677
- https://webkit.org/blog/8555/release-notes-for-safari-technology-preview-73/
- https://trac.webkit.org/changeset/239537/webkit/