### PR TITLE
Symbol.prototype.description is supported in Safari 12.1.

### DIFF
--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -144,12 +144,26 @@
               "opera_android": {
                 "version_added": "49"
               },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari": [
+                {
+                  "version_added": "12.1"
+                },
+                {
+                  "version_added": "12",
+                  "partial_implementation": true,
+                  "notes": "No support for an undefined description."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "12.2"
+                },
+                {
+                  "version_added": "12",
+                  "partial_implementation": true,
+                  "notes": "No support for an undefined description."
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": false
               },


### PR DESCRIPTION
Per the ES2016+ compat table, Safari 12 supported this partially, but 12.1 completed support for the feature.

- http://kangax.github.io/compat-table/es2016plus/#test-Symbol.prototype.description
- https://webkit.org/blog/8414/release-notes-for-safari-technology-preview-66/
- https://trac.webkit.org/changeset/235712/webkit/

The original implementation in Safari 12:
- https://webkit.org/blog/8332/release-notes-for-safari-technology-preview-59/
- https://trac.webkit.org/changeset/232404/webkit/