### PR TITLE
Correct compatibility data for <input type="color"> on Safari

### DIFF
--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -36,7 +36,7 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "10"
+                "version_added": "12.1"
               },
               "safari_ios": {
                 "version_added": false

--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -39,7 +39,7 @@
                 "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "webview_android": {
                 "version_added": "4.4"


### PR DESCRIPTION
This was mistakenly set to an earlier version of the browser, but has since been implemented. I have set the `version_added` field to the correct value.

Announcement blog post: [New WebKit Features in Safari 12.1](https://webkit.org/blog/8718/new-webkit-features-in-safari-12-1/).

Confirmed not working in Safari 12.0.3:

![Safari 12.0.3](http://i.stwrt.ca/V4zOTAcc.png)

Confirmed working in Safari 12.1:

![Safari 12.1](http://i.stwrt.ca/IIpM68Ze.png)