### PR TITLE
Safari 12.1 supports floats in RGB values

### DIFF
--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -570,10 +570,10 @@
                 "version_added": "47"
               },
               "safari": {
-                "version_added": null
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": null

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -621,10 +621,10 @@
                 "version_added": "47"
               },
               "safari": {
-                "version_added": null
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "12.2"
               },
               "webview_android": {
                 "version_added": "66"


### PR DESCRIPTION
Sources:
- https://trac.webkit.org/changeset/239574/webkit/
- https://webkit.org/blog/8566/release-notes-for-safari-technology-preview-74/

That Webkit changeset also mentions "There is a new comma-free syntax, where the optional alpha is separated by a slash", is that the `space_separated_functional_notation`? 