### PR TITLE
Add link to governance doc from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ browser support for APIs. For example:
 [![Build Status](https://travis-ci.org/mdn/browser-compat-data.svg?branch=master)](https://travis-ci.org/mdn/browser-compat-data)
 [![Twitter Follow](https://img.shields.io/twitter/follow/mozdevnet.svg?style=social&label=Follow&style=plastic)](https://twitter.com/MozDevNet)
 
-Maintained by the [MDN team at Mozilla](https://wiki.mozilla.org/MDN).
+Read how this project is [governed](https://github.com/mdn/browser-compat-data/blob/master/governance.md).
 
 ## Installation
 You can install mdn-browser-compat-data as a node package.


### PR DESCRIPTION
I think we should rather link to the governance doc than saying that this project is solely maintained by the MDN team.