### PR TITLE
Remove or replace MSDN links that redirect to MDN

### DIFF
--- a/api/NavigatorLanguage.json
+++ b/api/NavigatorLanguage.json
@@ -128,7 +128,7 @@
             },
             "ie": {
               "version_added": "11",
-              "notes": "Closest available (non-standard) properties are <code><a href='http://msdn.microsoft.com/en-us/library/ie/ms534713.aspx'>userLanguage</a></code> and <code><a href='http://msdn.microsoft.com/en-us/library/ie/ms533542.aspx'>browserLanguage</a></code>."
+              "notes": "Closest available (non-standard) properties are <code>userLanguage</code> and <code>browserLanguage</code>."
             },
             "opera": {
               "version_added": true

--- a/api/Node.json
+++ b/api/Node.json
@@ -1734,8 +1734,7 @@
               }
             ],
             "ie": {
-              "version_added": "9",
-              "notes": "See <a href='http://msdn.microsoft.com/en-us/library/ie/ms534315(v=vs.85).aspx'>MSDN</a>."
+              "version_added": "9"
             },
             "opera": {
               "version_added": true

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1981,7 +1981,7 @@
             },
             "ie": {
               "version_added": "10",
-              "notes": "Internet Explorer versions 8 and 9 supported cross-domain requests (CORS) using <a href='https://developer.mozilla.org/en-US/docs/Web/API/XDomainRequest'><code>XDomainRequest</code></a>."
+              "notes": "Internet Explorer versions 8 and 9 supported cross-domain requests (CORS) using <a href='https://developer.mozilla.org/docs/Web/API/XDomainRequest'><code>XDomainRequest</code></a>."
             },
             "opera": {
               "version_added": "12"

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1981,7 +1981,7 @@
             },
             "ie": {
               "version_added": "10",
-              "notes": "Internet Explorer versions 8 and 9 supported cross-domain requests (CORS) using <a href='https://msdn.microsoft.com/en-us/library/cc288060%28VS.85%29.aspx'>XDomainRequest</a>"
+              "notes": "Internet Explorer versions 8 and 9 supported cross-domain requests (CORS) using <a href='https://developer.mozilla.org/en-US/docs/Web/API/XDomainRequest'><code>XDomainRequest</code></a>."
             },
             "opera": {
               "version_added": "12"

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -77,7 +77,7 @@
               },
               "ie": {
                 "version_added": "7",
-                "notes": "In Internet Explorer, fixed positioning doesn't work if the document is in <a href='http://msdn.microsoft.com/en-us/library/ie/ms531140(v=vs.85).aspx'>quirks mode</a>."
+                "notes": "In Internet Explorer, fixed positioning doesn't work if the document is in <a href='https://developer.mozilla.org/docs/Web/HTML/Quirks_Mode_and_Standards_Mode'>quirks mode</a>."
               },
               "opera": {
                 "version_added": "4"


### PR DESCRIPTION
In a few notes, there are a few links to MSDN that redirect back to MDN. The MDN pages don't actually explain the thing that the original link presumably covered. This PR removes those unhelpful links.