### PR TITLE
Add initial CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @Elchi3 @wbamberg @chrisdavidmills @atopal

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
-*   @Elchi3 @wbamberg @chrisdavidmills @atopal
+# See governance.md for more about this repository's owners and this project's
+# governance.
+
+webextensions/ @irenesmith
+!*.json @Elchi3

--- a/governance.md
+++ b/governance.md
@@ -96,8 +96,6 @@ An individual is invited to become an Owner by existing Owners. A nomination wil
 - Chris David Mills (@chrisdavidmills), Mozilla
 - Kadir Topal (@atopal), Mozilla
 
-The owners are also listed as top-level owners in GitHub’s code owner file.
-
 ## Additional paths to becoming a Peer or Owner
 
 Some Owners or Peers are also [MDN Content Curators](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Documentation_topics_and_curators) and have thus earned the privilege to be a mdn-browser-compat-data Peer, so that their expertise in a given content area (CSS, HTML, etc.) can help improve the compat data for that same content area. Such Peers are marked in the relevant folders using GitHub’s Code Owner mechanism.


### PR DESCRIPTION
The new governance doc (#3668) calls for a CODEOWNERS file: 

> The owners are also listed as top-level owners in GitHub’s code owner file.

This PR adds this, though we might might want to fill it out a bit more, unless we want every PR to request the owners' reviews