### PR TITLE
Edge desktop does not support MediaRecorder

### DIFF
--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -11,7 +11,7 @@
             "version_added": "47"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "edge_mobile": {
             "version_added": null
@@ -64,7 +64,7 @@
               "version_added": "47"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -114,7 +114,7 @@
                 "version_added": "49"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
@@ -175,7 +175,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -227,7 +227,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -279,7 +279,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -331,7 +331,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -384,7 +384,7 @@
               "version_removed": "57"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -436,7 +436,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -487,7 +487,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -538,7 +538,7 @@
               "version_added": "47"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -597,7 +597,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -656,7 +656,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -715,7 +715,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -766,7 +766,7 @@
               "version_added": "47"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -825,7 +825,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -884,7 +884,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -943,7 +943,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -1002,7 +1002,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -1061,7 +1061,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -1120,7 +1120,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -1179,7 +1179,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -1238,7 +1238,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null


### PR DESCRIPTION
I tested `new MediaRecorder(stream)` and it gave an error saying that is was not defined. I was not able to test on mobile. Tested with the latest version on Windows 10.