### PR TITLE
Chrome does not yet support gap on flexbox

### DIFF
--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -8,7 +8,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gap",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
                 "version_added": null

--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -11,7 +11,7 @@
                 "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": null
@@ -29,10 +29,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "qq_android": {
                 "version_added": null
@@ -53,7 +53,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
Set support of css `gap` property in flexbox layout to `false` for Chrome.

Cf. https://bugs.chromium.org/p/chromium/issues/detail?id=762679