### PR TITLE
Edge desktop does not support InputEvent

### DIFF
--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -11,7 +11,7 @@
             "version_added": "60"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "edge_mobile": {
             "version_added": null
@@ -62,7 +62,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -113,7 +113,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -164,7 +164,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -266,7 +266,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -317,7 +317,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null


### PR DESCRIPTION
Windows 10
Edge 44.17763.1.0
EdgeHTML 18.17763

`window.InputEvent` is `undefined`
I was not able to test on mobile.

Plus I test with [Masayuki Nakano's InputEvent test suite](https://d-toybox.com/studio/lib/input_event_viewer.html) and it showed that an `input` event is triggered but with type `Event` a with all fields `undefined` except `cancelable` and `bubbles` .