### PR TITLE
forEach not supported in Internet Explorer

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -713,7 +713,7 @@
               "version_added": "50"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "32"


### PR DESCRIPTION
Set forEach support as not supported for any version of Internet Explorer.

Tested in IE11 with no support for `forEach`.