### PR TITLE
Add Vinyl Darkscratch as a BCD Peer

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -49,6 +49,7 @@ It is important to recognize that being a Peer is a privilege, not a right. That
 #### List of current peers
 - Rachel Andrew (@rachelandrew)
 - Daniel Beck (@ddbeck)
+- Vinyl Darkscratch (@vinyldarkscratch)
 - Ryan Johnson (@escattone), Mozilla
 - Joe Medley (@jpmedley), Google
 - Jean-Yves Perrier (@teoli2003), Mozilla


### PR DESCRIPTION
Vinyl (@vinyldarkscratch) agrees and abides by the Mozilla Commit Access Requirements per https://github.com/mdn/mdn/issues/55

Information on the repo governance and what exactly it means to be a Peer can be found here: https://github.com/mdn/browser-compat-data/blob/master/governance.md

Requesting approval from other BCD Owners and I will give Vinyl write access to the repo after this PR has been merged.