### PR TITLE
Update grid-template-columns.json

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -180,8 +180,6 @@
               "ie": {
                 "version_added": "11",
                 "notes": "IE can treat the first (<code>min-content</code>) parameter as the <code>max-content</code> parameter (source: <a href='https://css-tricks.com/css-grid-in-ie-css-grid-and-the-new-autoprefixer/#article-header-id-10'>CSS grid in IE: CSS Grid and the New Autoprefixer</a>)."
-                    }
-                  ]
               },
               "opera": [
                 {

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -178,8 +178,7 @@
                 }
               ],
               "ie": {
-                "version_added": "11",
-                "notes": "IE can treat the first (<code>min-content</code>) parameter as the <code>max-content</code> parameter (source: <a href='https://css-tricks.com/css-grid-in-ie-css-grid-and-the-new-autoprefixer/#article-header-id-10'>CSS grid in IE: CSS Grid and the New Autoprefixer</a>)."
+                "version_added": "11"
               },
               "opera": [
                 {

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -178,7 +178,10 @@
                 }
               ],
               "ie": {
-                "version_added": false
+                "version_added": "11",
+                "notes": "IE can treat the first (<code>min-content</code>) parameter as the <code>max-content</code> parameter (source: <a href='https://css-tricks.com/css-grid-in-ie-css-grid-and-the-new-autoprefixer/#article-header-id-10'>CSS grid in IE: CSS Grid and the New Autoprefixer</a>)."
+                    }
+                  ]
               },
               "opera": [
                 {


### PR DESCRIPTION
I was reading the grid `minmax()` documentation on MDN and I noticed the compatibility-table didn't reflect properly that the property is actually working in IE (with a caveat, as added in a note).

