### PR TITLE
Fix standard track for api.XMLHttpRequest.responseType.moz-blob

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1249,7 +1249,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }


### PR DESCRIPTION
Reviewing a PR recently, I noticed a tiny problem with the standards data for `moz-blob` (it's not one of the values in the XHR spec).