### PR TITLE
Fix IE data and note for api.XMLHttpRequest.responseText

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -919,8 +919,8 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null,
-              "notes": "Before IE 10, the value of XMLHttpRequest.responseText could be read only once the request was complete."
+              "version_added": true,
+              "notes": "Before IE 10, the value of <code>XMLHttpRequest.responseText</code> could be read only once the request was complete."
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
The note for the IE data on api.XMLHttpRequest.responseText implies the IE supports it before IE 10, so I set the value to `true`. Also, the note lacked code formatting. More little fixes!

I meant to include this in #3815 but forgot, and @Elchi3 was too quick for me to update the first PR! 😄 