### PR TITLE
Promote Daniel Beck to BCD Owner

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -48,7 +48,6 @@ It is important to recognize that being a Peer is a privilege, not a right. That
 
 #### List of current peers
 - Rachel Andrew (@rachelandrew)
-- Daniel Beck (@ddbeck)
 - Vinyl Darkscratch (@vinyldarkscratch)
 - Ryan Johnson (@escattone), Mozilla
 - Joe Medley (@jpmedley), Google
@@ -94,6 +93,7 @@ An individual is invited to become an Owner by existing Owners. A nomination wil
 
 #### List of current Owners
 - Florian Scholz (@Elchi3), Mozilla, BCD project lead
+- Daniel Beck (@ddbeck)
 - Will Bamberg (@wbamberg), Mozilla
 - Chris David Mills (@chrisdavidmills), Mozilla
 - Kadir Topal (@atopal), Mozilla


### PR DESCRIPTION
Daniel Beck (@ddbeck) has been BCD Peer for many months now and we would like to have him join the BCD Owners group. His contributions have been essential and we're lucky to have him caring so enthusiastically and with lots of attention to detail for this project. 
Formally asking all owners to approve Daniel's promotion.

Please join me in congratulating Daniel.