### PR TITLE
Remove outdated "defect" note for Safari iOS beforeunload event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -553,8 +553,7 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": false,
-              "notes": "Implementation seems <a href='https://webkit.org/b/19324'>defect</a>."
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -178,8 +178,7 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": false,
-              "notes": "Implementation seems <a href='https://webkit.org/b/19324'>defect</a>."
+              "version_added": true
             },
             "webview_android": {
               "version_added": true


### PR DESCRIPTION
I saw a couple of notes with awkward wording relating to the `beforeunload` event and this WebKit bug: https://webkit.org/b/19324. After reviewing the issue, it seems that the bug has been either fixed or mitigated in [a related bug](https://bugs.webkit.org/show_bug.cgi?id=26211), so I decided to just remove the note.