### PR TITLE
Remove 50.0.1 from Firefox browser version data

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -274,10 +274,6 @@
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/50",
           "status": "retired"
         },
-        "50.0.1": {
-          "release_date": "2016-11-28",
-          "status": "retired"
-        },
         "51": {
           "release_date": "2017-01-24",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/51",


### PR DESCRIPTION
When scanning through all the browsers, it seems that we had a very specific version number in browsers/firefox.json, of which was never actually used in any data.  Since APIs and features aren't expected to change between minor versions, I think we can safely remove this.