### PR TITLE
Add release notes for Opera 9.6-12.1

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -77,46 +77,57 @@
         },
         "9.6": {
           "release_date": "2008-10-08",
+          "release_notes": "https://dev.opera.com/blog/a-look-under-the-hood-of-opera-9-6/",
           "status": "retired"
         },
         "10": {
           "release_date": "2009-09-01",
+          "release_notes": "https://dev.opera.com/blog/opera-10-weve-only-just-begun/",
           "status": "retired"
         },
         "10.1": {
           "release_date": "2009-11-23",
+          "release_notes": "https://dev.opera.com/blog/opera-10-10-and-10-2-alpha/",
           "status": "retired"
         },
         "10.5": {
           "release_date": "2010-03-02",
+          "release_notes": "https://dev.opera.com/blog/opera-10-50-final-for-windows-is-out/",
           "status": "retired"
         },
         "10.6": {
           "release_date": "2010-07-01",
+          "release_notes": "https://dev.opera.com/blog/hello-opera-10-60/",
           "status": "retired"
         },
         "11": {
           "release_date": "2010-12-16",
+          "release_notes": "https://dev.opera.com/blog/new-html5-features-in-opera-11/",
           "status": "retired"
         },
         "11.1": {
           "release_date": "2011-04-12",
+          "release_notes": "https://dev.opera.com/blog/unveiling-opera-11-10-final/",
           "status": "retired"
         },
         "11.5": {
           "release_date": "2011-06-28",
+          "release_notes": "https://dev.opera.com/blog/opera-11-50-released-speed-dial-extensions-improved-standards-support/",
           "status": "retired"
         },
         "11.6": {
           "release_date": "2011-12-06",
+          "release_notes": "https://dev.opera.com/blog/hello-opera-11-60/",
           "status": "retired"
         },
         "12": {
           "release_date": "2012-06-14",
+          "release_notes": "https://dev.opera.com/blog/hello-opera-12/",
           "status": "retired"
         },
         "12.1": {
           "release_date": "2012-11-20",
+          "release_notes": "https://dev.opera.com/blog/opera-12-10-is-out/",
           "status": "retired"
         },
         "15": {


### PR DESCRIPTION
This adds all the release notes for Opera Desktop 9.6 to 12.1.  I couldn't find anything earlier than 9.6 for final release notes, only betas or small tips and tricks.
