### PR TITLE
reset and submit bcds

### DIFF
--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -764,9 +764,111 @@
           }
         }
       },
+      "reset_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/reset_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "submit": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/submit",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "submit_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/submit_event",
           "support": {
             "chrome": {
               "version_added": true

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -775,7 +775,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "12"
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": true
@@ -787,7 +787,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -802,10 +802,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -877,7 +877,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "12"
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": true


### PR DESCRIPTION
For https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/reset_event and
https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit_event as part of event migration