### PR TITLE
Mirror Chrome -> Chrome Android for html/*

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -428,7 +428,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": false

--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -58,7 +58,7 @@
                 "version_added": "5"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -258,7 +258,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -308,7 +308,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -358,7 +358,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true

--- a/html/elements/canvas.json
+++ b/html/elements/canvas.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -69,7 +69,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -180,7 +180,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true

--- a/html/elements/embed.json
+++ b/html/elements/embed.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": true
@@ -58,7 +58,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true
@@ -108,7 +108,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true
@@ -158,7 +158,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true
@@ -208,7 +208,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true

--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -459,7 +459,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -1118,7 +1118,7 @@
                 "version_added": "20"
               },
               "chrome_android": {
-                "version_added": "20"
+                "version_added": "25"
               },
               "edge": {
                 "version_added": false

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -167,9 +167,15 @@
                   "version_added": "17"
                 }
               ],
-              "chrome_android": {
-                "version_added": null
-              },
+              "chrome_android": [
+                {
+                  "version_added": "27"
+                },
+                {
+                  "prefix": "webkit",
+                  "version_added": "18"
+                }
+              ],
               "edge": {
                 "version_added": true
               },
@@ -744,7 +750,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true
@@ -1112,7 +1118,7 @@
                 "version_added": "20"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "20"
               },
               "edge": {
                 "version_added": false

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -562,7 +562,8 @@
                   "notes": "Until Chrome 46, <code>content</code> values weren't constrained to the values listed in the spec."
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "18",
+                  "notes": "Until Chrome 46, <code>content</code> values weren't constrained to the values listed in the spec."
                 },
                 "edge": {
                   "version_added": false

--- a/html/elements/meter.json
+++ b/html/elements/meter.json
@@ -9,7 +9,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -58,7 +58,7 @@
                 "version_added": "6"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -108,7 +108,7 @@
                 "version_added": "6"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -158,7 +158,7 @@
                 "version_added": "6"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -208,7 +208,7 @@
                 "version_added": "6"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -258,7 +258,7 @@
                 "version_added": "6"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -308,7 +308,7 @@
                 "version_added": "6"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true
@@ -358,7 +358,7 @@
                 "version_added": "6"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": true

--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -169,7 +169,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true
@@ -369,7 +369,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true
@@ -519,7 +519,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true
@@ -569,7 +569,7 @@
                   "version_added": "36"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "36"
                 },
                 "edge": {
                   "version_added": true

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1620,7 +1620,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Chrome Android when it is set to "null". This should help reduce inconsistencies in the browser data.