### PR TITLE
Mirror Chrome -> Chrome Android for javascript/*

### DIFF
--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -63,7 +63,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": "14"

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -63,7 +63,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": "13"
@@ -117,7 +117,7 @@
                 "version_added": "60"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "60"
               },
               "edge": {
                 "version_added": false
@@ -225,7 +225,7 @@
                   "version_added": "60"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "60"
                 },
                 "edge": {
                   "version_added": false

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2703,7 +2703,7 @@
                   "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": "24"
+                  "version_added": "26"
                 },
                 "edge": {
                   "version_added": "14"
@@ -2977,7 +2977,7 @@
                   "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": "24"
+                  "version_added": "26"
                 },
                 "edge": {
                   "version_added": "14"
@@ -3195,7 +3195,7 @@
                   "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": "24"
+                  "version_added": "26"
                 },
                 "edge": {
                   "version_added": "14"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2703,7 +2703,7 @@
                   "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "24"
                 },
                 "edge": {
                   "version_added": "14"
@@ -2977,7 +2977,7 @@
                   "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "24"
                 },
                 "edge": {
                   "version_added": "14"
@@ -3195,7 +3195,7 @@
                   "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "24"
                 },
                 "edge": {
                   "version_added": "14"

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -63,7 +63,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": "14"

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -63,7 +63,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": "14"

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -63,7 +63,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -63,7 +63,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -63,7 +63,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1273,7 +1273,7 @@
                   "version_added": true
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "edge": {
                   "version_added": null

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -1677,7 +1677,7 @@
                 "version_added": "45"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "14"
@@ -1732,7 +1732,7 @@
                 "version_added": "45"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "14"
@@ -1787,7 +1787,7 @@
                 "version_added": "45"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "14"
@@ -1897,7 +1897,7 @@
                 "version_added": "45"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "14"
@@ -1952,7 +1952,7 @@
                 "version_added": "45"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "14"
@@ -2007,7 +2007,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": "14"
@@ -2365,7 +2365,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": null

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -63,7 +63,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -63,7 +63,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -63,7 +63,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -63,7 +63,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": true

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1380,7 +1380,7 @@
                 "version_added": "49"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "49"
               },
               "edge": {
                 "version_added": null


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Chrome Android when it is set to "null". This should help reduce inconsistencies in the browser data.