### PR TITLE
Mirror Chrome -> Chrome Android for svg/*

### DIFF
--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -1930,7 +1930,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": null

--- a/svg/elements/animateColor.json
+++ b/svg/elements/animateColor.json
@@ -9,7 +9,7 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -55,7 +55,7 @@
                 "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": false
@@ -102,7 +102,7 @@
                 "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": false
@@ -149,7 +149,7 @@
                 "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": false

--- a/svg/elements/animateMotion.json
+++ b/svg/elements/animateMotion.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null

--- a/svg/elements/animateTransform.json
+++ b/svg/elements/animateTransform.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": null


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Chrome Android when it is set to "null". This should help reduce inconsistencies in the browser data.