### PR TITLE
Mirror Chrome -> Webview for xpath/*

### DIFF
--- a/xpath/axes/self.json
+++ b/xpath/axes/self.json
@@ -42,7 +42,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Webview when it is set to "null". This should help reduce inconsistencies in the browser data.