### PR TITLE
Mirror Firefox -> Firefox Android for html/*

### DIFF
--- a/html/elements/embed.json
+++ b/html/elements/embed.json
@@ -21,7 +21,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -70,7 +70,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -120,7 +120,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -170,7 +170,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -220,7 +220,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/html/elements/fieldset.json
+++ b/html/elements/fieldset.json
@@ -72,7 +72,7 @@
                 "version_added": true
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": true
               },
               "ie": {
                 "version_added": true,


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Firefox Desktop to Firefox Android when it is set to "null". This should help reduce inconsistencies in the browser data.