### PR TITLE
Mirror Firefox -> Firefox Android for http/*

### DIFF
--- a/http/headers/retry-after.json
+++ b/http/headers/retry-after.json
@@ -22,7 +22,8 @@
               "notes": "See <a href='https://bugzil.la/230260'>bug 230260</a>."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/230260'>bug 230260</a>."
             },
             "ie": {
               "version_added": null

--- a/http/headers/x-frame-options.json
+++ b/http/headers/x-frame-options.json
@@ -71,7 +71,7 @@
                 "version_added": "18"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "ie": {
                 "version_added": "8"
@@ -125,7 +125,8 @@
                 "notes": "Starting in Firefox 59, this applies to all of a frame's ancestors."
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": true,
+                "notes": "Starting in Firefox 59, this applies to all of a frame's ancestors."
               },
               "ie": {
                 "version_added": "8"


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Firefox Desktop to Firefox Android when it is set to "null". This should help reduce inconsistencies in the browser data.