### PR TITLE
Mirror Firefox -> Firefox Android for javascript/*

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -1448,7 +1448,7 @@
                   "version_added": "58"
                 },
                 "firefox_android": {
-                  "version_added": null
+                  "version_added": "58"
                 },
                 "ie": {
                   "version_added": null

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1005,7 +1005,7 @@
               "version_added": "57"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "57"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Firefox Desktop to Firefox Android when it is set to "null". This should help reduce inconsistencies in the browser data.