### PR TITLE
Mirror Firefox -> Firefox Android for svg/*

### DIFF
--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -1942,7 +1942,7 @@
                 "version_added": true
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": true
               },
               "ie": {
                 "version_added": false

--- a/svg/elements/animateColor.json
+++ b/svg/elements/animateColor.json
@@ -21,7 +21,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -67,7 +67,7 @@
                 "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -114,7 +114,7 @@
                 "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -161,7 +161,7 @@
                 "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/svg/elements/animateMotion.json
+++ b/svg/elements/animateMotion.json
@@ -21,7 +21,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/svg/elements/animateTransform.json
+++ b/svg/elements/animateTransform.json
@@ -21,7 +21,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/svg/elements/feComposite.json
+++ b/svg/elements/feComposite.json
@@ -21,7 +21,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -67,7 +67,7 @@
                 "version_added": true
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": true
               },
               "ie": {
                 "version_added": null
@@ -114,7 +114,7 @@
                 "version_added": true
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": true
               },
               "ie": {
                 "version_added": null
@@ -350,7 +350,7 @@
                 "version_added": true
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": true
               },
               "ie": {
                 "version_added": null
@@ -397,7 +397,7 @@
                 "version_added": true
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": true
               },
               "ie": {
                 "version_added": null

--- a/svg/elements/feMorphology.json
+++ b/svg/elements/feMorphology.json
@@ -21,7 +21,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -115,7 +115,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -162,7 +162,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true
@@ -209,7 +209,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": true

--- a/svg/elements/filter.json
+++ b/svg/elements/filter.json
@@ -21,7 +21,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"

--- a/svg/elements/glyphRef.json
+++ b/svg/elements/glyphRef.json
@@ -21,7 +21,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null

--- a/svg/elements/mpath.json
+++ b/svg/elements/mpath.json
@@ -21,7 +21,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/svg/elements/title.json
+++ b/svg/elements/title.json
@@ -68,7 +68,7 @@
                 "version_added": "4"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": null


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Firefox Desktop to Firefox Android when it is set to "null". This should help reduce inconsistencies in the browser data.