### PR TITLE
Mirror Chrome -> Samsung Internet for api/*

### DIFF
--- a/api/AbsoluteOrientationSensor.json
+++ b/api/AbsoluteOrientationSensor.json
@@ -31,9 +31,7 @@
           "safari": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "69"
           }
@@ -76,9 +74,7 @@
             "safari": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }

--- a/api/Accelerometer.json
+++ b/api/Accelerometer.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "69"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }

--- a/api/AnimationEffect.json
+++ b/api/AnimationEffect.json
@@ -51,9 +51,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -101,9 +99,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -152,9 +148,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -203,9 +197,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -401,9 +401,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -557,9 +555,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -472,9 +472,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true,
               "version_removed": "56",
@@ -678,9 +676,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -780,9 +776,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -87,9 +87,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "68"
             }

--- a/api/AudioProcessingEvent.json
+++ b/api/AudioProcessingEvent.json
@@ -88,9 +88,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "57"
             }

--- a/api/AudioTrack.json
+++ b/api/AudioTrack.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -291,9 +281,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -342,9 +330,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/AudioTrackList.json
+++ b/api/AudioTrackList.json
@@ -79,9 +79,7 @@
           "safari_ios": {
             "version_added": "7.1"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "45"
           }
@@ -172,9 +170,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -266,9 +262,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -359,9 +353,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -452,9 +444,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -545,9 +535,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -638,9 +626,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -731,9 +717,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -825,9 +809,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }

--- a/api/AudioWorklet.json
+++ b/api/AudioWorklet.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }

--- a/api/AudioWorkletGlobalScope.json
+++ b/api/AudioWorkletGlobalScope.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/AudioWorkletNode.json
+++ b/api/AudioWorkletNode.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/AudioWorkletProcessor.json
+++ b/api/AudioWorkletProcessor.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "64"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "64"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "64"
             }

--- a/api/AuthenticatorAssertionResponse.json
+++ b/api/AuthenticatorAssertionResponse.json
@@ -52,9 +52,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "70"
           }
@@ -117,9 +115,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "70"
             }
@@ -183,9 +179,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "70"
             }
@@ -249,9 +243,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "70"
             }

--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -52,9 +52,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "70"
           }
@@ -117,9 +115,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "70"
             }
@@ -168,9 +164,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/AuthenticatorResponse.json
+++ b/api/AuthenticatorResponse.json
@@ -52,9 +52,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "70"
           }
@@ -117,9 +115,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "70"
             }

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -50,9 +50,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -100,9 +98,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -165,9 +161,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -230,9 +224,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -295,9 +287,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -360,9 +350,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -425,9 +413,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -490,9 +476,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -541,9 +525,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "56"
             }
@@ -606,9 +588,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -671,9 +651,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -736,9 +714,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -801,9 +777,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -852,9 +826,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "49"
             }
@@ -917,9 +889,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -982,9 +952,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1066,9 +1034,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "59",
@@ -1126,9 +1092,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1192,9 +1156,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1243,9 +1205,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1308,9 +1268,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1373,9 +1331,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1438,9 +1394,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1488,9 +1442,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "49"
               }
@@ -1554,9 +1506,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1619,9 +1569,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1670,9 +1618,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1735,9 +1681,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1786,9 +1730,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/BeforeInstallPromptEvent.json
+++ b/api/BeforeInstallPromptEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "45"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -90,9 +88,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -259,9 +255,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/BlobBuilder.json
+++ b/api/BlobBuilder.json
@@ -45,9 +45,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "3",
             "prefix": "Webkit"

--- a/api/BluetoothRemoteGATTService.json
+++ b/api/BluetoothRemoteGATTService.json
@@ -73,9 +73,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -141,9 +139,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -228,9 +224,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -279,9 +273,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -330,9 +322,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -417,9 +407,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -468,9 +456,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -555,9 +541,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/CSS.json
+++ b/api/CSS.json
@@ -59,9 +59,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "37"
           }
@@ -109,9 +107,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -160,9 +156,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -211,9 +205,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -262,9 +254,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -313,9 +303,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -364,9 +352,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -415,9 +401,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -466,9 +450,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "46"
             }
@@ -517,9 +499,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -568,9 +548,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -619,9 +597,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -670,9 +646,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -721,9 +695,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -823,9 +795,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -925,9 +895,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -976,9 +944,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -1027,9 +993,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -1078,9 +1042,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1129,9 +1091,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -1180,9 +1140,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -1231,9 +1189,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -1282,9 +1238,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -1333,9 +1287,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -1384,9 +1336,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -1486,9 +1436,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -1537,9 +1485,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -1698,9 +1644,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -1800,9 +1744,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -1902,9 +1844,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -1953,9 +1893,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -2004,9 +1942,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSImageValue.json
+++ b/api/CSSImageValue.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }

--- a/api/CSSKeywordValue.json
+++ b/api/CSSKeywordValue.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSMathInvert.json
+++ b/api/CSSMathInvert.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSMathMax.json
+++ b/api/CSSMathMax.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSMathMin.json
+++ b/api/CSSMathMin.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSMathNegate.json
+++ b/api/CSSMathNegate.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSMathProduct.json
+++ b/api/CSSMathProduct.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSMathSum.json
+++ b/api/CSSMathSum.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSMathValue.json
+++ b/api/CSSMathValue.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSMatrixComponent.json
+++ b/api/CSSMatrixComponent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSNumericArray.json
+++ b/api/CSSNumericArray.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -291,9 +281,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -342,9 +330,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -393,9 +379,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSNumericValue.json
+++ b/api/CSSNumericValue.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -291,9 +281,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -342,9 +330,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -397,9 +383,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66",
               "notes": "Not exposed to PaintWorklet."
@@ -449,9 +433,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -500,9 +482,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -551,9 +531,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -602,9 +580,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSPageRule.json
+++ b/api/CSSPageRule.json
@@ -87,9 +87,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -138,9 +136,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/CSSPerspective.json
+++ b/api/CSSPerspective.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSPositionValue.json
+++ b/api/CSSPositionValue.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSPrimitiveValue.json
+++ b/api/CSSPrimitiveValue.json
@@ -39,9 +39,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -91,9 +89,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -144,9 +140,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -197,9 +191,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -250,9 +242,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -303,9 +293,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -356,9 +344,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -409,9 +395,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -462,9 +446,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/CSSRotate.json
+++ b/api/CSSRotate.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -292,9 +282,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSScale.json
+++ b/api/CSSScale.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSSkew.json
+++ b/api/CSSSkew.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSSkewX.json
+++ b/api/CSSSkewX.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSSkewY.json
+++ b/api/CSSSkewY.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSStyleValue.json
+++ b/api/CSSStyleValue.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSTransformComponent.json
+++ b/api/CSSTransformComponent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSTransformValue.json
+++ b/api/CSSTransformValue.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -292,9 +282,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -343,9 +331,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -394,9 +380,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -445,9 +429,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -496,9 +478,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSTranslate.json
+++ b/api/CSSTranslate.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSUnitValue.json
+++ b/api/CSSUnitValue.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSUnparsedValue.json
+++ b/api/CSSUnparsedValue.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -292,9 +282,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -343,9 +331,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -394,9 +380,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -445,9 +429,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CSSVariableReferenceValue.json
+++ b/api/CSSVariableReferenceValue.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -612,9 +612,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "4.4"
             }
@@ -2074,9 +2072,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -2922,9 +2918,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -3240,9 +3234,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -3342,9 +3334,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -4233,9 +4223,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -103,9 +101,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -156,9 +152,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -223,9 +217,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -276,9 +268,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/ClipboardEvent.json
+++ b/api/ClipboardEvent.json
@@ -88,9 +88,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "58"
             }
@@ -139,9 +137,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/CompositionEvent.json
+++ b/api/CompositionEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/Console.json
+++ b/api/Console.json
@@ -83,9 +83,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -128,9 +126,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -176,9 +172,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -224,9 +218,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -323,9 +315,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -375,9 +365,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -424,9 +412,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -472,9 +458,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -520,9 +504,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -568,9 +550,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -714,9 +694,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -762,9 +740,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -810,9 +786,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -859,9 +833,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -907,9 +879,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -956,9 +926,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -1005,9 +973,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1054,9 +1020,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -1102,9 +1066,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -1150,9 +1112,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -1198,9 +1158,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -1246,9 +1204,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -1344,9 +1300,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -1392,9 +1346,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -1440,9 +1392,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -1488,9 +1438,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/api/Coordinates.json
+++ b/api/Coordinates.json
@@ -49,9 +49,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -99,9 +97,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -162,9 +158,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -225,9 +219,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -288,9 +280,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -351,9 +341,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -414,9 +402,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -477,9 +463,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -540,9 +524,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/Credential.json
+++ b/api/Credential.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "51"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "51"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "51"
             }
@@ -191,9 +185,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "51",
               "version_removed": "52",

--- a/api/CredentialUserData.json
+++ b/api/CredentialUserData.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "60"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -554,9 +554,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "68"
             }

--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/DOMQuad.json
+++ b/api/DOMQuad.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "61"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -292,9 +282,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -343,9 +331,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -394,9 +380,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -445,9 +429,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -496,9 +478,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -151,9 +151,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "57"
             }

--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -185,9 +185,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -236,9 +234,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -287,9 +283,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -338,9 +332,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -389,9 +381,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -896,9 +886,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -947,9 +935,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -998,9 +984,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/DeviceAcceleration.json
+++ b/api/DeviceAcceleration.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/DeviceLightEvent.json
+++ b/api/DeviceLightEvent.json
@@ -66,9 +66,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -145,9 +143,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": "4.2"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "59"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": "4.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": "4.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": "4.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -292,9 +282,7 @@
             "safari_ios": {
               "version_added": "4.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -41,9 +41,7 @@
           "safari_ios": {
             "version_added": "4.2"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true,
             "notes": "Before version 50, Chrome provided absolute values instead of relative values for this event. Developers still needing absolute values may use the <code>ondeviceorientationabsolute</code> event."
@@ -93,9 +91,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "59"
             }
@@ -144,9 +140,7 @@
             "safari_ios": {
               "version_added": "4.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -195,9 +189,7 @@
             "safari_ios": {
               "version_added": "4.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -246,9 +238,7 @@
             "safari_ios": {
               "version_added": "4.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -297,9 +287,7 @@
             "safari_ios": {
               "version_added": "4.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/DeviceProximityEvent.json
+++ b/api/DeviceProximityEvent.json
@@ -65,9 +65,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -143,9 +141,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -222,9 +218,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -301,9 +295,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/DeviceRotationRate.json
+++ b/api/DeviceRotationRate.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/DirectoryEntrySync.json
+++ b/api/DirectoryEntrySync.json
@@ -39,9 +39,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }

--- a/api/DirectoryReaderSync.json
+++ b/api/DirectoryReaderSync.json
@@ -39,9 +39,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }

--- a/api/Document.json
+++ b/api/Document.json
@@ -440,9 +440,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -492,9 +490,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -544,9 +540,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -596,9 +590,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -1361,9 +1353,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "58"
             }
@@ -1410,9 +1400,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "58"
               }
@@ -2675,9 +2663,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "58"
             }
@@ -2724,9 +2710,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "58"
               }
@@ -4282,9 +4266,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "71"
               }
@@ -5156,9 +5138,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "57"
             }
@@ -5983,9 +5963,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "57"
             }
@@ -7050,9 +7028,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "58"
             }
@@ -7099,9 +7075,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "58"
               }
@@ -7228,9 +7202,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -7305,9 +7277,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -7382,9 +7352,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -7459,9 +7427,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -7525,9 +7491,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "45"
@@ -7598,9 +7562,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "45"
@@ -7682,9 +7644,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -7759,9 +7719,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -7836,9 +7794,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -7913,9 +7869,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -9568,9 +9522,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -9620,9 +9572,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -9672,9 +9622,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -9724,9 +9672,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/DoubleRange.json
+++ b/api/DoubleRange.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }

--- a/api/EXT_color_buffer_float.json
+++ b/api/EXT_color_buffer_float.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "63"
           }

--- a/api/EXT_color_buffer_half_float.json
+++ b/api/EXT_color_buffer_half_float.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "63"
           }

--- a/api/EffectTiming.json
+++ b/api/EffectTiming.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -342,9 +332,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -393,9 +381,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -444,9 +430,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -495,9 +479,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/Element.json
+++ b/api/Element.json
@@ -91,9 +91,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false,
               "notes": "Implemented on <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'>HTMLElement</a>."
@@ -143,9 +141,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "37"
             }
@@ -193,9 +189,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "50"
               }
@@ -324,9 +318,7 @@
             "safari_ios": {
               "version_added": "10"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "53"
             }
@@ -374,9 +366,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -426,9 +416,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -477,9 +465,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -643,9 +629,7 @@
             "safari_ios": {
               "version_added": "5"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -693,9 +677,7 @@
               "safari_ios": {
                 "version_added": "7"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }
@@ -744,9 +726,7 @@
               "safari_ios": {
                 "version_added": "7"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }
@@ -795,9 +775,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1052,9 +1030,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -1103,9 +1079,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -1205,9 +1179,7 @@
             "safari_ios": {
               "version_added": "9"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "41"
             }
@@ -1257,9 +1229,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1309,9 +1279,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1361,9 +1329,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1412,9 +1378,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -1464,9 +1428,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "58"
             }
@@ -1513,9 +1475,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "58"
               }
@@ -1757,9 +1717,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "58"
             }
@@ -1806,9 +1764,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "58"
               }
@@ -1859,9 +1815,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -2073,9 +2027,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -2176,9 +2128,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "61"
             }
@@ -2227,9 +2177,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -2278,9 +2226,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -2330,9 +2276,7 @@
               "version_added": "4",
               "notes": "Safari for iOS will modify the effective viewport based on the user zoom. This results in incorrect values whenever the user has zoomed."
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -2379,9 +2323,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }
@@ -2429,9 +2371,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }
@@ -2481,9 +2421,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }
@@ -2533,9 +2471,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }
@@ -2585,9 +2521,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -2638,9 +2572,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -2745,9 +2677,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }
@@ -2808,9 +2738,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -2943,9 +2871,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -2995,9 +2921,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -3070,9 +2994,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -3384,9 +3306,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true,
               "notes": "This API was previously available on the <code>Node</code> API."
@@ -3591,9 +3511,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -3646,9 +3564,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true,
               "notes": "This API was previously available on the <code>Node</code> API."
@@ -3930,9 +3846,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "58"
             }
@@ -3979,9 +3893,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "58"
               }
@@ -4035,9 +3947,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4232,9 +4142,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -4283,9 +4191,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4334,9 +4240,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4385,9 +4289,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4622,9 +4524,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "71"
               }
@@ -4692,9 +4592,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": true
@@ -5008,9 +4906,7 @@
               "version_added": "5",
               "notes": "No support for <code>smooth</code> behavior or <code>center</code> options."
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -5070,9 +4966,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "61",
                 "notes": "The <code>block</code> and <code>inline</code> options support the values <code>start</code>, <code>center</code>, <code>end</code>, <code>nearest</code>."
@@ -5123,9 +5017,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -5539,9 +5431,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -5590,9 +5480,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -5641,9 +5529,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -5692,9 +5578,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -5745,9 +5629,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -5797,9 +5679,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -5878,9 +5758,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -5957,9 +5835,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -6008,9 +5884,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "53"
             }
@@ -6059,9 +5933,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -6110,9 +5982,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -6161,9 +6031,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }

--- a/api/EntrySync.json
+++ b/api/EntrySync.json
@@ -39,9 +39,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -519,9 +519,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": "73"
                 }

--- a/api/ExtendableEvent.json
+++ b/api/ExtendableEvent.json
@@ -191,9 +191,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/api/ExtendableMessageEvent.json
+++ b/api/ExtendableMessageEvent.json
@@ -38,9 +38,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -89,9 +87,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -141,9 +137,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -193,9 +187,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -245,9 +237,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -297,9 +287,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -349,9 +337,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/External.json
+++ b/api/External.json
@@ -31,9 +31,7 @@
           "safari": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -75,9 +73,7 @@
             "safari": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -120,9 +116,7 @@
             "safari": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -611,9 +611,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "72"
             }
@@ -662,9 +660,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/FileList.json
+++ b/api/FileList.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/FocusEvent.json
+++ b/api/FocusEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/FormData.json
+++ b/api/FormData.json
@@ -38,9 +38,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true,
             "notes": "XHR in Android 4.0 sends empty content for <code>FormData</code> with <code>blob</code>."
@@ -90,9 +88,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -144,9 +140,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "3",
               "notes": "XHR in Android 4.0 sends empty content for <code>FormData</code> with <code>blob</code>."
@@ -196,9 +190,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -248,9 +240,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -299,9 +289,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -350,9 +338,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -401,9 +387,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -452,9 +436,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -503,9 +485,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -554,9 +534,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -605,9 +583,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -657,9 +633,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -709,9 +683,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/FullscreenOptions.json
+++ b/api/FullscreenOptions.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "71"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "71"
             }

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -291,9 +291,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/Geolocation.json
+++ b/api/Geolocation.json
@@ -100,9 +100,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "51",
               "notes": "Secure context is only required for applications targeting Android Nougat (7) and higher. See <a href='https://crbug.com/603574'>bug 603574</a>."

--- a/api/GeometryUtils.json
+++ b/api/GeometryUtils.json
@@ -39,9 +39,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -89,9 +87,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -140,9 +136,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -191,9 +185,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -256,9 +248,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/GestureEvent.json
+++ b/api/GestureEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": "2"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": "2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": "2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": "2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": "2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -201,9 +195,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": true
@@ -270,9 +262,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": true
@@ -339,9 +329,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": true
@@ -498,9 +486,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -549,9 +535,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -600,9 +584,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -753,9 +735,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -804,9 +784,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -855,9 +833,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -906,9 +882,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -957,9 +931,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1008,9 +980,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1059,9 +1029,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1110,9 +1078,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1161,9 +1127,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1212,9 +1176,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1263,9 +1225,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1314,9 +1274,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1365,9 +1323,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1416,9 +1372,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1467,9 +1421,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1518,9 +1470,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1620,9 +1570,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "57"
             }
@@ -1773,9 +1721,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1824,9 +1770,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1875,9 +1819,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1977,9 +1919,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -2028,9 +1968,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -2079,9 +2017,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -2189,9 +2125,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "57"
             }
@@ -2597,9 +2531,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -2648,9 +2580,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -2699,9 +2629,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -2750,9 +2678,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -2826,9 +2752,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -2902,9 +2826,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -2978,9 +2900,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -3054,9 +2974,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -3105,9 +3023,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -3156,9 +3072,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -3232,9 +3146,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -3308,9 +3220,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -3384,9 +3294,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -3460,9 +3368,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -3511,9 +3417,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -3562,9 +3466,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -3613,9 +3515,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -3715,9 +3615,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -3766,9 +3664,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -3817,9 +3713,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -3868,9 +3762,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -3943,9 +3835,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4018,9 +3908,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4069,9 +3957,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -4120,9 +4006,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -4171,9 +4055,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4273,9 +4155,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4324,9 +4204,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4375,9 +4253,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4426,9 +4302,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4477,9 +4351,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4528,9 +4400,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4579,9 +4449,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -4632,9 +4500,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true,
               "alternative_name": "onwebkittransitionend"
@@ -4684,9 +4550,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -4735,9 +4599,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -4786,9 +4648,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4837,9 +4697,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4888,9 +4746,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "61"
             }

--- a/api/Gyroscope.json
+++ b/api/Gyroscope.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "69"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -218,9 +218,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/api/HTMLDetailsElement.json
+++ b/api/HTMLDetailsElement.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -104,9 +104,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -156,9 +154,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -230,9 +230,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -282,9 +280,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -334,9 +330,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -974,9 +968,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "57"
             }
@@ -1172,9 +1164,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -1626,9 +1616,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "57"
             }
@@ -2279,9 +2267,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -2356,9 +2342,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -2433,9 +2417,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -2510,9 +2492,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -2587,9 +2567,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -2664,9 +2642,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -2741,9 +2717,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -2818,9 +2792,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }
@@ -3074,9 +3046,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -3126,9 +3096,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -3178,9 +3146,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -3230,9 +3196,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -87,9 +87,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -138,9 +136,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -189,9 +185,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -240,9 +234,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -291,9 +283,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -342,9 +332,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -393,9 +381,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -444,9 +430,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -495,9 +479,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -546,9 +528,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -597,9 +577,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -699,9 +677,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -750,9 +726,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -852,9 +826,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1176,9 +1176,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "uc_android": {
               "version_added": null
             },
@@ -1283,9 +1281,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "uc_android": {
               "version_added": null
             },

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -103,9 +103,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1307,9 +1305,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1585,9 +1581,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -2848,9 +2842,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/HTMLOptionsCollection.json
+++ b/api/HTMLOptionsCollection.json
@@ -138,9 +138,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -189,9 +187,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -240,9 +236,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -258,9 +258,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }

--- a/api/HashChangeEvent.json
+++ b/api/HashChangeEvent.json
@@ -84,9 +84,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -135,9 +133,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -153,9 +153,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/IdleDeadline.json
+++ b/api/IdleDeadline.json
@@ -61,9 +61,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "47"
           }
@@ -135,9 +133,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "47"
             }
@@ -210,9 +206,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "47"
             }

--- a/api/ImageCapture.json
+++ b/api/ImageCapture.json
@@ -190,9 +190,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "61"
             }

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -87,9 +87,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/InputDeviceCapabilities.json
+++ b/api/InputDeviceCapabilities.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "47"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "47"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "47"
             }

--- a/api/InputDeviceInfo.json
+++ b/api/InputDeviceInfo.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": "10.1"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "60"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }
@@ -292,9 +282,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }
@@ -343,9 +331,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -137,9 +133,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "49"
               }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": "5.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -291,9 +281,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -342,9 +330,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -393,9 +379,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "56"
             }
@@ -445,9 +429,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "51"
             }
@@ -496,9 +478,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "51"
               }
@@ -548,9 +528,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "51"
               }
@@ -599,9 +577,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "51"
               }
@@ -651,9 +627,7 @@
             "safari_ios": {
               "version_added": "5.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -706,9 +680,7 @@
             "safari_ios": {
               "version_added": "5.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true,
               "version_removed": "54"
@@ -758,9 +730,7 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -809,9 +779,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -860,9 +828,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -911,9 +877,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -964,9 +928,7 @@
             "safari_ios": {
               "version_added": "5.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1065,9 +1027,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "48"
               }
@@ -1117,9 +1077,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1168,9 +1126,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1219,9 +1175,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1270,9 +1224,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/KeyframeEffect.json
+++ b/api/KeyframeEffect.json
@@ -153,9 +153,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -204,9 +202,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -269,9 +265,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -371,9 +365,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/LinearAccelerationSensor.json
+++ b/api/LinearAccelerationSensor.json
@@ -31,9 +31,7 @@
           "safari": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "69"
           }
@@ -76,9 +74,7 @@
             "safari": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -127,9 +123,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -178,9 +172,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -229,9 +221,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }

--- a/api/Location.json
+++ b/api/Location.json
@@ -342,9 +342,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -390,9 +388,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -752,9 +748,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "52"
             }
@@ -800,9 +794,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/Lock.json
+++ b/api/Lock.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "69"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }

--- a/api/LockManager.json
+++ b/api/LockManager.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "69"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }

--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -87,9 +87,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -138,9 +136,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -189,9 +185,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -240,9 +234,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }

--- a/api/Magnetometer.json
+++ b/api/Magnetometer.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "69"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }

--- a/api/MediaCapabilitiesInfo.json
+++ b/api/MediaCapabilitiesInfo.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -316,9 +316,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": "11"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "47"
           }
@@ -101,9 +99,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -153,9 +149,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -210,9 +204,7 @@
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "47"
             }
@@ -261,9 +253,7 @@
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "53"
             }
@@ -336,9 +326,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false,
               "notes": "API is available, but will always fail with <code>NotAllowedError</code>."
@@ -508,9 +496,7 @@
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "53"
             }
@@ -558,9 +544,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -610,9 +594,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -142,9 +142,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/MediaEncryptedEvent.json
+++ b/api/MediaEncryptedEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "43"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -292,9 +282,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/MediaQueryListListener.json
+++ b/api/MediaQueryListListener.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -201,9 +201,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "49"
             }
@@ -623,9 +621,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "49"
             }
@@ -682,9 +678,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "49"
             }
@@ -741,9 +735,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "49"
             }
@@ -851,9 +843,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "49"
             }
@@ -910,9 +900,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "49"
             }
@@ -969,9 +957,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "49"
             }
@@ -1028,9 +1014,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "49"
             }
@@ -1087,9 +1071,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "49"
             }
@@ -1146,9 +1128,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "49"
             }
@@ -1205,9 +1185,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "49"
             }
@@ -1264,9 +1242,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "49"
             }

--- a/api/MediaStreamAudioSourceNode.json
+++ b/api/MediaStreamAudioSourceNode.json
@@ -142,9 +142,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/MediaStreamAudioSourceOptions.json
+++ b/api/MediaStreamAudioSourceOptions.json
@@ -87,9 +87,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "55"
             }

--- a/api/MediaStreamEvent.json
+++ b/api/MediaStreamEvent.json
@@ -139,9 +139,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -549,9 +549,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -856,9 +854,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -1060,9 +1056,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/MediaStreamTrackAudioSourceNode.json
+++ b/api/MediaStreamTrackAudioSourceNode.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }

--- a/api/MediaStreamTrackEvent.json
+++ b/api/MediaStreamTrackEvent.json
@@ -139,9 +139,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/MerchantValidationEvent.json
+++ b/api/MerchantValidationEvent.json
@@ -53,9 +53,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -106,9 +104,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -160,9 +156,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -213,9 +207,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -266,9 +258,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/MessageChannel.json
+++ b/api/MessageChannel.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": "5.1"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "4.4"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": "5.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "4.4"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": "5.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "4.4"
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": "5.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "4.4"
             }

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": "3"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": "3"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": "3"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": "3"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": "3"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -291,9 +281,7 @@
             "safari_ios": {
               "version_added": "3"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -341,9 +329,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -393,9 +379,7 @@
             "safari_ios": {
               "version_added": "3"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -444,9 +428,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -494,9 +476,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": "5.1"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -138,9 +136,7 @@
             "safari_ios": {
               "version_added": "5.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -190,9 +186,7 @@
             "safari_ios": {
               "version_added": "5.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -242,9 +236,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }
@@ -293,9 +285,7 @@
             "safari_ios": {
               "version_added": "5.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -344,9 +334,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }
@@ -395,9 +383,7 @@
             "safari_ios": {
               "version_added": "5.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -446,9 +432,7 @@
             "safari_ios": {
               "version_added": "5.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/Metadata.json
+++ b/api/Metadata.json
@@ -39,9 +39,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -89,9 +87,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -140,9 +136,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/MimeType.json
+++ b/api/MimeType.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "47"
             }
@@ -146,9 +142,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -197,9 +191,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "56"
               }
@@ -249,9 +241,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -306,9 +296,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -358,9 +346,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -409,9 +395,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -459,9 +443,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "56"
               }
@@ -511,9 +493,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -561,9 +541,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "56"
               }
@@ -613,9 +591,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -664,9 +640,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "47"
             }
@@ -714,9 +688,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -766,9 +738,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -817,9 +787,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -896,9 +864,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "37"
             }
@@ -975,9 +941,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "37"
             }
@@ -1026,9 +990,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1076,9 +1038,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "56"
               }
@@ -1128,9 +1088,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1178,9 +1136,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "56"
               }
@@ -1230,9 +1186,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -1280,9 +1234,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "56"
               }
@@ -1332,9 +1284,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -1382,9 +1332,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "56"
               }
@@ -1455,9 +1403,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1506,9 +1452,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1557,9 +1501,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1607,9 +1549,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "56"
               }
@@ -1659,9 +1599,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1709,9 +1647,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "56"
               }
@@ -1761,9 +1697,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1814,9 +1748,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1865,9 +1797,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1916,9 +1846,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/MouseWheelEvent.json
+++ b/api/MouseWheelEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -62,9 +62,7 @@
               "version_removed": "7"
             }
           ],
-          "samsunginternet_android": {
-            "version_added": null
-          }
+          "samsunginternet_android": null
         },
         "status": {
           "experimental": false,
@@ -134,9 +132,7 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": null
           },
           "status": {
             "experimental": false,
@@ -209,9 +205,7 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": null
           },
           "status": {
             "experimental": false,
@@ -284,9 +278,7 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": null
           },
           "status": {
             "experimental": false,
@@ -359,9 +351,7 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": null
           },
           "status": {
             "experimental": false,
@@ -434,9 +424,7 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": null
           },
           "status": {
             "experimental": false,
@@ -507,9 +495,7 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": null
           },
           "status": {
             "experimental": false,
@@ -580,9 +566,7 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": null
           },
           "status": {
             "experimental": false,

--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -291,9 +281,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -96,9 +96,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -264,9 +262,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -327,9 +323,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -378,9 +372,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -430,9 +422,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "50"
             }
@@ -483,9 +473,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "59"
             }
@@ -534,9 +522,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "51"
             }
@@ -585,9 +571,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "63"
             }
@@ -645,9 +629,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -708,9 +690,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -758,9 +738,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -814,9 +792,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -889,9 +865,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "37"
@@ -1024,9 +998,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1126,9 +1098,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -1203,9 +1173,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "37"
             }
@@ -1254,9 +1222,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -1305,9 +1271,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "51"
             }
@@ -1356,9 +1320,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1460,9 +1422,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1511,9 +1471,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1562,9 +1520,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1618,9 +1574,7 @@
               "version_added": true,
               "notes": "Always returns <code>20030107</code>."
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1670,9 +1624,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -1722,9 +1674,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1772,9 +1722,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -1850,9 +1798,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43",
               "notes": [
@@ -1909,9 +1855,7 @@
             "safari_ios": {
               "version_added": "11.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "40",
               "notes": "Starting in Chrome 59, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information see <a href='https://crbug.com/720283'>Chrome bug 720283</a>."
@@ -1973,9 +1917,7 @@
             "safari_ios": {
               "version_added": "11.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "40"
             }
@@ -2024,9 +1966,7 @@
             "safari_ios": {
               "version_added": "12.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -2126,9 +2066,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -2202,9 +2140,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "4.4.3",
               "notes": [
@@ -2257,9 +2193,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/Node.json
+++ b/api/Node.json
@@ -193,9 +193,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -56,9 +56,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -106,9 +104,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -157,9 +153,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -227,9 +221,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -278,9 +270,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -329,9 +319,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -380,9 +368,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -431,9 +417,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -482,9 +466,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -551,9 +533,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -602,9 +582,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -653,9 +631,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -704,9 +680,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -755,9 +729,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -806,9 +778,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -857,9 +827,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -908,9 +876,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -959,9 +925,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1010,9 +974,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1061,9 +1023,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1112,9 +1072,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1163,9 +1121,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1214,9 +1170,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1265,9 +1219,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1316,9 +1268,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1367,9 +1317,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1418,9 +1366,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/OrientationSensor.json
+++ b/api/OrientationSensor.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "69"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }

--- a/api/OverconstrainedError.json
+++ b/api/OverconstrainedError.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "63"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "63"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "63"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "63"
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "63"
             }

--- a/api/OverconstrainedErrorEvent.json
+++ b/api/OverconstrainedErrorEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/PageTransitionEvent.json
+++ b/api/PageTransitionEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/PaintRenderingContext2D.json
+++ b/api/PaintRenderingContext2D.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "65"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -291,9 +281,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -342,9 +330,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -393,9 +379,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -444,9 +428,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -495,9 +477,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -546,9 +526,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -597,9 +575,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -648,9 +624,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -699,9 +673,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "68"
             }
@@ -750,9 +722,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -801,9 +771,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -852,9 +820,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -903,9 +869,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -954,9 +918,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1005,9 +967,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1056,9 +1016,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1107,9 +1065,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1158,9 +1114,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1209,9 +1163,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1260,9 +1212,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1311,9 +1261,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1362,9 +1310,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1413,9 +1359,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1464,9 +1408,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1515,9 +1457,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1566,9 +1506,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1617,9 +1555,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "68"
             }
@@ -1668,9 +1604,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1719,9 +1653,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1770,9 +1702,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1821,9 +1751,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1872,9 +1800,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1923,9 +1849,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1974,9 +1898,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -2025,9 +1947,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -2076,9 +1996,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }

--- a/api/PaintSize.json
+++ b/api/PaintSize.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "65"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }

--- a/api/PaintWorkletGlobalScope.json
+++ b/api/PaintWorkletGlobalScope.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "65"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }

--- a/api/ParentNode.json
+++ b/api/ParentNode.json
@@ -342,9 +342,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -386,9 +386,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/PaymentCurrencyAmount.json
+++ b/api/PaymentCurrencyAmount.json
@@ -89,9 +89,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": [
             {
               "version_added": "56"
@@ -194,9 +192,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "56"
@@ -276,9 +272,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "53",
               "flags": [
@@ -376,9 +370,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "56"

--- a/api/PaymentMethodChangeEvent.json
+++ b/api/PaymentMethodChangeEvent.json
@@ -63,9 +63,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -129,9 +127,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -196,9 +192,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -333,9 +333,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -401,9 +399,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -468,9 +464,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -535,9 +529,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -806,9 +798,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -515,9 +515,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -890,9 +888,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -48,9 +48,7 @@
           "safari_ios": {
             "version_added": "11"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": [
             {
               "version_added": "46"
@@ -104,9 +102,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "62"
             }
@@ -155,9 +151,7 @@
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -206,9 +200,7 @@
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -257,9 +249,7 @@
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -308,9 +298,7 @@
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -359,9 +347,7 @@
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/PerformanceLongTaskTiming.json
+++ b/api/PerformanceLongTaskTiming.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "58"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "58"
             }

--- a/api/PerformanceMark.json
+++ b/api/PerformanceMark.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": "11"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }

--- a/api/PerformanceMeasure.json
+++ b/api/PerformanceMeasure.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": "11"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }

--- a/api/PerformanceNavigation.json
+++ b/api/PerformanceNavigation.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -89,9 +87,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -140,9 +136,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -193,9 +187,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/PerformanceObserverEntryList.json
+++ b/api/PerformanceObserverEntryList.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": "11"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/PerformancePaintTiming.json
+++ b/api/PerformancePaintTiming.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "60"
           }

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -852,9 +852,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }

--- a/api/PerformanceServerTiming.json
+++ b/api/PerformanceServerTiming.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "65"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }

--- a/api/PermissionStatus.json
+++ b/api/PermissionStatus.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -152,9 +148,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "43"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "46"
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "48"
             }
@@ -266,9 +258,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "46"
             }
@@ -317,9 +307,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "62"
             }
@@ -368,9 +356,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "62"
             }
@@ -419,9 +405,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "62"
             }
@@ -470,9 +454,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "62"
             }
@@ -521,9 +503,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "64"
             }
@@ -572,9 +552,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "64"
             }
@@ -623,9 +601,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "64"
             }
@@ -674,9 +650,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -725,9 +699,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "51"
             }
@@ -776,9 +748,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "62"
             }
@@ -827,9 +797,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "64"
             }
@@ -878,9 +846,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -929,9 +895,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -980,9 +944,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -1031,9 +993,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1082,9 +1042,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/Plugin.json
+++ b/api/Plugin.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -191,9 +185,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true,
               "notes": "Starting with version 59, method parameters are required instead of optional."
@@ -243,9 +235,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -296,9 +286,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true,
               "notes": "Starting with version 59, method parameters are required instead of optional."
@@ -348,9 +336,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/PluginArray.json
+++ b/api/PluginArray.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -89,9 +87,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true,
               "notes": "Starting with version 59, method parameters are required instead of optional."
@@ -141,9 +137,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -194,9 +188,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true,
               "notes": "Starting with version 59, method parameters are required instead of optional."
@@ -248,9 +240,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true,
               "notes": "Starting with version 59, method parameters are required instead of optional."

--- a/api/Point.json
+++ b/api/Point.json
@@ -39,9 +39,7 @@
             "version_added": true,
             "prefix": "WebKit"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -905,9 +905,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "64"
               }

--- a/api/Policy.json
+++ b/api/Policy.json
@@ -65,9 +65,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "69",
             "flags": [
@@ -150,9 +148,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69",
               "flags": [
@@ -236,9 +232,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69",
               "flags": [
@@ -322,9 +316,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69",
               "flags": [

--- a/api/PositionOptions.json
+++ b/api/PositionOptions.json
@@ -49,9 +49,7 @@
           "safari_ios": {
             "version_added": "5"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -99,9 +97,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "51",
               "notes": "Secure context is only required for applications targeting Android Nougat (7) and higher. See <a href='https://crbug.com/603574'>bug 603574</a>."
@@ -163,9 +159,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -226,9 +220,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -289,9 +281,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/Presentation.json
+++ b/api/Presentation.json
@@ -51,9 +51,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -115,9 +113,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -180,9 +176,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/PresentationAvailability.json
+++ b/api/PresentationAvailability.json
@@ -51,9 +51,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -115,9 +113,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -180,9 +176,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/PresentationConnection.json
+++ b/api/PresentationConnection.json
@@ -51,9 +51,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -115,9 +113,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -180,9 +176,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -245,9 +239,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -310,9 +302,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -375,9 +365,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -440,9 +428,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -505,9 +491,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -570,9 +554,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -635,9 +617,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -700,9 +680,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -765,9 +743,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/PresentationConnectionAvailableEvent.json
+++ b/api/PresentationConnectionAvailableEvent.json
@@ -51,9 +51,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -116,9 +114,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -181,9 +177,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/PresentationConnectionCloseEvent.json
+++ b/api/PresentationConnectionCloseEvent.json
@@ -51,9 +51,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -116,9 +114,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -181,9 +177,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -246,9 +240,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/PresentationConnectionList.json
+++ b/api/PresentationConnectionList.json
@@ -51,9 +51,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -115,9 +113,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -180,9 +176,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/PresentationReceiver.json
+++ b/api/PresentationReceiver.json
@@ -51,9 +51,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -115,9 +113,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -51,9 +51,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -101,9 +99,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -167,9 +163,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -232,9 +226,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -297,9 +289,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -362,9 +352,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -427,9 +415,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -492,9 +478,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/ProgressEvent.json
+++ b/api/ProgressEvent.json
@@ -88,9 +88,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -139,9 +137,7 @@
             "safari_ios": {
               "version_added": "2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "50"
             }

--- a/api/PromiseRejectionEvent.json
+++ b/api/PromiseRejectionEvent.json
@@ -53,9 +53,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -118,9 +116,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -183,9 +179,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -248,9 +242,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -52,9 +52,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "70"
           }
@@ -117,9 +115,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "70"
             }
@@ -183,9 +179,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "70"
             }
@@ -249,9 +243,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "70"
             }
@@ -315,9 +307,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "70"
             }

--- a/api/PushSubscriptionChangeEvent.json
+++ b/api/PushSubscriptionChangeEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/RTCAnswerOptions.json
+++ b/api/RTCAnswerOptions.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "50"
           }

--- a/api/RTCCertificate.json
+++ b/api/RTCCertificate.json
@@ -138,9 +138,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -189,9 +187,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/RTCDTMFSender.json
+++ b/api/RTCDTMFSender.json
@@ -292,9 +292,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -1187,9 +1187,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -1340,9 +1338,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "58"
             }

--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -291,9 +281,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -751,9 +751,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -802,9 +800,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -853,9 +849,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/RTCIceCandidatePairStats.json
+++ b/api/RTCIceCandidatePairStats.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "56"
           }
@@ -189,9 +187,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -240,9 +236,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -456,9 +450,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1616,9 +1608,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/RTCIceCandidateStats.json
+++ b/api/RTCIceCandidateStats.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -99,9 +97,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -150,9 +146,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -203,9 +197,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -254,9 +246,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -305,9 +295,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -358,9 +346,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -409,9 +395,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -472,9 +456,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -535,9 +517,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -588,9 +568,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -639,9 +617,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/RTCIceCandidateType.json
+++ b/api/RTCIceCandidateType.json
@@ -41,9 +41,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false,
             "notes": "An <code>RTCIceCandidate</code> object's <code>type</code> is not maintained by this browser."

--- a/api/RTCIceComponent.json
+++ b/api/RTCIceComponent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }

--- a/api/RTCIdentityProviderGlobalScope.json
+++ b/api/RTCIdentityProviderGlobalScope.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/RTCIdentityProviderRegistrar.json
+++ b/api/RTCIdentityProviderRegistrar.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/RTCOfferAnswerOptions.json
+++ b/api/RTCOfferAnswerOptions.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "50"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "50"
             }

--- a/api/RTCOfferOptions.json
+++ b/api/RTCOfferOptions.json
@@ -49,9 +49,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "50"
           }
@@ -99,9 +97,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "50"
             }

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -545,9 +545,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1374,9 +1372,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1742,9 +1738,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "58",
@@ -1803,9 +1797,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "37"
               }
@@ -1854,9 +1846,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "67"
               }
@@ -2728,9 +2718,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/RTCPeerConnectionIceEvent.json
+++ b/api/RTCPeerConnectionIceEvent.json
@@ -211,9 +211,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "67"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "67"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -241,9 +235,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -292,9 +284,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "67"
             }
@@ -343,9 +333,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -394,9 +382,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -448,9 +434,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "67",
               "notes": "The standard version of this property is <a href='https://developer.mozilla.org/docs/Web/API/RTCRtpSendParameters/priority'><code>RTCRtpSendParameters.priority</code></a>."
@@ -604,9 +588,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/RTCRtpSendParameters.json
+++ b/api/RTCRtpSendParameters.json
@@ -39,9 +39,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "69"
           }

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -344,9 +344,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -396,9 +394,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -448,9 +444,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -512,9 +506,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/RTCRtpStreamStats.json
+++ b/api/RTCRtpStreamStats.json
@@ -49,9 +49,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }
@@ -99,9 +97,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -150,9 +146,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -203,9 +197,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -254,9 +246,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -305,9 +295,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -356,9 +344,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -407,9 +393,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -458,9 +442,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -509,9 +491,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -560,9 +540,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -611,9 +589,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -662,9 +638,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -713,9 +687,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/RTCRtpTransceiverDirection.json
+++ b/api/RTCRtpTransceiverDirection.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }

--- a/api/RTCRtpTransceiverInit.json
+++ b/api/RTCRtpTransceiverInit.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -140,9 +136,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -191,9 +185,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/RTCStatsEvent.json
+++ b/api/RTCStatsEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/RadioNodeList.json
+++ b/api/RadioNodeList.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": "9"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": "9"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/ReadableStreamDefaultController.json
+++ b/api/ReadableStreamDefaultController.json
@@ -71,9 +71,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "52"
           }
@@ -156,9 +154,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -241,9 +237,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -326,9 +320,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -411,9 +403,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -496,9 +486,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -71,9 +71,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "52"
           }
@@ -156,9 +154,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -241,9 +237,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -326,9 +320,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -411,9 +403,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -496,9 +486,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/RelativeOrientationSensor.json
+++ b/api/RelativeOrientationSensor.json
@@ -31,9 +31,7 @@
           "safari": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "69"
           }
@@ -76,9 +74,7 @@
             "safari": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }

--- a/api/Request.json
+++ b/api/Request.json
@@ -851,9 +851,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "72"
               }
@@ -903,9 +901,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }
@@ -1536,9 +1532,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/ResizeObserverEntry.json
+++ b/api/ResizeObserverEntry.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "64"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "64"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "64"
             }

--- a/api/Response.json
+++ b/api/Response.json
@@ -1297,9 +1297,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -86,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -85,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -185,9 +183,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -239,9 +235,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -551,9 +545,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -603,9 +595,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -655,9 +645,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/SVGFEColorMatrixElement.json
+++ b/api/SVGFEColorMatrixElement.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/Screen.json
+++ b/api/Screen.json
@@ -699,9 +699,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -87,9 +87,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "38"
             }
@@ -138,9 +136,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "38"
             }
@@ -189,9 +185,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "38"
             }
@@ -240,9 +234,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "38"
             }
@@ -291,9 +283,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "38"
             }

--- a/api/ScriptProcessorNode.json
+++ b/api/ScriptProcessorNode.json
@@ -52,9 +52,7 @@
             "version_added": "6",
             "prefix": "webkit"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -117,9 +115,7 @@
               "version_added": "6",
               "prefix": "webkit"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -183,9 +179,7 @@
               "version_added": "6",
               "prefix": "webkit"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/Sensor.json
+++ b/api/Sensor.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "69"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -291,9 +281,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -342,9 +330,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -393,9 +379,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -444,9 +428,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }

--- a/api/SensorErrorEvent.json
+++ b/api/SensorErrorEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "69"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "69"
             }

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -603,9 +603,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -654,9 +652,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "74"
             }

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -259,9 +259,7 @@
             "safari_ios": {
               "version_added": "11.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -376,9 +374,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -583,9 +579,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -752,9 +746,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -428,9 +428,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1273,9 +1271,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "68"
             }

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -115,9 +115,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "57"
             }

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": "10.1"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "60"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }
@@ -292,9 +282,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }
@@ -343,9 +331,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }
@@ -394,9 +380,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }

--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -59,9 +59,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "48"
           }
@@ -109,9 +107,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "52"
             }
@@ -174,9 +170,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "52"
@@ -246,9 +240,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "52"

--- a/api/StorageQuota.json
+++ b/api/StorageQuota.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/StylePropertyMap.json
+++ b/api/StylePropertyMap.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/StylePropertyMapReadOnly.json
+++ b/api/StylePropertyMapReadOnly.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "66"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -291,9 +281,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -342,9 +330,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -393,9 +379,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -444,9 +428,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }
@@ -495,9 +477,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "66"
             }

--- a/api/TaskAttributionTiming.json
+++ b/api/TaskAttributionTiming.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "58"
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "58"
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "58"
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "58"
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "58"
             }

--- a/api/Text.json
+++ b/api/Text.json
@@ -213,9 +213,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "53"
             }

--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -51,9 +51,7 @@
           "safari_ios": {
             "version_added": "10.1"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "38"
           }
@@ -101,9 +99,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "38"
             }
@@ -167,9 +163,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "38"
             }
@@ -232,9 +226,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "38"
             }
@@ -297,9 +289,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "38"
             }
@@ -348,9 +338,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -399,9 +387,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -49,9 +49,7 @@
           "safari_ios": {
             "version_added": "10.1"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "38"
           }
@@ -99,9 +97,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "38"
             }
@@ -193,9 +189,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "38"
             }
@@ -256,9 +250,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "38"
             }
@@ -319,9 +311,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "38"
             }

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -87,9 +87,7 @@
             "safari_ios": {
               "version_added": "3.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -151,9 +149,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -215,9 +211,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -279,9 +273,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -343,9 +335,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -407,9 +397,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -471,9 +459,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -535,9 +521,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -599,9 +583,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -663,9 +645,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -727,9 +707,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -791,9 +769,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -696,9 +696,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/Touch.json
+++ b/api/Touch.json
@@ -45,9 +45,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -155,9 +153,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -214,9 +210,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -265,9 +259,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -324,9 +316,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -383,9 +373,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -442,9 +430,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -493,9 +479,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -544,9 +528,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -595,9 +577,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "43"
             }
@@ -654,9 +634,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -713,9 +691,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -772,9 +748,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/TouchEvent.json
+++ b/api/TouchEvent.json
@@ -51,9 +51,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -104,9 +102,7 @@
             "safari_ios": {
               "version_added": "3.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "48",
               "notes": "Chrome only supports the following <code>touchEventInit</code> properties: <code>touches</code>, <code>targetTouches</code>, <code>changedTouches</code>."
@@ -162,9 +158,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -219,9 +213,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -276,9 +268,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -333,9 +323,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -390,9 +378,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -447,9 +433,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -504,9 +488,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -189,9 +183,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -241,9 +233,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -292,9 +282,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -398,9 +386,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -449,9 +435,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -504,9 +488,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true,
               "version_removed": "44",
@@ -561,9 +543,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true,
               "version_removed": "44",
@@ -614,9 +594,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "47"
             }
@@ -665,9 +643,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -716,9 +692,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/URL.json
+++ b/api/URL.json
@@ -248,9 +248,7 @@
                 "version_added": null,
                 "notes": "See <a href='https://webkit.org/b/167518'>here</a> for progress on deprecation."
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/api/UserProximityEvent.json
+++ b/api/UserProximityEvent.json
@@ -140,9 +140,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/VideoTrack.json
+++ b/api/VideoTrack.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -138,9 +134,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -189,9 +183,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -240,9 +232,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -291,9 +281,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -342,9 +330,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/VideoTrackList.json
+++ b/api/VideoTrackList.json
@@ -79,9 +79,7 @@
           "safari_ios": {
             "version_added": "7.1"
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "45"
           }
@@ -172,9 +170,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -266,9 +262,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -359,9 +353,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -452,9 +444,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -545,9 +535,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -638,9 +626,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -731,9 +717,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -825,9 +809,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "45"
             }
@@ -918,9 +900,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/VisualViewport.json
+++ b/api/VisualViewport.json
@@ -51,9 +51,7 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "61"
           }
@@ -115,9 +113,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "61"
             }
@@ -180,9 +176,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "61"
             }
@@ -245,9 +239,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "61"
             }
@@ -334,9 +326,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "62"
@@ -429,9 +419,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "62"
@@ -500,9 +488,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "61"
             }
@@ -565,9 +551,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "61"
             }
@@ -655,9 +639,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "62"
@@ -751,9 +733,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "62"
@@ -822,9 +802,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "61"
             }
@@ -887,9 +865,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "61"
             }

--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -50,9 +50,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }

--- a/api/WebGL2ComputeRenderingContext.json
+++ b/api/WebGL2ComputeRenderingContext.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": false
           }

--- a/api/WebGLObject.json
+++ b/api/WebGLObject.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }

--- a/api/WebGLVertexArrayObjectOES.json
+++ b/api/WebGLVertexArrayObjectOES.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": null
           }

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }
@@ -87,9 +85,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -190,9 +184,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -242,9 +234,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -294,9 +284,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -346,9 +334,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/Window.json
+++ b/api/Window.json
@@ -245,9 +245,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -309,9 +307,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "43"
@@ -379,9 +375,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "43"
@@ -449,9 +443,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "43"
@@ -970,9 +962,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "58"
             }
@@ -1019,9 +1009,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "58"
               }
@@ -1092,9 +1080,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1167,9 +1153,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "47"
             }
@@ -1218,9 +1202,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1271,9 +1253,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1323,9 +1303,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1368,9 +1346,7 @@
             "safari": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1677,9 +1653,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -1729,9 +1703,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -1811,9 +1783,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "50",
@@ -1870,9 +1840,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "50"
             }
@@ -1922,9 +1890,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -2117,9 +2083,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -2269,9 +2233,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -2962,9 +2924,7 @@
             "safari_ios": {
               "version_added": "10.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "54"
             }
@@ -3014,9 +2974,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "58"
             }
@@ -3063,9 +3021,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "58"
               }
@@ -3115,9 +3071,7 @@
             "safari_ios": {
               "version_added": "9.3"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -3166,9 +3120,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -3284,9 +3236,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -3335,9 +3285,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -3437,9 +3385,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -3488,9 +3434,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -3539,9 +3483,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -3592,9 +3534,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -3694,9 +3634,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -3744,9 +3682,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -3798,9 +3734,7 @@
               "version_added": "5.1",
               "notes": "No support for selection start."
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -3850,9 +3784,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -3950,9 +3882,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4002,9 +3932,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -4067,9 +3995,7 @@
             "safari_ios": {
               "version_added": "3"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4132,9 +4058,7 @@
             "safari_ios": {
               "version_added": "3"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4183,9 +4107,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4233,9 +4155,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }
@@ -4334,9 +4254,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4490,9 +4408,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4540,9 +4456,7 @@
               "safari_ios": {
                 "version_added": "7"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -4592,9 +4506,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4643,9 +4555,7 @@
             "safari_ios": {
               "version_added": "5"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4694,9 +4604,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -4745,9 +4653,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4796,9 +4702,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -4847,9 +4751,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -4898,9 +4800,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -5153,9 +5053,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -5204,9 +5102,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -5269,9 +5165,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -5320,9 +5214,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -5371,9 +5263,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -5422,9 +5312,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -5473,9 +5361,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -5523,9 +5409,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -5575,9 +5459,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -5626,9 +5508,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -5677,9 +5557,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -5780,9 +5658,7 @@
             "safari_ios": {
               "version_added": "3"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -5831,9 +5707,7 @@
             "safari_ios": {
               "version_added": "3"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -5882,9 +5756,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "63"
             }
@@ -5934,9 +5806,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -5986,9 +5856,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -6037,9 +5905,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -6088,9 +5954,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -6139,9 +6003,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -6191,9 +6053,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "58"
             }
@@ -6240,9 +6100,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "58"
               }
@@ -6292,9 +6150,7 @@
             "safari_ios": {
               "version_added": "9"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -6343,9 +6199,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -6396,9 +6250,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -6480,9 +6332,7 @@
               "version_added": true,
               "notes": "For security reasons, to work properly on Safari, construct using <code>document.getElementById('your-frame').contentWindow</code>."
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -6530,9 +6380,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -6583,9 +6431,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -6636,9 +6482,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -6738,9 +6582,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -6849,9 +6691,7 @@
                 "prefix": "webkit"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -6899,9 +6739,7 @@
               "safari_ios": {
                 "version_added": "6.1"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }
@@ -6953,9 +6791,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -7020,9 +6856,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "47"
             }
@@ -7072,9 +6906,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -7124,9 +6956,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -7175,9 +7005,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -7226,9 +7054,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -7277,9 +7103,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -7328,9 +7152,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -7483,9 +7305,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -7536,9 +7356,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -7587,9 +7405,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -7689,9 +7505,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -7744,9 +7558,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -7846,9 +7658,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -7897,9 +7707,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -7948,9 +7756,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -7999,9 +7805,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -8280,9 +8084,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }
@@ -8460,9 +8262,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }
@@ -8512,9 +8312,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -8563,9 +8361,7 @@
             "safari_ios": {
               "version_added": "3.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -8614,9 +8410,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -8665,9 +8459,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -8716,9 +8508,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -8821,9 +8611,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -8879,9 +8667,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -8930,9 +8716,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -8981,9 +8765,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -9032,9 +8814,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -9083,9 +8863,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -9134,9 +8912,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -9186,9 +8962,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -9238,9 +9012,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -9290,9 +9062,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -9342,9 +9112,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -9394,9 +9162,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -9548,9 +9314,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -9613,9 +9377,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }
@@ -10203,9 +9965,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -296,9 +296,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -189,9 +189,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/WritableStreamDefaultController.json
+++ b/api/WritableStreamDefaultController.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": null
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": "58"
           }
@@ -88,9 +86,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -139,9 +135,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/api/XMLHttpRequestEventTarget.json
+++ b/api/XMLHttpRequestEventTarget.json
@@ -87,9 +87,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -138,9 +136,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -189,9 +185,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -240,9 +234,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -291,9 +283,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -342,9 +332,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -393,9 +381,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/api/XMLHttpRequestUpload.json
+++ b/api/XMLHttpRequestUpload.json
@@ -37,9 +37,7 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": null
-          },
+          "samsunginternet_android": null,
           "webview_android": {
             "version_added": true
           }


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Samsung Internet when it is set to "null". This should help reduce inconsistencies in the browser data.